### PR TITLE
v1.3.0 — System sorting, theme picker, smarter scans, Dolphin & back-nav fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ A lightweight game frontend for Android. Browse your ROM collection by platform,
 
 ## Features
 
-- **Carousel & Grid layouts** — switch between a full-screen carousel with animated video previews, or a compact box art grid
-- **Video previews** — auto-plays a game's video preview after 1.5 seconds of selection; cached locally after first download
-- **ScreenScraper.fr scraper** — batch-scrapes box art, screenshots, wheel logos, and video previews for your entire library
-- **Multi-emulator support** — launch into RetroArch (with per-platform core selection), any standalone emulator, or any installed app via a custom intent mapping
-- **ROM scanner** — scans a configurable folder, auto-detects platforms by subfolder name and file extension, and keeps the library in sync when ROMs are added or removed
+- **3DS-inspired UI** — a fanned box art preview over a system carousel, with a colourful box art grid per system. Liquid-glass tiles, bounce animations, and a donkey mascot beside the **eOr** wordmark
+- **Recently Played tab** — an optional top-level tab (toggle in *Settings → Display*) showing a grid of recently launched games
+- **Dark mode** — toggle light/dark theming in *Settings → Display*
+- **Hold-to-scroll** — hold a direction on the D-pad to keep moving through any grid or carousel
+- **Video previews** — auto-plays a game's video preview after a short delay; cached locally after first download
+- **Two artwork sources** — batch-scrape box art, screenshots, wheel logos, and video previews from [ScreenScraper.fr](https://www.screenscraper.fr), or pull box art and snaps from the public **libretro thumbnail** server with no account required
+- **ES-DE media import** — import an existing ES-DE `downloaded_media` folder instead of re-scraping
+- **Multi-emulator support** — launch into RetroArch (with per-platform core selection), any standalone emulator, or any installed app via a custom intent mapping; emulators are auto-detected and assigned per platform
+- **Broad system coverage** — 30 systems from the NES through the Switch, PS2/PS Vita, GameCube/Wii/Wii U, arcade (MAME, FinalBurn Neo, Neo Geo) and more
+- **Console & system icons** — full-colour console illustrations for every system, with custom icons for the modern consoles the icon pack doesn't cover
+- **ROM scanner** — scans a configurable folder, auto-detects platforms by subfolder name and file extension (including arcade `.zip`/`.7z` sets), and keeps the library in sync when ROMs are added or removed
+- **Gamepad-first navigation** — full D-pad/bumper control; LB/RB switch top-level tabs and cycle systems
 - **Favorites & play history** — mark favorites and track recently played games
-- **Material You theming** — adapts to your system's dynamic color palette (Android 12+)
 
 ---
 
@@ -28,47 +34,131 @@ A lightweight game frontend for Android. Browse your ROM collection by platform,
 
 ## Supported Platforms
 
-| System | Folder Name(s) | Extensions |
+Thirty systems are recognised out of the box. The scanner matches a ROM's parent folder
+name (case-insensitively) against each system, and falls back to the file extension.
+
+**Nintendo**
+
+| System | Typical folder(s) | Extensions |
 |---|---|---|
-| Nintendo NES | `NES`, `nes` | `.nes` |
-| Super Nintendo | `SNES`, `snes`, `Super Famicom` | `.sfc`, `.smc`, `.snes` |
-| Nintendo 64 | `N64`, `n64` | `.n64`, `.z64`, `.v64` |
-| Game Boy | `GB`, `gb` | `.gb` |
-| Game Boy Color | `GBC`, `gbc` | `.gbc` |
-| Game Boy Advance | `GBA`, `gba` | `.gba` |
-| Nintendo DS | `NDS`, `nds` | `.nds` |
-| Nintendo 3DS | `3DS`, `3ds` | `.3ds`, `.cia` |
-| Nintendo Switch | `Switch`, `switch` | `.nsp`, `.xci` |
-| PlayStation | `PS1`, `psx`, `PSX` | `.bin`, `.cue`, `.iso`, `.pbp`, `.chd` |
-| PlayStation 2 | `PS2`, `ps2` | `.iso`, `.chd` |
-| PSP | `PSP`, `psp` | `.iso`, `.cso` |
-| Dreamcast | `Dreamcast`, `DC` | `.cdi`, `.gdi`, `.chd` |
-| Sega Genesis / Mega Drive | `Genesis`, `MD`, `MegaDrive` | `.md`, `.gen` |
-| Sega Master System | `SMS`, `sms` | `.sms` |
-| Game Gear | `GG`, `GameGear` | `.gg` |
-| Sega Saturn | `Saturn` | `.cue`, `.iso`, `.chd` |
-| Atari 2600 | `Atari2600`, `2600` | `.a26`, `.bin` |
-| MAME / Arcade | `MAME`, `Arcade`, `FBNeo` | `.zip`, `.7z`, `.chd` |
+| NES | `nes` | `.nes` |
+| Super Nintendo | `snes`, `Super Famicom` | `.sfc`, `.smc`, `.snes` |
+| Nintendo 64 | `n64` | `.n64`, `.z64`, `.v64` |
+| Game Boy | `gb` | `.gb` |
+| Game Boy Color | `gbc` | `.gbc` |
+| Game Boy Advance | `gba` | `.gba` |
+| Nintendo DS | `nds` | `.nds` |
+| Nintendo 3DS | `3ds`, `n3ds` | `.3ds`, `.cia` |
+| Nintendo GameCube | `gc`, `gamecube`, `ngc` | `.iso`, `.rvz`, `.gcm`, `.gcz`, `.ciso` |
+| Nintendo Wii | `wii` | `.iso`, `.rvz`, `.wbfs` |
+| Nintendo Wii U | `wiiu` | `.wua`, `.wux`, `.rpx` |
+| Nintendo Switch | `switch` | `.nsp`, `.xci` |
+
+**Sony**
+
+| System | Typical folder(s) | Extensions |
+|---|---|---|
+| PlayStation | `ps1`, `psx` | `.bin`, `.cue`, `.iso`, `.pbp`, `.chd` |
+| PlayStation 2 | `ps2` | `.iso`, `.chd` |
+| PSP | `psp` | `.iso`, `.cso` |
+| PlayStation Vita | `psvita`, `vita` | `.vpk` |
+
+**Sega**
+
+| System | Typical folder(s) | Extensions |
+|---|---|---|
+| Genesis / Mega Drive | `genesis`, `md`, `megadrive` | `.md`, `.gen`, `.bin` |
+| Master System | `sms`, `mastersystem` | `.sms` |
+| Game Gear | `gg`, `gamegear` | `.gg` |
+| Sega CD / Mega-CD | `segacd`, `megacd` | `.cue`, `.chd`, `.iso` |
+| Sega 32X | `32x`, `sega32x` | `.32x`, `.bin` |
+| Saturn | `saturn` | `.cue`, `.iso`, `.chd` |
+| Dreamcast | `dc`, `dreamcast` | `.cdi`, `.gdi`, `.chd` |
+
+**Arcade, NEC, SNK & others**
+
+| System | Typical folder(s) | Extensions |
+|---|---|---|
+| MAME | `mame`, `arcade` | `.zip`, `.7z`, `.chd` |
+| FinalBurn Neo | `fbneo`, `fba` | `.zip`, `.7z` |
+| Neo Geo | `neogeo` | `.zip`, `.7z` |
+| Neo Geo Pocket | `ngp` | `.ngp`, `.ngc` |
+| PC Engine / TurboGrafx-16 | `pcengine`, `tg16` | `.pce`, `.sgx`, `.cue`, `.chd` |
+| Panasonic 3DO | `3do` | `.iso`, `.chd`, `.cue`, `.bin` |
+| Atari 2600 | `atari2600`, `2600` | `.a26`, `.bin` |
 
 ---
 
 ## Supported Emulators
 
-The app auto-detects whichever of these are installed and lets you assign one per platform:
+The app auto-detects whichever of these are installed and lets you assign one per platform. Where multiple variants exist for the same emulator, the first one found (top of each group) is used automatically.
+
+**RetroArch** (universal fallback for most platforms)
 
 | Emulator | Package |
 |---|---|
+| RetroArch (AArch64) | `com.retroarch.aarch64` |
 | RetroArch | `org.libretro.retroarch` |
-| Dolphin | `org.dolphinemu.dolphinemu` |
-| PPSSPP | `org.ppsspp.ppsspp` |
-| DuckStation | `com.github.stenzek.duckstation` |
-| DraStic | `com.drastic.ds` |
-| Flycast | `com.flycast.emulator` |
-| GBC.emu | `com.explusalpha.GbcEmu` |
-| GBA.emu | `com.explusalpha.GbaEmu` |
-| Snes9x EX+ | `com.explusalpha.Snes9xEmu` |
+
+**PlayStation**
+
+| Emulator | Covers | Package |
+|---|---|---|
+| DuckStation | PS1 | `com.github.stenzek.duckstation` |
+| NetherSX2 / AetherSX2 | PS2 | `xyz.aethersx2.android` |
+| NetherSX2 | PS2 | `xyz.trizle.nethersx2` |
+| AetherSX2 | PS2 | `net.play.ptmk.ps2` |
+| PPSSPP Gold | PSP | `org.ppsspp.ppssppgold` |
+| PPSSPP | PSP | `org.ppsspp.ppsspp` |
+| Vita3K | PS Vita | `org.vita3k.emulator` |
+
+**Nintendo handhelds**
+
+| Emulator | Covers | Package |
+|---|---|---|
+| DraStic | NDS | `com.drastic.ds` |
+| melonDS | NDS | `me.magnum.melonds` |
+| Azahar | 3DS | `org.azahar_emu.azahar` |
+| Citra (Retroid build) | 3DS | `org.citra.emu` |
+| Citra MMJ | 3DS | `com.weihuoya.citra` |
+| Citra | 3DS | `org.citra_emu.citra` |
+| GBA.emu | GBA | `com.explusalpha.GbaEmu` |
+| GBC.emu | GBC / GB | `com.explusalpha.GbcEmu` |
+| Snes9x EX+ | SNES | `com.explusalpha.Snes9xEmu` |
+
+**Nintendo 64 / consoles**
+
+| Emulator | Covers | Package |
+|---|---|---|
+| Mupen64Plus FZ Pro | N64 | `org.mupen64plusae.v3.fzurita.pro` |
+| Mupen64Plus FZ | N64 | `org.mupen64plusae.v3.fzurita` |
+| Dolphin | GameCube / Wii | `org.dolphinemu.dolphinemu` |
+| Cemu | Wii U | `info.cemu.cemu` |
+
+**Switch**
+
+| Emulator | Package |
+|---|---|
+| Eden (Retroid build) | `dev.eden.eden_emulator` |
+| Eden | `dev.eden.emulator` |
+| Sudachi (Retroid build) | `org.sudachi.sudachi_emu` |
 | Yuzu | `org.yuzu.yuzu_emu` |
-| Citra | `org.citra_emu.citra` |
+
+**Sega**
+
+| Emulator | Covers | Package |
+|---|---|---|
+| Redream | Dreamcast | `io.recompiled.redream` |
+| Flycast | Dreamcast | `com.flycast.emulator` |
+| Reicast | Dreamcast | `com.reicast.emulator` |
+| Yaba Sanshiro 2 Pro | Saturn | `org.devmiyax.yabasanshioro2.pro` |
+| Yaba Sanshiro 2 | Saturn | `org.devmiyax.yabasanshioro2` |
+
+**Other**
+
+| Emulator | Covers | Package |
+|---|---|---|
+| J2ME Loader | Java ME games | `ru.playsoftware.j2meloader` |
 
 Any other emulator can be added via **Settings → Configure Emulators** using a custom package name.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 11
-        versionName = "1.2.1"
+        versionCode = 12
+        versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 2
-        versionName = "1.1.0"
+        versionCode = 10
+        versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 10
-        versionName = "1.2.0"
+        versionCode = 11
+        versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/gamelaunch/frontend/GameLauncherApp.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/GameLauncherApp.kt
@@ -2,10 +2,15 @@ package com.gamelaunch.frontend
 
 import android.app.Application
 import android.os.StrictMode
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.CachePolicy
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class GameLauncherApp : Application() {
+class GameLauncherApp : Application(), ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
         // Emulators expect a raw file path / file:// URI to the ROM. On targetSdk >= 24 the
@@ -15,4 +20,30 @@ class GameLauncherApp : Application() {
         // storage permissions.
         StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder().build())
     }
+
+    /**
+     * Box art is shown in dense grids and carousels, so artwork loading has to feel instant. A
+     * generous in-memory cache keeps recently-seen covers ready while scrolling, a persistent disk
+     * cache means scraped/remote art is only ever fetched once, and RGB_565 halves bitmap memory so
+     * more covers stay resident. Cache headers are ignored so cached art is never re-validated.
+     */
+    override fun newImageLoader(): ImageLoader =
+        ImageLoader.Builder(this)
+            .memoryCache {
+                MemoryCache.Builder(this)
+                    .maxSizePercent(0.30)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(512L * 1024 * 1024)
+                    .build()
+            }
+            .allowRgb565(true)
+            .respectCacheHeaders(false)
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .crossfade(120)
+            .build()
 }

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -58,7 +58,8 @@ class MainActivity : ComponentActivity() {
         requestAllFilesAccessIfNeeded()
 
         setContent {
-            AppTheme {
+            val darkMode by settingsRepository.darkMode.collectAsState(initial = false)
+            AppTheme(darkMode = darkMode) {
                 val navController = rememberNavController()
                 // Use null as initial so NavHost isn't created until we know the real value.
                 // With initial = true (old code) the NavHost always initialized at Settings,

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -12,6 +12,7 @@ import android.view.InputDevice
 import android.view.KeyEvent as AndroidKeyEvent
 import android.view.MotionEvent
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.WindowCompat
@@ -78,6 +79,12 @@ class MainActivity : ComponentActivity() {
                             navController    = navController,
                             startDestination = startDestination
                         )
+                        // System Back (the Retroid's B maps to it): pop the nav stack so the
+                        // detail/settings screens return to where they came from. At the launcher
+                        // root nothing pops, so we consume it and stay instead of exiting.
+                        // Focused screens (e.g. the home game grid) handle Back in their own
+                        // onKeyEvent first, so this only runs when nothing else consumed it.
+                        BackHandler { navController.popBackStack() }
                     }
                 }
             }
@@ -97,10 +104,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        // Swallow Back at the launcher root — sub-screens handle it via the nav stack
-    }
 
     /**
      * Convert left-stick and D-pad hat axis motion to discrete DPAD key events so

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -129,12 +129,26 @@ class MainActivity : ComponentActivity() {
         return super.dispatchGenericMotionEvent(ev)
     }
 
+    /**
+     * Emit DPAD key events for an axis as it crosses the dead zone. Critically this also injects
+     * ACTION_UP when the axis returns to (or passes through) neutral, so a released D-pad/stick
+     * produces a real KeyUp — without it the hold-to-scroll repeat would never be cancelled and the
+     * UI would scroll forever. A direction flip (e.g. right → left) releases the old direction and
+     * presses the new one in the same step.
+     */
     private fun injectIfCrossed(cur: Float, prev: Float, dead: Float, posCode: Int, negCode: Int) {
+        val curDir  = if (cur  > dead) 1 else if (cur  < -dead) -1 else 0
+        val prevDir = if (prev > dead) 1 else if (prev < -dead) -1 else 0
+        if (curDir == prevDir) return
+
         val now = SystemClock.uptimeMillis()
-        if (cur > dead && prev <= dead)
-            dispatchKeyEvent(AndroidKeyEvent(now, now, AndroidKeyEvent.ACTION_DOWN, posCode, 0))
-        else if (cur < -dead && prev >= -dead)
-            dispatchKeyEvent(AndroidKeyEvent(now, now, AndroidKeyEvent.ACTION_DOWN, negCode, 0))
+        fun send(action: Int, dir: Int) {
+            val code = if (dir > 0) posCode else negCode
+            dispatchKeyEvent(AndroidKeyEvent(now, now, action, code, 0))
+        }
+        // Release whatever direction was held, then press the new one (either may be neutral).
+        if (prevDir != 0) send(AndroidKeyEvent.ACTION_UP, prevDir)
+        if (curDir  != 0) send(AndroidKeyEvent.ACTION_DOWN, curDir)
     }
 
     private fun requestStoragePermissions() {

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
@@ -77,6 +77,9 @@ interface GameDao {
     @Query("DELETE FROM games WHERE rom_path NOT IN (:validPaths)")
     suspend fun deleteGamesNotInPaths(validPaths: List<String>): Int
 
+    @Query("DELETE FROM games WHERE platform_id = 'android' AND rom_path NOT IN (:validPaths)")
+    suspend fun deleteAndroidGamesNotIn(validPaths: List<String>): Int
+
     @Query("DELETE FROM games WHERE id = :id")
     suspend fun deleteById(id: Long)
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
@@ -25,6 +25,35 @@ interface GameDao {
     @Query("SELECT * FROM games WHERE is_scraped = 0 ORDER BY title ASC")
     suspend fun getUnscrapedGames(): List<GameEntity>
 
+    /**
+     * Games that still need scraping for the enabled options: never scraped, or scraped but
+     * missing any artwork/metadata the user has turned on. Games that already have everything
+     * enabled are skipped. Flags are passed as 1/0.
+     */
+    @Query(
+        """
+        SELECT g.* FROM games g
+        LEFT JOIN game_media m ON m.game_id = g.id
+        WHERE g.rom_filename NOT LIKE '.%'
+          AND (
+            g.is_scraped = 0
+            OR (:needMeta = 1 AND g.description IS NULL)
+            OR (:needBox = 1 AND m.box_art_local IS NULL AND m.box_art_remote IS NULL)
+            OR (:needShot = 1 AND m.screenshot_local IS NULL AND m.screenshot_remote IS NULL)
+            OR (:needWheel = 1 AND m.wheel_logo_local IS NULL AND m.wheel_logo_remote IS NULL)
+            OR (:needVideo = 1 AND m.video_local IS NULL AND m.video_remote IS NULL)
+          )
+        ORDER BY g.title ASC
+        """
+    )
+    suspend fun getGamesNeedingScrape(
+        needMeta: Int,
+        needBox: Int,
+        needShot: Int,
+        needWheel: Int,
+        needVideo: Int
+    ): List<GameEntity>
+
     @Query("SELECT * FROM games WHERE is_favorite = 1 ORDER BY title ASC")
     fun getFavorites(): Flow<List<GameEntity>>
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/network/RetroAchievementsApi.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/network/RetroAchievementsApi.kt
@@ -1,0 +1,26 @@
+package com.gamelaunch.frontend.data.network
+
+import com.gamelaunch.frontend.data.network.dto.RaRecentGameDto
+import com.gamelaunch.frontend.data.network.dto.RaUserSummaryDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface RetroAchievementsApi {
+
+    @GET("API_GetUserSummary.php")
+    suspend fun getUserSummary(
+        @Query("z") callerUsername: String,
+        @Query("y") apiKey: String,
+        @Query("u") targetUsername: String,
+        @Query("g") recentGamesCount: Int = 0
+    ): Response<RaUserSummaryDto>
+
+    @GET("API_GetUserRecentlyPlayedGames.php")
+    suspend fun getRecentlyPlayedGames(
+        @Query("z") callerUsername: String,
+        @Query("y") apiKey: String,
+        @Query("u") targetUsername: String,
+        @Query("c") count: Int = 15
+    ): Response<List<RaRecentGameDto>>
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/network/RetroAchievementsConnectApi.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/network/RetroAchievementsConnectApi.kt
@@ -1,0 +1,32 @@
+package com.gamelaunch.frontend.data.network
+
+import com.gamelaunch.frontend.data.network.dto.RaLoginDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * RetroAchievements "Connect" API (dorequest.php) — the same endpoint emulators use.
+ * Lets a user authenticate with their username + password and receive a long-lived token.
+ * The absolute URL overrides the @Named("ra") Retrofit base (which points at /API/).
+ *
+ * A User-Agent header is mandatory and is injected by the @Named("ra") OkHttp client.
+ */
+interface RetroAchievementsConnectApi {
+
+    /** Authenticate with a password. Returns a token, hardcore score and softcore score. */
+    @GET("https://retroachievements.org/dorequest.php")
+    suspend fun loginWithPassword(
+        @Query("r") request: String = "login2",
+        @Query("u") username: String,
+        @Query("p") password: String
+    ): Response<RaLoginDto>
+
+    /** Re-validate using a previously issued token (no password needed) to refresh the score. */
+    @GET("https://retroachievements.org/dorequest.php")
+    suspend fun loginWithToken(
+        @Query("r") request: String = "login2",
+        @Query("u") username: String,
+        @Query("t") token: String
+    ): Response<RaLoginDto>
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/network/dto/RaDto.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/network/dto/RaDto.kt
@@ -1,0 +1,39 @@
+package com.gamelaunch.frontend.data.network.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class RaUserSummaryDto(
+    @SerializedName("User")               val user: String? = null,
+    @SerializedName("TotalPoints")        val totalPoints: Int? = null,
+    @SerializedName("TotalSoftcorePoints") val softcorePoints: Int? = null,
+    @SerializedName("TotalTruePoints")    val truePoints: Int? = null,
+    @SerializedName("Rank")               val rank: Int? = null,
+    @SerializedName("UserPic")            val userPic: String? = null,
+    @SerializedName("Status")             val status: String? = null,
+    @SerializedName("RecentlyPlayed")     val recentlyPlayed: List<RaRecentlyPlayedDto>? = null
+)
+
+data class RaRecentlyPlayedDto(
+    @SerializedName("GameID")      val gameId: Int? = null,
+    @SerializedName("ConsoleID")   val consoleId: Int? = null,
+    @SerializedName("ConsoleName") val consoleName: String? = null,
+    @SerializedName("Title")       val title: String? = null,
+    @SerializedName("ImageIcon")   val imageIcon: String? = null,
+    @SerializedName("LastPlayed")  val lastPlayed: String? = null
+)
+
+data class RaRecentGameDto(
+    @SerializedName("GameID")                    val gameId: Int? = null,
+    @SerializedName("ConsoleID")                 val consoleId: Int? = null,
+    @SerializedName("ConsoleName")               val consoleName: String? = null,
+    @SerializedName("Title")                     val title: String? = null,
+    @SerializedName("ImageIcon")                 val imageIcon: String? = null,
+    @SerializedName("NumAchievements")           val numAchievements: Int? = null,
+    @SerializedName("NumAwardedToUser")          val numAwardedToUser: Int? = null,
+    @SerializedName("NumAwardedToUserHardcore")  val numAwardedHardcore: Int? = null,
+    @SerializedName("ScoreAchieved")             val scoreAchieved: Int? = null,
+    @SerializedName("ScoreAchievedHardcore")     val scoreAchievedHardcore: Int? = null,
+    @SerializedName("MaxPossible")               val maxPossible: Int? = null,
+    @SerializedName("LastPlayed")                val lastPlayed: String? = null,
+    @SerializedName("HighestAwardKind")          val highestAwardKind: String? = null
+)

--- a/app/src/main/java/com/gamelaunch/frontend/data/network/dto/RaDto.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/network/dto/RaDto.kt
@@ -22,6 +22,17 @@ data class RaRecentlyPlayedDto(
     @SerializedName("LastPlayed")  val lastPlayed: String? = null
 )
 
+data class RaLoginDto(
+    @SerializedName("Success")       val success: Boolean? = null,
+    @SerializedName("User")          val user: String? = null,
+    @SerializedName("Token")         val token: String? = null,
+    @SerializedName("Score")         val score: Int? = null,
+    @SerializedName("SoftcoreScore") val softcoreScore: Int? = null,
+    @SerializedName("AccountType")   val accountType: String? = null,
+    @SerializedName("Error")         val error: String? = null,
+    @SerializedName("Code")          val code: String? = null
+)
+
 data class RaRecentGameDto(
     @SerializedName("GameID")                    val gameId: Int? = null,
     @SerializedName("ConsoleID")                 val consoleId: Int? = null,

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -37,6 +38,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val DARK_MODE = booleanPreferencesKey("dark_mode")
         val RA_USERNAME = stringPreferencesKey("ra_username")
         val RA_API_KEY = stringPreferencesKey("ra_api_key")
+        val RA_TOKEN = stringPreferencesKey("ra_token")
+        val RA_POINTS = intPreferencesKey("ra_points")
+        val RA_SOFTCORE_POINTS = intPreferencesKey("ra_softcore_points")
     }
 
     val romRootPath: Flow<String> = context.dataStore.data.map { it[Keys.ROM_ROOT_PATH] ?: "" }
@@ -56,6 +60,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
     val raUsername: Flow<String> = context.dataStore.data.map { it[Keys.RA_USERNAME] ?: "" }
     val raApiKey: Flow<String> = context.dataStore.data.map { it[Keys.RA_API_KEY] ?: "" }
+    val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
+    val raPoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_POINTS] ?: 0 }
+    val raSoftcorePoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_SOFTCORE_POINTS] ?: 0 }
 
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
@@ -74,8 +81,20 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setFirstLaunchComplete() = context.dataStore.edit { it[Keys.FIRST_LAUNCH] = false }
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
     suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
-    suspend fun setRaCredentials(username: String, apiKey: String) = context.dataStore.edit {
-        it[Keys.RA_USERNAME] = username
+    suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
         it[Keys.RA_API_KEY] = apiKey
+    }
+    suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) = context.dataStore.edit {
+        it[Keys.RA_USERNAME] = username
+        it[Keys.RA_TOKEN] = token
+        it[Keys.RA_POINTS] = points
+        it[Keys.RA_SOFTCORE_POINTS] = softcorePoints
+    }
+    suspend fun clearRaCredentials() = context.dataStore.edit {
+        it.remove(Keys.RA_USERNAME)
+        it.remove(Keys.RA_API_KEY)
+        it.remove(Keys.RA_TOKEN)
+        it.remove(Keys.RA_POINTS)
+        it.remove(Keys.RA_SOFTCORE_POINTS)
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -35,6 +35,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val FIRST_LAUNCH = booleanPreferencesKey("first_launch")
         val SHOW_RECENTLY_PLAYED = booleanPreferencesKey("show_recently_played")
         val DARK_MODE = booleanPreferencesKey("dark_mode")
+        val RA_USERNAME = stringPreferencesKey("ra_username")
+        val RA_API_KEY = stringPreferencesKey("ra_api_key")
     }
 
     val romRootPath: Flow<String> = context.dataStore.data.map { it[Keys.ROM_ROOT_PATH] ?: "" }
@@ -52,6 +54,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val isFirstLaunch: Flow<Boolean> = context.dataStore.data.map { it[Keys.FIRST_LAUNCH] ?: true }
     val showRecentlyPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RECENTLY_PLAYED] ?: true }
     val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
+    val raUsername: Flow<String> = context.dataStore.data.map { it[Keys.RA_USERNAME] ?: "" }
+    val raApiKey: Flow<String> = context.dataStore.data.map { it[Keys.RA_API_KEY] ?: "" }
 
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
@@ -70,4 +74,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setFirstLaunchComplete() = context.dataStore.edit { it[Keys.FIRST_LAUNCH] = false }
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
     suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
+    suspend fun setRaCredentials(username: String, apiKey: String) = context.dataStore.edit {
+        it[Keys.RA_USERNAME] = username
+        it[Keys.RA_API_KEY] = apiKey
+    }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -37,6 +37,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val FIRST_LAUNCH = booleanPreferencesKey("first_launch")
         val SHOW_RECENTLY_PLAYED = booleanPreferencesKey("show_recently_played")
         val DARK_MODE = booleanPreferencesKey("dark_mode")
+        val SYSTEM_SORT = stringPreferencesKey("system_sort")
         val RA_USERNAME = stringPreferencesKey("ra_username")
         val RA_API_KEY = stringPreferencesKey("ra_api_key")
         val RA_TOKEN = stringPreferencesKey("ra_token")
@@ -60,6 +61,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val isFirstLaunch: Flow<Boolean> = context.dataStore.data.map { it[Keys.FIRST_LAUNCH] ?: true }
     val showRecentlyPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RECENTLY_PLAYED] ?: true }
     val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
+    // Up to two sort keys, comma-joined (e.g. "RELEASE_DATE,BRAND"). Empty = default order.
+    val systemSort: Flow<List<String>> = context.dataStore.data.map {
+        it[Keys.SYSTEM_SORT]?.split(",")?.filter { s -> s.isNotBlank() } ?: emptyList()
+    }
     val raUsername: Flow<String> = context.dataStore.data.map { it[Keys.RA_USERNAME] ?: "" }
     val raApiKey: Flow<String> = context.dataStore.data.map { it[Keys.RA_API_KEY] ?: "" }
     val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
@@ -84,6 +89,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setFirstLaunchComplete() = context.dataStore.edit { it[Keys.FIRST_LAUNCH] = false }
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
     suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
+    suspend fun setSystemSort(keys: List<String>) = context.dataStore.edit { it[Keys.SYSTEM_SORT] = keys.joinToString(",") }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
         it[Keys.RA_API_KEY] = apiKey
     }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -34,6 +34,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val VIDEO_MUTED = booleanPreferencesKey("video_muted")
         val FIRST_LAUNCH = booleanPreferencesKey("first_launch")
         val SHOW_RECENTLY_PLAYED = booleanPreferencesKey("show_recently_played")
+        val DARK_MODE = booleanPreferencesKey("dark_mode")
     }
 
     val romRootPath: Flow<String> = context.dataStore.data.map { it[Keys.ROM_ROOT_PATH] ?: "" }
@@ -50,6 +51,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val videoMuted: Flow<Boolean> = context.dataStore.data.map { it[Keys.VIDEO_MUTED] ?: true }
     val isFirstLaunch: Flow<Boolean> = context.dataStore.data.map { it[Keys.FIRST_LAUNCH] ?: true }
     val showRecentlyPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RECENTLY_PLAYED] ?: true }
+    val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
 
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
@@ -67,4 +69,5 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setVideoMuted(muted: Boolean) = context.dataStore.edit { it[Keys.VIDEO_MUTED] = muted }
     suspend fun setFirstLaunchComplete() = context.dataStore.edit { it[Keys.FIRST_LAUNCH] = false }
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
+    suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -27,6 +27,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val SS_ID = stringPreferencesKey("ss_id")
         val SS_PASSWORD = stringPreferencesKey("ss_password")
         val PREFERRED_REGION = stringPreferencesKey("preferred_region")
+        val SCRAPE_METADATA = booleanPreferencesKey("scrape_metadata")
         val SCRAPE_BOX_ART = booleanPreferencesKey("scrape_box_art")
         val SCRAPE_SCREENSHOTS = booleanPreferencesKey("scrape_screenshots")
         val SCRAPE_WHEEL_LOGOS = booleanPreferencesKey("scrape_wheel_logos")
@@ -49,6 +50,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val ssId: Flow<String> = context.dataStore.data.map { it[Keys.SS_ID] ?: "" }
     val ssPassword: Flow<String> = context.dataStore.data.map { it[Keys.SS_PASSWORD] ?: "" }
     val preferredRegion: Flow<String> = context.dataStore.data.map { it[Keys.PREFERRED_REGION] ?: "us" }
+    val scrapeMetadata: Flow<Boolean> = context.dataStore.data.map { it[Keys.SCRAPE_METADATA] ?: true }
     val scrapeBoxArt: Flow<Boolean> = context.dataStore.data.map { it[Keys.SCRAPE_BOX_ART] ?: true }
     val scrapeScreenshots: Flow<Boolean> = context.dataStore.data.map { it[Keys.SCRAPE_SCREENSHOTS] ?: true }
     val scrapeWheelLogos: Flow<Boolean> = context.dataStore.data.map { it[Keys.SCRAPE_WHEEL_LOGOS] ?: true }
@@ -72,6 +74,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         it[Keys.SS_PASSWORD] = password
     }
     suspend fun setPreferredRegion(region: String) = context.dataStore.edit { it[Keys.PREFERRED_REGION] = region }
+    suspend fun setScrapeMetadata(enabled: Boolean) = context.dataStore.edit { it[Keys.SCRAPE_METADATA] = enabled }
     suspend fun setScrapeBoxArt(enabled: Boolean) = context.dataStore.edit { it[Keys.SCRAPE_BOX_ART] = enabled }
     suspend fun setScrapeScreenshots(enabled: Boolean) = context.dataStore.edit { it[Keys.SCRAPE_SCREENSHOTS] = enabled }
     suspend fun setScrapeWheelLogos(enabled: Boolean) = context.dataStore.edit { it[Keys.SCRAPE_WHEEL_LOGOS] = enabled }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
@@ -26,6 +26,21 @@ class GameRepositoryImpl @Inject constructor(
     override suspend fun getUnscrapedGames(): List<Game> =
         gameDao.getUnscrapedGames().map(GameEntity::toDomain)
 
+    override suspend fun getGamesNeedingScrape(
+        needMeta: Boolean,
+        needBox: Boolean,
+        needShot: Boolean,
+        needWheel: Boolean,
+        needVideo: Boolean
+    ): List<Game> =
+        gameDao.getGamesNeedingScrape(
+            if (needMeta) 1 else 0,
+            if (needBox) 1 else 0,
+            if (needShot) 1 else 0,
+            if (needWheel) 1 else 0,
+            if (needVideo) 1 else 0
+        ).map(GameEntity::toDomain)
+
     override fun getFavorites(): Flow<List<Game>> =
         gameDao.getFavorites().map { it.map(GameEntity::toDomain) }
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
@@ -62,6 +62,10 @@ class GameRepositoryImpl @Inject constructor(
         gameDao.updateScrapedMetadata(gameId, scraperGameId, description, genre, releaseYear, rating)
     }
 
+    override suspend fun markScraped(gameId: Long, title: String) {
+        gameDao.updateTitle(gameId, title)
+    }
+
     override suspend fun setFavorite(gameId: Long, isFavorite: Boolean) {
         gameDao.setFavorite(gameId, isFavorite)
     }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
@@ -73,6 +73,9 @@ class GameRepositoryImpl @Inject constructor(
     override suspend fun deleteGamesNotInPaths(validPaths: List<String>): Int =
         gameDao.deleteGamesNotInPaths(validPaths)
 
+    override suspend fun deleteAndroidGamesNotIn(validPaths: List<String>): Int =
+        gameDao.deleteAndroidGamesNotIn(validPaths)
+
     override suspend fun getTotalCount(): Int = gameDao.getTotalCount()
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/RetroAchievementsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/RetroAchievementsRepositoryImpl.kt
@@ -1,18 +1,48 @@
 package com.gamelaunch.frontend.data.repository
 
 import com.gamelaunch.frontend.data.network.RetroAchievementsApi
+import com.gamelaunch.frontend.data.network.RetroAchievementsConnectApi
+import com.gamelaunch.frontend.data.network.dto.RaLoginDto
 import com.gamelaunch.frontend.domain.model.RaProfile
 import com.gamelaunch.frontend.domain.model.RaRecentGame
+import com.gamelaunch.frontend.domain.model.RaSession
 import com.gamelaunch.frontend.domain.model.raAvatarUrl
 import com.gamelaunch.frontend.domain.model.toRaMediaUrl
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
+import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class RetroAchievementsRepositoryImpl @Inject constructor(
-    private val api: RetroAchievementsApi
+    private val api: RetroAchievementsApi,
+    private val connectApi: RetroAchievementsConnectApi
 ) : RetroAchievementsRepository {
+
+    override suspend fun login(username: String, password: String): Result<RaSession> =
+        runCatching {
+            connectApi.loginWithPassword(username = username, password = password)
+                .toSession(username)
+        }
+
+    override suspend fun refreshSession(username: String, token: String): Result<RaSession> =
+        runCatching {
+            connectApi.loginWithToken(username = username, token = token)
+                .toSession(username)
+        }
+
+    private fun Response<RaLoginDto>.toSession(fallbackUsername: String): RaSession {
+        val dto = body() ?: error("Empty response (HTTP ${code()})")
+        if (dto.success != true || dto.token.isNullOrBlank()) {
+            error(dto.error ?: "Invalid username or password")
+        }
+        return RaSession(
+            username       = dto.user ?: fallbackUsername,
+            token          = dto.token,
+            points         = dto.score ?: 0,
+            softcorePoints = dto.softcoreScore ?: 0
+        )
+    }
 
     override suspend fun getUserProfile(username: String, apiKey: String): Result<RaProfile> =
         runCatching {

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/RetroAchievementsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/RetroAchievementsRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.gamelaunch.frontend.data.repository
+
+import com.gamelaunch.frontend.data.network.RetroAchievementsApi
+import com.gamelaunch.frontend.domain.model.RaProfile
+import com.gamelaunch.frontend.domain.model.RaRecentGame
+import com.gamelaunch.frontend.domain.model.raAvatarUrl
+import com.gamelaunch.frontend.domain.model.toRaMediaUrl
+import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RetroAchievementsRepositoryImpl @Inject constructor(
+    private val api: RetroAchievementsApi
+) : RetroAchievementsRepository {
+
+    override suspend fun getUserProfile(username: String, apiKey: String): Result<RaProfile> =
+        runCatching {
+            val response = api.getUserSummary(username, apiKey, username)
+            val dto = response.body() ?: error("Empty response (HTTP ${response.code()})")
+            RaProfile(
+                username      = dto.user ?: username,
+                avatarUrl     = raAvatarUrl(dto.user ?: username),
+                totalPoints   = dto.totalPoints ?: 0,
+                softcorePoints = dto.softcorePoints ?: 0,
+                truePoints    = dto.truePoints ?: 0,
+                rank          = dto.rank,
+                status        = dto.status
+            )
+        }
+
+    override suspend fun getRecentlyPlayed(username: String, apiKey: String, count: Int): Result<List<RaRecentGame>> =
+        runCatching {
+            val response = api.getRecentlyPlayedGames(username, apiKey, username, count)
+            val list = response.body() ?: error("Empty response (HTTP ${response.code()})")
+            list.mapNotNull { dto ->
+                val id = dto.gameId ?: return@mapNotNull null
+                RaRecentGame(
+                    gameId           = id,
+                    title            = dto.title ?: "Unknown",
+                    consoleName      = dto.consoleName ?: "",
+                    iconUrl          = dto.imageIcon?.toRaMediaUrl() ?: "",
+                    numAchievements  = dto.numAchievements ?: 0,
+                    numEarned        = dto.numAwardedToUser ?: 0,
+                    numEarnedHardcore = dto.numAwardedHardcore ?: 0,
+                    scoreEarned      = dto.scoreAchieved ?: 0,
+                    maxScore         = dto.maxPossible ?: 0,
+                    lastPlayed       = dto.lastPlayed,
+                    highestAwardKind = dto.highestAwardKind
+                )
+            }
+        }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import com.gamelaunch.frontend.domain.platform.SystemSort
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -49,6 +50,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override val isFirstLaunch: Flow<Boolean> = dataStore.isFirstLaunch
     override val showRecentlyPlayed: Flow<Boolean> = dataStore.showRecentlyPlayed
     override val darkMode: Flow<Boolean> = dataStore.darkMode
+    override val systemSort: Flow<List<SystemSort>> =
+        dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
     override val raUsername: Flow<String> = dataStore.raUsername
     override val raApiKey: Flow<String> = dataStore.raApiKey
     override val raToken: Flow<String> = dataStore.raToken
@@ -84,6 +87,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setFirstLaunchComplete() { dataStore.setFirstLaunchComplete() }
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
     override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
+    override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
     override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }
     override suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) {
         dataStore.setRaSession(username, token, points, softcorePoints)

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -47,6 +47,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override val isFirstLaunch: Flow<Boolean> = dataStore.isFirstLaunch
     override val showRecentlyPlayed: Flow<Boolean> = dataStore.showRecentlyPlayed
     override val darkMode: Flow<Boolean> = dataStore.darkMode
+    override val raUsername: Flow<String> = dataStore.raUsername
+    override val raApiKey: Flow<String> = dataStore.raApiKey
 
     override suspend fun setRomRootPath(path: String) { dataStore.setRomRootPath(path) }
     override suspend fun setMediaFolderPath(path: String) { dataStore.setMediaFolderPath(path) }
@@ -75,4 +77,5 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setFirstLaunchComplete() { dataStore.setFirstLaunchComplete() }
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
     override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
+    override suspend fun setRaCredentials(username: String, apiKey: String) { dataStore.setRaCredentials(username, apiKey) }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -49,6 +49,9 @@ class SettingsRepositoryImpl @Inject constructor(
     override val darkMode: Flow<Boolean> = dataStore.darkMode
     override val raUsername: Flow<String> = dataStore.raUsername
     override val raApiKey: Flow<String> = dataStore.raApiKey
+    override val raToken: Flow<String> = dataStore.raToken
+    override val raPoints: Flow<Int> = dataStore.raPoints
+    override val raSoftcorePoints: Flow<Int> = dataStore.raSoftcorePoints
 
     override suspend fun setRomRootPath(path: String) { dataStore.setRomRootPath(path) }
     override suspend fun setMediaFolderPath(path: String) { dataStore.setMediaFolderPath(path) }
@@ -77,5 +80,9 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setFirstLaunchComplete() { dataStore.setFirstLaunchComplete() }
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
     override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
-    override suspend fun setRaCredentials(username: String, apiKey: String) { dataStore.setRaCredentials(username, apiKey) }
+    override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }
+    override suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) {
+        dataStore.setRaSession(username, token, points, softcorePoints)
+    }
+    override suspend fun clearRaCredentials() { dataStore.clearRaCredentials() }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -46,6 +46,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override val videoMuted: Flow<Boolean> = dataStore.videoMuted
     override val isFirstLaunch: Flow<Boolean> = dataStore.isFirstLaunch
     override val showRecentlyPlayed: Flow<Boolean> = dataStore.showRecentlyPlayed
+    override val darkMode: Flow<Boolean> = dataStore.darkMode
 
     override suspend fun setRomRootPath(path: String) { dataStore.setRomRootPath(path) }
     override suspend fun setMediaFolderPath(path: String) { dataStore.setMediaFolderPath(path) }
@@ -73,4 +74,5 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setVideoMuted(muted: Boolean) { dataStore.setVideoMuted(muted) }
     override suspend fun setFirstLaunchComplete() { dataStore.setFirstLaunchComplete() }
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
+    override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -26,6 +26,7 @@ class SettingsRepositoryImpl @Inject constructor(
         dataStore.ssId,
         dataStore.ssPassword,
         dataStore.preferredRegion,
+        dataStore.scrapeMetadata,
         dataStore.scrapeBoxArt,
         dataStore.scrapeScreenshots,
         dataStore.scrapeWheelLogos,
@@ -35,10 +36,11 @@ class SettingsRepositoryImpl @Inject constructor(
             ssid = values[0] as String,
             sspassword = values[1] as String,
             preferredRegion = values[2] as String,
-            scrapeBoxArt = values[3] as Boolean,
-            scrapeScreenshots = values[4] as Boolean,
-            scrapeWheelLogos = values[5] as Boolean,
-            scrapeVideos = values[6] as Boolean
+            scrapeMetadata = values[3] as Boolean,
+            scrapeBoxArt = values[4] as Boolean,
+            scrapeScreenshots = values[5] as Boolean,
+            scrapeWheelLogos = values[6] as Boolean,
+            scrapeVideos = values[7] as Boolean
         )
     }
 
@@ -63,11 +65,13 @@ class SettingsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun updateScraperOptions(
+        scrapeMetadata: Boolean,
         scrapeBoxArt: Boolean,
         scrapeScreenshots: Boolean,
         scrapeWheelLogos: Boolean,
         scrapeVideos: Boolean
     ) {
+        dataStore.setScrapeMetadata(scrapeMetadata)
         dataStore.setScrapeBoxArt(scrapeBoxArt)
         dataStore.setScrapeScreenshots(scrapeScreenshots)
         dataStore.setScrapeWheelLogos(scrapeWheelLogos)

--- a/app/src/main/java/com/gamelaunch/frontend/di/NetworkModule.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.gamelaunch.frontend.di
 
 import com.gamelaunch.frontend.data.network.LaunchBoxService
 import com.gamelaunch.frontend.data.network.RetroAchievementsApi
+import com.gamelaunch.frontend.data.network.RetroAchievementsConnectApi
 import com.gamelaunch.frontend.data.network.ScreenScraperApi
 import com.gamelaunch.frontend.data.network.interceptor.RateLimitInterceptor
 import dagger.Module
@@ -89,6 +90,14 @@ object NetworkModule {
     @Named("ra")
     fun provideRaOkHttpClient(): OkHttpClient =
         OkHttpClient.Builder()
+            // The RA Connect API (dorequest.php) REJECTS requests without a User-Agent.
+            // Format: {Frontend}/{version} ({platform}) — see api-docs.retroachievements.org
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", "eOr/${com.gamelaunch.frontend.BuildConfig.VERSION_NAME} (Android)")
+                    .build()
+                chain.proceed(request)
+            }
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .build()
@@ -107,4 +116,9 @@ object NetworkModule {
     @Singleton
     fun provideRetroAchievementsApi(@Named("ra") retrofit: Retrofit): RetroAchievementsApi =
         retrofit.create(RetroAchievementsApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideRetroAchievementsConnectApi(@Named("ra") retrofit: Retrofit): RetroAchievementsConnectApi =
+        retrofit.create(RetroAchievementsConnectApi::class.java)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/di/NetworkModule.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.di
 
 import com.gamelaunch.frontend.data.network.LaunchBoxService
+import com.gamelaunch.frontend.data.network.RetroAchievementsApi
 import com.gamelaunch.frontend.data.network.ScreenScraperApi
 import com.gamelaunch.frontend.data.network.interceptor.RateLimitInterceptor
 import dagger.Module
@@ -82,4 +83,28 @@ object NetworkModule {
     @Singleton
     fun provideLaunchBoxService(@Named("launchbox") retrofit: Retrofit): LaunchBoxService =
         retrofit.create(LaunchBoxService::class.java)
+
+    @Provides
+    @Singleton
+    @Named("ra")
+    fun provideRaOkHttpClient(): OkHttpClient =
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+    @Provides
+    @Singleton
+    @Named("ra")
+    fun provideRaRetrofit(@Named("ra") client: OkHttpClient): Retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://retroachievements.org/API/")
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideRetroAchievementsApi(@Named("ra") retrofit: Retrofit): RetroAchievementsApi =
+        retrofit.create(RetroAchievementsApi::class.java)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/di/RepositoryModule.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/di/RepositoryModule.kt
@@ -3,11 +3,13 @@ package com.gamelaunch.frontend.di
 import com.gamelaunch.frontend.data.repository.EmulatorRepositoryImpl
 import com.gamelaunch.frontend.data.repository.GameRepositoryImpl
 import com.gamelaunch.frontend.data.repository.MediaRepositoryImpl
+import com.gamelaunch.frontend.data.repository.RetroAchievementsRepositoryImpl
 import com.gamelaunch.frontend.data.repository.ScraperRepositoryImpl
 import com.gamelaunch.frontend.data.repository.SettingsRepositoryImpl
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.MediaRepository
+import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
 import com.gamelaunch.frontend.domain.repository.ScraperRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import dagger.Binds
@@ -34,4 +36,7 @@ abstract class RepositoryModule {
 
     @Binds @Singleton
     abstract fun bindSettingsRepository(impl: SettingsRepositoryImpl): SettingsRepository
+
+    @Binds @Singleton
+    abstract fun bindRetroAchievementsRepository(impl: RetroAchievementsRepositoryImpl): RetroAchievementsRepository
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/model/RaModels.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/model/RaModels.kt
@@ -12,6 +12,25 @@ data class RaProfile(
     val status: String?
 )
 
+/** Result of a Connect API username/password (or token) login. */
+data class RaSession(
+    val username: String,
+    val token: String,
+    val points: Int,
+    val softcorePoints: Int
+) {
+    /** Basic profile that can be shown without a Web API key. */
+    fun toProfile(): RaProfile = RaProfile(
+        username       = username,
+        avatarUrl      = raAvatarUrl(username),
+        totalPoints    = points,
+        softcorePoints = softcorePoints,
+        truePoints     = 0,
+        rank           = null,
+        status         = null
+    )
+}
+
 data class RaRecentGame(
     val gameId: Int,
     val title: String,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/model/RaModels.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/model/RaModels.kt
@@ -1,0 +1,39 @@
+package com.gamelaunch.frontend.domain.model
+
+private const val RA_MEDIA_BASE = "https://media.retroachievements.org"
+
+data class RaProfile(
+    val username: String,
+    val avatarUrl: String,
+    val totalPoints: Int,
+    val softcorePoints: Int,
+    val truePoints: Int,
+    val rank: Int?,
+    val status: String?
+)
+
+data class RaRecentGame(
+    val gameId: Int,
+    val title: String,
+    val consoleName: String,
+    val iconUrl: String,
+    val numAchievements: Int,
+    val numEarned: Int,
+    val numEarnedHardcore: Int,
+    val scoreEarned: Int,
+    val maxScore: Int,
+    val lastPlayed: String?,
+    val highestAwardKind: String?
+) {
+    val completionPercent: Float
+        get() = if (numAchievements > 0) numEarned.toFloat() / numAchievements else 0f
+
+    val isMastered: Boolean
+        get() = highestAwardKind == "mastered" || highestAwardKind == "completed"
+}
+
+fun String.toRaMediaUrl(): String =
+    if (startsWith("http")) this else "$RA_MEDIA_BASE$this"
+
+fun raAvatarUrl(username: String): String =
+    "$RA_MEDIA_BASE/UserPic/$username.png"

--- a/app/src/main/java/com/gamelaunch/frontend/domain/model/ScraperConfig.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/model/ScraperConfig.kt
@@ -9,6 +9,7 @@ data class ScraperConfig(
     val devpassword: String = BuildConfig.SS_DEV_PASSWORD,
     val softname: String = "eOr",
     val preferredRegion: String = "us",
+    val scrapeMetadata: Boolean = true,
     val scrapeBoxArt: Boolean = true,
     val scrapeScreenshots: Boolean = true,
     val scrapeWheelLogos: Boolean = true,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/model/ScraperConfig.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/model/ScraperConfig.kt
@@ -7,7 +7,7 @@ data class ScraperConfig(
     val sspassword: String = "",
     val devid: String = BuildConfig.SS_DEV_ID,
     val devpassword: String = BuildConfig.SS_DEV_PASSWORD,
-    val softname: String = "GameLauncherAndroid",
+    val softname: String = "eOr",
     val preferredRegion: String = "us",
     val scrapeBoxArt: Boolean = true,
     val scrapeScreenshots: Boolean = true,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
@@ -194,6 +194,12 @@ object PlatformDefinitions {
             extensions = listOf(".lnk", ".url", ".exe"),
             folderNames = listOf("steam", "Steam", "pc", "PC", "Windows"),
             defaultEmulatorPackage = "com.gamenative.android"
+        ),
+        Platform(
+            id = "android", displayName = "Android Games", scraperSystemId = 0,
+            extensions = listOf(".apk"),
+            folderNames = listOf("android", "Android", "Android Games"),
+            defaultEmulatorPackage = null
         )
     )
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
@@ -188,6 +188,12 @@ object PlatformDefinitions {
             extensions = listOf(".vpk"),
             folderNames = listOf("psvita", "PSVita", "PS Vita", "Vita"),
             defaultEmulatorPackage = "org.vita3k.emulator"
+        ),
+        Platform(
+            id = "steam", displayName = "PC / Steam", scraperSystemId = 0,
+            extensions = listOf(".lnk", ".url", ".exe"),
+            folderNames = listOf("steam", "Steam", "pc", "PC", "Windows"),
+            defaultEmulatorPackage = "com.gamenative.android"
         )
     )
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/SystemSort.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/SystemSort.kt
@@ -1,0 +1,85 @@
+package com.gamelaunch.frontend.domain.platform
+
+/** How the user can order the systems shown on the home screen. */
+enum class SystemSort(val label: String) {
+    ALPHABETICAL("Alphabetical"),
+    RELEASE_DATE("Release date"),
+    CONSOLE_TYPE("Console type"),
+    BRAND("Brand name"),
+    GAME_COUNT("Number of games");
+
+    companion object {
+        fun fromName(name: String): SystemSort? = entries.firstOrNull { it.name == name }
+    }
+}
+
+enum class ConsoleKind(val order: Int) { CONSOLE(0), HANDHELD(1), ARCADE(2), COMPUTER(3), MOBILE(4), OTHER(5) }
+
+data class PlatformMeta(val releaseYear: Int, val brand: String, val kind: ConsoleKind)
+
+/** Static per-platform metadata used only for sorting the system list. */
+object PlatformMetadata {
+    val byId: Map<String, PlatformMeta> = mapOf(
+        "nes"       to PlatformMeta(1983, "Nintendo", ConsoleKind.CONSOLE),
+        "snes"      to PlatformMeta(1990, "Nintendo", ConsoleKind.CONSOLE),
+        "n64"       to PlatformMeta(1996, "Nintendo", ConsoleKind.CONSOLE),
+        "gb"        to PlatformMeta(1989, "Nintendo", ConsoleKind.HANDHELD),
+        "gbc"       to PlatformMeta(1998, "Nintendo", ConsoleKind.HANDHELD),
+        "gba"       to PlatformMeta(2001, "Nintendo", ConsoleKind.HANDHELD),
+        "nds"       to PlatformMeta(2004, "Nintendo", ConsoleKind.HANDHELD),
+        "3ds"       to PlatformMeta(2011, "Nintendo", ConsoleKind.HANDHELD),
+        "gc"        to PlatformMeta(2001, "Nintendo", ConsoleKind.CONSOLE),
+        "wii"       to PlatformMeta(2006, "Nintendo", ConsoleKind.CONSOLE),
+        "wiiu"      to PlatformMeta(2012, "Nintendo", ConsoleKind.CONSOLE),
+        "switch"    to PlatformMeta(2017, "Nintendo", ConsoleKind.CONSOLE),
+        "ps1"       to PlatformMeta(1994, "Sony", ConsoleKind.CONSOLE),
+        "ps2"       to PlatformMeta(2000, "Sony", ConsoleKind.CONSOLE),
+        "psp"       to PlatformMeta(2004, "Sony", ConsoleKind.HANDHELD),
+        "psvita"    to PlatformMeta(2011, "Sony", ConsoleKind.HANDHELD),
+        "genesis"   to PlatformMeta(1988, "Sega", ConsoleKind.CONSOLE),
+        "sms"       to PlatformMeta(1985, "Sega", ConsoleKind.CONSOLE),
+        "gg"        to PlatformMeta(1990, "Sega", ConsoleKind.HANDHELD),
+        "saturn"    to PlatformMeta(1994, "Sega", ConsoleKind.CONSOLE),
+        "32x"       to PlatformMeta(1994, "Sega", ConsoleKind.CONSOLE),
+        "segacd"    to PlatformMeta(1991, "Sega", ConsoleKind.CONSOLE),
+        "dc"        to PlatformMeta(1998, "Sega", ConsoleKind.CONSOLE),
+        "atari2600" to PlatformMeta(1977, "Atari", ConsoleKind.CONSOLE),
+        "neogeo"    to PlatformMeta(1990, "SNK", ConsoleKind.CONSOLE),
+        "ngp"       to PlatformMeta(1998, "SNK", ConsoleKind.HANDHELD),
+        "pcengine"  to PlatformMeta(1987, "NEC", ConsoleKind.CONSOLE),
+        "3do"       to PlatformMeta(1993, "Panasonic", ConsoleKind.CONSOLE),
+        "mame"      to PlatformMeta(1980, "Arcade", ConsoleKind.ARCADE),
+        "fbneo"     to PlatformMeta(1980, "Arcade", ConsoleKind.ARCADE),
+        "steam"     to PlatformMeta(2003, "PC", ConsoleKind.COMPUTER),
+        "android"   to PlatformMeta(2008, "Android", ConsoleKind.MOBILE),
+    )
+
+    fun year(id: String): Int = byId[id]?.releaseYear ?: Int.MAX_VALUE
+    fun brand(id: String): String = byId[id]?.brand ?: "￿"
+    fun kindOrder(id: String): Int = (byId[id]?.kind ?: ConsoleKind.OTHER).order
+}
+
+/**
+ * Order a list of platform ids by up to two sort keys (primary, then secondary tie-breaker).
+ * [displayName] and [gameCount] are looked up via the supplied lambdas. Alphabetical is always the
+ * final tie-breaker so the order is stable.
+ */
+fun List<String>.sortedBySystems(
+    sorts: List<SystemSort>,
+    displayName: (String) -> String,
+    gameCount: (String) -> Int
+): List<String> {
+    if (sorts.isEmpty()) return this
+    fun keyComparator(sort: SystemSort): Comparator<String> = when (sort) {
+        SystemSort.ALPHABETICAL -> compareBy { displayName(it).lowercase() }
+        SystemSort.RELEASE_DATE -> compareBy { PlatformMetadata.year(it) }
+        SystemSort.CONSOLE_TYPE -> compareBy { PlatformMetadata.kindOrder(it) }
+        SystemSort.BRAND        -> compareBy { PlatformMetadata.brand(it).lowercase() }
+        SystemSort.GAME_COUNT   -> compareByDescending { gameCount(it) }
+    }
+    var comparator = keyComparator(sorts.first())
+    sorts.drop(1).forEach { comparator = comparator.then(keyComparator(it)) }
+    // Stable final tie-breaker.
+    comparator = comparator.thenBy { displayName(it).lowercase() }
+    return sortedWith(comparator)
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
@@ -16,6 +16,8 @@ interface GameRepository {
     suspend fun insertGames(games: List<Game>)
     suspend fun updateGame(game: Game)
     suspend fun updateScrapedMetadata(gameId: Long, scraperGameId: Long?, title: String, description: String?, genre: String?, releaseYear: Int?, rating: Float?)
+    /** Mark a game as scraped and keep its title without touching description/genre/year/rating. */
+    suspend fun markScraped(gameId: Long, title: String)
     suspend fun setFavorite(gameId: Long, isFavorite: Boolean)
     suspend fun recordPlay(gameId: Long)
     suspend fun deleteGamesNotInPaths(validPaths: List<String>): Int

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
@@ -19,5 +19,6 @@ interface GameRepository {
     suspend fun setFavorite(gameId: Long, isFavorite: Boolean)
     suspend fun recordPlay(gameId: Long)
     suspend fun deleteGamesNotInPaths(validPaths: List<String>): Int
+    suspend fun deleteAndroidGamesNotIn(validPaths: List<String>): Int
     suspend fun getTotalCount(): Int
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
@@ -8,6 +8,14 @@ interface GameRepository {
     fun getGamesByPlatform(platformId: String): Flow<List<Game>>
     suspend fun getGameById(id: Long): Game?
     suspend fun getUnscrapedGames(): List<Game>
+    /** Games missing any of the enabled scrape outputs (skips ones that already have everything). */
+    suspend fun getGamesNeedingScrape(
+        needMeta: Boolean,
+        needBox: Boolean,
+        needShot: Boolean,
+        needWheel: Boolean,
+        needVideo: Boolean
+    ): List<Game>
     fun getFavorites(): Flow<List<Game>>
     fun getRecentlyPlayed(limit: Int = 20): Flow<List<Game>>
     fun getDistinctPlatformIds(): Flow<List<String>>

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/RetroAchievementsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/RetroAchievementsRepository.kt
@@ -2,8 +2,15 @@ package com.gamelaunch.frontend.domain.repository
 
 import com.gamelaunch.frontend.domain.model.RaProfile
 import com.gamelaunch.frontend.domain.model.RaRecentGame
+import com.gamelaunch.frontend.domain.model.RaSession
 
 interface RetroAchievementsRepository {
+    /** Authenticate with username + password via the Connect API. Returns a reusable token. */
+    suspend fun login(username: String, password: String): Result<RaSession>
+
+    /** Re-validate with a stored token (no password) to refresh the score totals. */
+    suspend fun refreshSession(username: String, token: String): Result<RaSession>
+
     suspend fun getUserProfile(username: String, apiKey: String): Result<RaProfile>
     suspend fun getRecentlyPlayed(username: String, apiKey: String, count: Int = 15): Result<List<RaRecentGame>>
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/RetroAchievementsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/RetroAchievementsRepository.kt
@@ -1,0 +1,9 @@
+package com.gamelaunch.frontend.domain.repository
+
+import com.gamelaunch.frontend.domain.model.RaProfile
+import com.gamelaunch.frontend.domain.model.RaRecentGame
+
+interface RetroAchievementsRepository {
+    suspend fun getUserProfile(username: String, apiKey: String): Result<RaProfile>
+    suspend fun getRecentlyPlayed(username: String, apiKey: String, count: Int = 15): Result<List<RaRecentGame>>
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -25,6 +25,7 @@ interface SettingsRepository {
     suspend fun setLayoutMode(mode: LayoutMode)
     suspend fun setScraperCredentials(ssid: String, sspassword: String)
     suspend fun updateScraperOptions(
+        scrapeMetadata: Boolean,
         scrapeBoxArt: Boolean,
         scrapeScreenshots: Boolean,
         scrapeWheelLogos: Boolean,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -13,6 +13,7 @@ interface SettingsRepository {
     val videoMuted: Flow<Boolean>
     val isFirstLaunch: Flow<Boolean>
     val showRecentlyPlayed: Flow<Boolean>
+    val darkMode: Flow<Boolean>
 
     suspend fun setRomRootPath(path: String)
     suspend fun setMediaFolderPath(path: String)
@@ -29,4 +30,5 @@ interface SettingsRepository {
     suspend fun setVideoMuted(muted: Boolean)
     suspend fun setFirstLaunchComplete()
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
+    suspend fun setDarkMode(enabled: Boolean)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -16,6 +16,9 @@ interface SettingsRepository {
     val darkMode: Flow<Boolean>
     val raUsername: Flow<String>
     val raApiKey: Flow<String>
+    val raToken: Flow<String>
+    val raPoints: Flow<Int>
+    val raSoftcorePoints: Flow<Int>
 
     suspend fun setRomRootPath(path: String)
     suspend fun setMediaFolderPath(path: String)
@@ -33,5 +36,7 @@ interface SettingsRepository {
     suspend fun setFirstLaunchComplete()
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
     suspend fun setDarkMode(enabled: Boolean)
-    suspend fun setRaCredentials(username: String, apiKey: String)
+    suspend fun setRaApiKey(apiKey: String)
+    suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)
+    suspend fun clearRaCredentials()
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.domain.repository
 
 import com.gamelaunch.frontend.domain.model.ScraperConfig
+import com.gamelaunch.frontend.domain.platform.SystemSort
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import kotlinx.coroutines.flow.Flow
 
@@ -14,6 +15,7 @@ interface SettingsRepository {
     val isFirstLaunch: Flow<Boolean>
     val showRecentlyPlayed: Flow<Boolean>
     val darkMode: Flow<Boolean>
+    val systemSort: Flow<List<SystemSort>>
     val raUsername: Flow<String>
     val raApiKey: Flow<String>
     val raToken: Flow<String>
@@ -37,6 +39,7 @@ interface SettingsRepository {
     suspend fun setFirstLaunchComplete()
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
     suspend fun setDarkMode(enabled: Boolean)
+    suspend fun setSystemSort(keys: List<SystemSort>)
     suspend fun setRaApiKey(apiKey: String)
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)
     suspend fun clearRaCredentials()

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -14,6 +14,8 @@ interface SettingsRepository {
     val isFirstLaunch: Flow<Boolean>
     val showRecentlyPlayed: Flow<Boolean>
     val darkMode: Flow<Boolean>
+    val raUsername: Flow<String>
+    val raApiKey: Flow<String>
 
     suspend fun setRomRootPath(path: String)
     suspend fun setMediaFolderPath(path: String)
@@ -31,4 +33,5 @@ interface SettingsRepository {
     suspend fun setFirstLaunchComplete()
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
     suspend fun setDarkMode(enabled: Boolean)
+    suspend fun setRaCredentials(username: String, apiKey: String)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/BatchScrapeUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/BatchScrapeUseCase.kt
@@ -23,7 +23,15 @@ class BatchScrapeUseCase @Inject constructor(
     private val scrapeGameUseCase: ScrapeGameUseCase
 ) {
     operator fun invoke(config: ScraperConfig): Flow<BatchScrapeState> = flow {
-        val games = gameRepository.getUnscrapedGames()
+        // Only scrape games missing something the user has enabled — fully-complete games are
+        // skipped so re-running the scrape doesn't re-fetch everything.
+        val games = gameRepository.getGamesNeedingScrape(
+            needMeta  = config.scrapeMetadata,
+            needBox   = config.scrapeBoxArt,
+            needShot  = config.scrapeScreenshots,
+            needWheel = config.scrapeWheelLogos,
+            needVideo = config.scrapeVideos
+        )
         val total = games.size
         val results = mutableListOf<ScrapeResult>()
         var succeeded = 0

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
@@ -1,0 +1,72 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import com.gamelaunch.frontend.domain.model.Game
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import javax.inject.Inject
+
+class ScanAndroidGamesUseCase @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val gameRepository: GameRepository
+) {
+    // Package prefixes that belong to the OS or this launcher — skip them.
+    private val systemPrefixes = setOf(
+        "android", "com.android", "com.google.android", "com.google.ar",
+        "com.samsung", "com.miui", "com.huawei", "com.gamelaunch.frontend"
+    )
+
+    operator fun invoke(): Flow<ScanProgress> = flow {
+        val pm = context.packageManager
+        // Primary: apps that declare CATEGORY_GAME.
+        val gameIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.GAME")
+        val fromCategory = pm.queryIntentActivities(gameIntent, 0)
+            .map { it.activityInfo.packageName }
+            .distinct()
+
+        // Filter out system packages.
+        val packages = fromCategory.filter { pkg ->
+            systemPrefixes.none { pkg == it || pkg.startsWith("$it.") } &&
+            runCatching {
+                val info = pm.getPackageInfo(pkg, 0)
+                (info.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) == 0
+            }.getOrDefault(false)
+        }
+
+        emit(ScanProgress(0, packages.size, "Scanning installed games…"))
+
+        val validPaths = mutableListOf<String>()
+        var added = 0
+
+        packages.forEachIndexed { index, pkg ->
+            val label = runCatching {
+                pm.getApplicationLabel(pm.getApplicationInfo(pkg, 0)).toString()
+            }.getOrDefault(pkg)
+
+            emit(ScanProgress(index, packages.size, label, added))
+
+            val romPath = "package:$pkg"
+            validPaths.add(romPath)
+
+            val game = Game(
+                title       = label,
+                romPath     = romPath,
+                romFilename = pkg,
+                platformId  = "android"
+            )
+            val id = gameRepository.insertGame(game)
+            if (id > 0) added++
+        }
+
+        // Remove android-platform games whose packages are no longer installed.
+        gameRepository.deleteAndroidGamesNotIn(validPaths)
+
+        emit(ScanProgress(packages.size, packages.size, added = added))
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
@@ -2,6 +2,7 @@ package com.gamelaunch.frontend.domain.usecase
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.repository.GameRepository
@@ -24,18 +25,34 @@ class ScanAndroidGamesUseCase @Inject constructor(
 
     operator fun invoke(): Flow<ScanProgress> = flow {
         val pm = context.packageManager
-        // Primary: apps that declare CATEGORY_GAME.
-        val gameIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.GAME")
-        val fromCategory = pm.queryIntentActivities(gameIntent, 0)
-            .map { it.activityInfo.packageName }
-            .distinct()
 
-        // Filter out system packages.
-        val packages = fromCategory.filter { pkg ->
-            systemPrefixes.none { pkg == it || pkg.startsWith("$it.") } &&
+        // Apps that declare the GAME launcher category (older / explicit signal).
+        val gameIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.GAME")
+        val categoryGamePkgs = pm.queryIntentActivities(gameIntent, 0)
+            .map { it.activityInfo.packageName }
+            .toSet()
+
+        // Every launchable user app — most modern games (CoD, RDR, KOTOR, Stardew, etc.) don't
+        // declare the GAME launcher category, so we instead classify by appCategory == GAME, which
+        // the Play Store sets for games, plus the legacy game flag and the GAME-category set above.
+        val launcherIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
+        val launchablePkgs = pm.queryIntentActivities(launcherIntent, 0)
+            .map { it.activityInfo.packageName }
+
+        val packages = (categoryGamePkgs + launchablePkgs).distinct().filter { pkg ->
+            if (systemPrefixes.any { pkg == it || pkg.startsWith("$it.") }) return@filter false
             runCatching {
-                val info = pm.getPackageInfo(pkg, 0)
-                (info.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) == 0
+                val ai = pm.getApplicationInfo(pkg, 0)
+                // Skip pre-installed system apps (unless the user updated one from the store).
+                val isSystem = (ai.flags and ApplicationInfo.FLAG_SYSTEM) != 0 &&
+                               (ai.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) == 0
+                if (isSystem) return@runCatching false
+                // Must be launchable so we can actually open it.
+                if (pm.getLaunchIntentForPackage(pkg) == null) return@runCatching false
+
+                pkg in categoryGamePkgs ||
+                    ai.category == ApplicationInfo.CATEGORY_GAME ||
+                    @Suppress("DEPRECATION") (ai.flags and ApplicationInfo.FLAG_IS_GAME) != 0
             }.getOrDefault(false)
         }
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
@@ -11,7 +11,7 @@ import com.gamelaunch.frontend.domain.repository.ScraperRepository
 import javax.inject.Inject
 
 sealed class ScrapeResult {
-    data class Success(val gameId: Long) : ScrapeResult()
+    data class Success(val gameId: Long, val title: String) : ScrapeResult()
     data class NotFound(val gameId: Long, val romName: String) : ScrapeResult()
     data class RateLimited(val gameId: Long) : ScrapeResult()
     data class Error(val gameId: Long, val cause: Throwable) : ScrapeResult()
@@ -43,18 +43,21 @@ class ScrapeGameUseCase @Inject constructor(
             ssResult.onSuccess { gameInfo ->
                 // When metadata scraping is off, keep the existing title and don't overwrite
                 // description/genre/year/rating — only the media below is fetched.
-                if (config.scrapeMetadata) {
+                val scrapedTitle = if (config.scrapeMetadata) {
+                    val title = gameInfo.getBestName(config.preferredRegion) ?: game.title
                     gameRepository.updateScrapedMetadata(
                         gameId        = game.id,
                         scraperGameId = gameInfo.id?.toLongOrNull(),
-                        title         = gameInfo.getBestName(config.preferredRegion) ?: game.title,
+                        title         = title,
                         description   = gameInfo.getBestSynopsis(config.preferredRegion),
                         genre         = gameInfo.getPrimaryGenre(),
                         releaseYear   = gameInfo.getReleaseYear(config.preferredRegion),
                         rating        = gameInfo.getRating()
                     )
+                    title
                 } else {
                     gameRepository.markScraped(game.id, game.title)
+                    game.title
                 }
                 val media = GameMedia(
                     gameId             = game.id,
@@ -72,7 +75,7 @@ class ScrapeGameUseCase @Inject constructor(
                 media.screenshotRemoteUrl?.let { mediaRepository.downloadAndCacheScreenshot(game.id, it) }
                 media.wheelLogoRemoteUrl?.let  { mediaRepository.downloadAndCacheWheelLogo(game.id, it) }
                 media.videoRemoteUrl?.let      { mediaRepository.downloadAndCacheVideo(game.id, it) }
-                return ScrapeResult.Success(game.id)
+                return ScrapeResult.Success(game.id, scrapedTitle)
             }
 
             // Only a rate-limit stops the batch; any other ScreenScraper failure
@@ -100,7 +103,7 @@ class ScrapeGameUseCase @Inject constructor(
                 gameId = game.id, scraperGameId = null, title = game.title,
                 description = null, genre = null, releaseYear = null, rating = null
             )
-            return ScrapeResult.Success(game.id)
+            return ScrapeResult.Success(game.id, game.title)
         }
 
         // ── LaunchBox fallback ───────────────────────────────────────────
@@ -131,7 +134,7 @@ class ScrapeGameUseCase @Inject constructor(
             lbMedia.boxFrontUrl?.let     { mediaRepository.downloadAndCacheBoxArt(game.id, it) }
             lbMedia.screenshotUrl?.let   { mediaRepository.downloadAndCacheScreenshot(game.id, it) }
             lbMedia.logoUrl?.let         { mediaRepository.downloadAndCacheWheelLogo(game.id, it) }
-            return ScrapeResult.Success(game.id)
+            return ScrapeResult.Success(game.id, lbMedia.title)
         }
 
         return ScrapeResult.NotFound(game.id, game.romFilename)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
@@ -83,58 +83,65 @@ class ScrapeGameUseCase @Inject constructor(
             if (ssResult.exceptionOrNull() is RateLimitException) return ScrapeResult.RateLimited(game.id)
         }
 
-        // ── libretro thumbnails (no credentials — box art + screenshot + title) ──
-        val thumbs = runCatching {
-            libretroThumbnailScraper.fetch(game.romFilename, game.platformId)
-        }.getOrNull()
+        // ── libretro thumbnails (free fallback — box art + screenshot only) ──
+        // It contributes no metadata, so only bother when the user actually wants artwork.
+        if (config.scrapeBoxArt || config.scrapeScreenshots) {
+            val thumbs = runCatching {
+                libretroThumbnailScraper.fetch(game.romFilename, game.platformId)
+            }.getOrNull()
 
-        if (thumbs != null) {
-            val media = GameMedia(
-                gameId              = game.id,
-                boxArtRemoteUrl     = thumbs.boxArt,
-                screenshotRemoteUrl = thumbs.screenshot,
-                scraperTimestampMs  = System.currentTimeMillis()
-            )
-            mediaRepository.upsertMedia(media)
-            mediaRepository.downloadAndCacheBoxArt(game.id, thumbs.boxArt)
-            runCatching { mediaRepository.downloadAndCacheScreenshot(game.id, thumbs.screenshot) }
-            // Mark scraped so we don't re-fetch every run, keeping the existing title.
-            gameRepository.updateScrapedMetadata(
-                gameId = game.id, scraperGameId = null, title = game.title,
-                description = null, genre = null, releaseYear = null, rating = null
-            )
-            return ScrapeResult.Success(game.id, game.title)
+            if (thumbs != null) {
+                val boxArt     = if (config.scrapeBoxArt) thumbs.boxArt else null
+                val screenshot = if (config.scrapeScreenshots) thumbs.screenshot else null
+                if (boxArt != null || screenshot != null) {
+                    val media = GameMedia(
+                        gameId              = game.id,
+                        boxArtRemoteUrl     = boxArt,
+                        screenshotRemoteUrl = screenshot,
+                        scraperTimestampMs  = System.currentTimeMillis()
+                    )
+                    mediaRepository.upsertMedia(media)
+                    boxArt?.let     { mediaRepository.downloadAndCacheBoxArt(game.id, it) }
+                    screenshot?.let { url -> runCatching { mediaRepository.downloadAndCacheScreenshot(game.id, url) } }
+                    // Mark scraped so we don't re-fetch every run, keeping the existing title.
+                    gameRepository.markScraped(game.id, game.title)
+                    return ScrapeResult.Success(game.id, game.title)
+                }
+            }
         }
 
-        // ── LaunchBox fallback ───────────────────────────────────────────
+        // ── LaunchBox fallback (metadata + art) ───────────────────────────
         val lbMedia = runCatching {
             scrapeLaunchBoxUseCase(game.title, game.platformId)
         }.getOrNull()
 
         if (lbMedia != null) {
-            // Update metadata from LaunchBox
-            gameRepository.updateScrapedMetadata(
-                gameId        = game.id,
-                scraperGameId = null,
-                title         = lbMedia.title,
-                description   = lbMedia.overview,
-                genre         = null,
-                releaseYear   = lbMedia.releaseYear,
-                rating        = lbMedia.rating
-            )
+            if (config.scrapeMetadata) {
+                gameRepository.updateScrapedMetadata(
+                    gameId        = game.id,
+                    scraperGameId = null,
+                    title         = lbMedia.title,
+                    description   = lbMedia.overview,
+                    genre         = null,
+                    releaseYear   = lbMedia.releaseYear,
+                    rating        = lbMedia.rating
+                )
+            } else {
+                gameRepository.markScraped(game.id, game.title)
+            }
             val media = GameMedia(
                 gameId              = game.id,
-                boxArtRemoteUrl     = lbMedia.boxFrontUrl,
-                screenshotRemoteUrl = lbMedia.screenshotUrl,
-                wheelLogoRemoteUrl  = lbMedia.logoUrl,
+                boxArtRemoteUrl     = if (config.scrapeBoxArt)     lbMedia.boxFrontUrl  else null,
+                screenshotRemoteUrl = if (config.scrapeScreenshots) lbMedia.screenshotUrl else null,
+                wheelLogoRemoteUrl  = if (config.scrapeWheelLogos)  lbMedia.logoUrl       else null,
                 videoRemoteUrl      = null, // LaunchBox has no hosted videos
                 scraperTimestampMs  = System.currentTimeMillis()
             )
             mediaRepository.upsertMedia(media)
-            lbMedia.boxFrontUrl?.let     { mediaRepository.downloadAndCacheBoxArt(game.id, it) }
-            lbMedia.screenshotUrl?.let   { mediaRepository.downloadAndCacheScreenshot(game.id, it) }
-            lbMedia.logoUrl?.let         { mediaRepository.downloadAndCacheWheelLogo(game.id, it) }
-            return ScrapeResult.Success(game.id, lbMedia.title)
+            media.boxArtRemoteUrl?.let     { mediaRepository.downloadAndCacheBoxArt(game.id, it) }
+            media.screenshotRemoteUrl?.let { mediaRepository.downloadAndCacheScreenshot(game.id, it) }
+            media.wheelLogoRemoteUrl?.let  { mediaRepository.downloadAndCacheWheelLogo(game.id, it) }
+            return ScrapeResult.Success(game.id, if (config.scrapeMetadata) lbMedia.title else game.title)
         }
 
         return ScrapeResult.NotFound(game.id, game.romFilename)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
@@ -28,8 +28,11 @@ class ScrapeGameUseCase @Inject constructor(
         val platform = PlatformDefinitions.byId[game.platformId]
             ?: return ScrapeResult.Error(game.id, IllegalArgumentException("Unknown platform: ${game.platformId}"))
 
-        // ── ScreenScraper (only when both dev + user credentials are present) ──
-        if (config.isConfigured && config.devid.isNotBlank() && config.devpassword.isNotBlank()) {
+        // ── ScreenScraper (default/preferred — requires user to have a free SS account) ──
+        // Dev credentials (devid/devpassword) are compiled in from local.properties.
+        // User credentials (ssid/sspassword) must be set in Settings.
+        // Falls through to libretro → LaunchBox only on 404 or other non-429 error.
+        if (config.isConfigured) {
             val ssResult = scraperRepository.scrapeGame(
                 config   = config,
                 systemId = platform.scraperSystemId,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
@@ -41,16 +41,21 @@ class ScrapeGameUseCase @Inject constructor(
             )
 
             ssResult.onSuccess { gameInfo ->
-                val title = gameInfo.getBestName(config.preferredRegion) ?: game.title
-                gameRepository.updateScrapedMetadata(
-                    gameId        = game.id,
-                    scraperGameId = gameInfo.id?.toLongOrNull(),
-                    title         = title,
-                    description   = gameInfo.getBestSynopsis(config.preferredRegion),
-                    genre         = gameInfo.getPrimaryGenre(),
-                    releaseYear   = gameInfo.getReleaseYear(config.preferredRegion),
-                    rating        = gameInfo.getRating()
-                )
+                // When metadata scraping is off, keep the existing title and don't overwrite
+                // description/genre/year/rating — only the media below is fetched.
+                if (config.scrapeMetadata) {
+                    gameRepository.updateScrapedMetadata(
+                        gameId        = game.id,
+                        scraperGameId = gameInfo.id?.toLongOrNull(),
+                        title         = gameInfo.getBestName(config.preferredRegion) ?: game.title,
+                        description   = gameInfo.getBestSynopsis(config.preferredRegion),
+                        genre         = gameInfo.getPrimaryGenre(),
+                        releaseYear   = gameInfo.getReleaseYear(config.preferredRegion),
+                        rating        = gameInfo.getRating()
+                    )
+                } else {
+                    gameRepository.markScraped(game.id, game.title)
+                }
                 val media = GameMedia(
                     gameId             = game.id,
                     boxArtRemoteUrl    = if (config.scrapeBoxArt)     gameInfo.getMediaUrl("box-2D", config.preferredRegion) else null,

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
@@ -18,6 +18,15 @@ class EmulatorLauncher @Inject constructor(
     private val packageManagerHelper: PackageManagerHelper
 ) {
     suspend fun launch(game: Game): Result<Unit> {
+        // Android game: romPath is "package:<pkg>" — launch the app directly.
+        if (game.romPath.startsWith("package:")) {
+            val pkg = game.romPath.removePrefix("package:")
+            val intent = context.packageManager.getLaunchIntentForPackage(pkg)
+                ?: return Result.failure(Exception("App not installed: $pkg"))
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            return tryStartActivity(intent)
+        }
+
         var mapping = emulatorRepository.getMappingForPlatform(game.platformId)
             ?: return Result.failure(NoEmulatorConfiguredException(game.platformId))
 

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
@@ -149,6 +149,12 @@ class EmulatorLauncher @Inject constructor(
         "net.play.ptmk.ps2" to
             LaunchSpec("xyz.aethersx2.android.EmulationActivity",
                        romExtraKey = "bootPath", action = Intent.ACTION_MAIN),
+        // GameCube / Wii — Dolphin boots a game when MainActivity gets an "AutoStartFile" path
+        // extra. It must NOT be an ACTION_VIEW intent (its MainActivity rejects VIEW), otherwise
+        // it just opens the game-list menu and sits on a loading screen.
+        "org.dolphinemu.dolphinemu" to
+            LaunchSpec("org.dolphinemu.dolphinemu.ui.main.MainActivity",
+                       romExtraKey = "AutoStartFile", action = Intent.ACTION_MAIN),
         // PSP — PPSSPP reads getData().
         "org.ppsspp.ppsspp"     to LaunchSpec("org.ppsspp.ppsspp.PpssppActivity"),
         "org.ppsspp.ppssppgold" to LaunchSpec("org.ppsspp.ppsspp.PpssppActivity"),

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
@@ -56,6 +56,10 @@ class PackageManagerHelper @Inject constructor(
         "com.explusalpha.GbaEmu"             to "GBA.emu (GBA)",
         "com.explusalpha.GbcEmu"             to "GBC.emu (GBC/GB)",
         "com.explusalpha.Snes9xEmu"          to "Snes9x EX+ (SNES)",
+        // PC / Steam launchers
+        "com.valvesoftware.steamlink"         to "Steam Link",
+        "com.gamenative.android"              to "GameNative",
+        "com.saber.gamehub"                  to "GameHub",
         // Other
         "ru.playsoftware.j2meloader"         to "J2ME Loader"
     )
@@ -93,7 +97,8 @@ class PackageManagerHelper @Inject constructor(
         "gc"        to listOf("org.dolphinemu.dolphinemu", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "wii"       to listOf("org.dolphinemu.dolphinemu", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "wiiu"      to listOf("info.cemu.cemu", "com.retroarch.aarch64", "org.libretro.retroarch"),
-        "psvita"    to listOf("org.vita3k.emulator")
+        "psvita"    to listOf("org.vita3k.emulator"),
+        "steam"     to listOf("com.gamenative.android", "com.saber.gamehub", "com.valvesoftware.steamlink")
     )
 
     fun getInstalledEmulators(): List<InstalledEmulator> {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
@@ -13,7 +13,8 @@ private val platformLabels = mapOf(
     "genesis"  to "GEN",    "gg"      to "GG",      "sms"    to "SMS",
     "pce"      to "PCE",    "neogeo"  to "Neo·Geo", "arcade" to "Arcade",
     "msx"      to "MSX",    "lynx"    to "Lynx",    "atari"  to "Atari",
-    "steam"    to "Steam"
+    "steam"    to "Steam",
+    "android"  to "Android"
 )
 
 /** Short pill label for a platform (falls back to the upper-cased id). */
@@ -121,6 +122,7 @@ private val iconByKey: Map<String, Int> = mapOf(
         "gamecube" to R.drawable.ic_sys_gamecube,
         "3do" to R.drawable.ic_sys_3do,
         "steam" to R.drawable.ic_sys_steam,
+        "android" to R.drawable.ic_sys_android,
 )
 
 // our platformId -> pack key, only where the two differ (direct id matches resolve automatically)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
@@ -12,7 +12,8 @@ private val platformLabels = mapOf(
     "psp"      to "PSP",    "dc"      to "DC",      "saturn" to "Saturn",
     "genesis"  to "GEN",    "gg"      to "GG",      "sms"    to "SMS",
     "pce"      to "PCE",    "neogeo"  to "Neo·Geo", "arcade" to "Arcade",
-    "msx"      to "MSX",    "lynx"    to "Lynx",    "atari"  to "Atari"
+    "msx"      to "MSX",    "lynx"    to "Lynx",    "atari"  to "Atari",
+    "steam"    to "Steam"
 )
 
 /** Short pill label for a platform (falls back to the upper-cased id). */
@@ -119,6 +120,7 @@ private val iconByKey: Map<String, Int> = mapOf(
         "wiiu" to R.drawable.ic_sys_wiiu,
         "gamecube" to R.drawable.ic_sys_gamecube,
         "3do" to R.drawable.ic_sys_3do,
+        "steam" to R.drawable.ic_sys_steam,
 )
 
 // our platformId -> pack key, only where the two differ (direct id matches resolve automatically)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/VideoPlayer.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/VideoPlayer.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import android.view.ViewGroup
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
@@ -79,6 +80,11 @@ fun VideoPlayer(
                 player = exoPlayer
                 useController = false
                 resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                // Don't steal D-pad / button key focus from the Compose detail screen — otherwise
+                // its onKeyEvent (B = back) never fires while a preview video is playing.
+                isFocusable = false
+                isFocusableInTouchMode = false
+                descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
             }
         },
         modifier = modifier

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -109,8 +109,8 @@ fun GameDetailScreen(
                     when (event.key) {
                         // A = launch
                         GamepadA, Key.DirectionCenter -> { viewModel.launchGame(); true }
-                        // B = back
-                        GamepadB -> { onBack(); true }
+                        // B / system back = return to the game grid
+                        GamepadB, Key.Back -> { onBack(); true }
                         // Y = toggle favourite
                         GamepadY -> { viewModel.toggleFavorite(); true }
                         else -> false

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -68,8 +68,9 @@ import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
 import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.component.VideoPlayer
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
-import com.gamelaunch.frontend.ui.theme.NavyCard
-import com.gamelaunch.frontend.ui.theme.NavySurface
+import com.gamelaunch.frontend.ui.theme.GameColorScheme
+import com.gamelaunch.frontend.ui.theme.GameLightColorScheme
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 
 private val playGradient = Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple))
@@ -87,7 +88,11 @@ fun GameDetailScreen(
         try { focusRequester.requestFocus() } catch (_: Exception) { }
     }
 
-    Scaffold(containerColor = NavySurface) { _ ->
+    // Follow the user's light/dark choice locally (the global theme stays dark elsewhere).
+    val detailScheme = if (LocalDarkMode.current) GameColorScheme else GameLightColorScheme
+
+    MaterialTheme(colorScheme = detailScheme) {
+    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { _ ->
         if (state.isLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(color = ElectricBlue)
@@ -148,7 +153,7 @@ fun GameDetailScreen(
                         .background(
                             Brush.verticalGradient(
                                 0f to Color.Transparent,
-                                1f to NavySurface
+                                1f to MaterialTheme.colorScheme.surface
                             )
                         )
                 )
@@ -221,7 +226,7 @@ fun GameDetailScreen(
                     .fillMaxWidth()
                     .offset(y = (-20).dp),
                 shape  = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
-                colors = CardDefaults.cardColors(containerColor = NavySurface),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
                 elevation = CardDefaults.cardElevation(0.dp)
             ) {
                 Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 20.dp)) {
@@ -346,6 +351,7 @@ fun GameDetailScreen(
             )
         }
     }
+    }
 }
 
 @Composable
@@ -355,7 +361,7 @@ private fun MetaChip(label: String) {
         style    = MaterialTheme.typography.labelSmall,
         color    = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier
-            .background(NavyCard, RoundedCornerShape(6.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(6.dp))
             .padding(horizontal = 8.dp, vertical = 4.dp)
     )
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -68,10 +68,8 @@ import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
 import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.component.VideoPlayer
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
-import com.gamelaunch.frontend.ui.theme.GameColorScheme
-import com.gamelaunch.frontend.ui.theme.GameLightColorScheme
-import com.gamelaunch.frontend.ui.theme.LocalDarkMode
 import com.gamelaunch.frontend.ui.theme.NeonPurple
+import com.gamelaunch.frontend.ui.theme.ThemedScreen
 
 private val playGradient = Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple))
 private val glassColor   = Color.White.copy(alpha = 0.14f)
@@ -88,10 +86,8 @@ fun GameDetailScreen(
         try { focusRequester.requestFocus() } catch (_: Exception) { }
     }
 
-    // Follow the user's light/dark choice locally (the global theme stays dark elsewhere).
-    val detailScheme = if (LocalDarkMode.current) GameColorScheme else GameLightColorScheme
-
-    MaterialTheme(colorScheme = detailScheme) {
+    // Follow the user's light/dark choice for this screen's Material components.
+    ThemedScreen {
     Scaffold(containerColor = MaterialTheme.colorScheme.surface) { _ ->
         if (state.isLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/AppsContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/AppsContent.kt
@@ -37,6 +37,9 @@ import com.gamelaunch.frontend.ui.component.AppIcon
 import com.gamelaunch.frontend.ui.theme.BounceDurationMs
 import com.gamelaunch.frontend.ui.theme.BounceEasing
 import com.gamelaunch.frontend.ui.theme.BrandBlue
+import com.gamelaunch.frontend.ui.theme.IceWhite
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
+import com.gamelaunch.frontend.ui.theme.SteelGray
 import com.gamelaunch.frontend.ui.theme.TileSub
 import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassTile
@@ -59,8 +62,9 @@ fun AppsContent(
         return
     }
     if (apps.isEmpty()) {
+        val darkMode = LocalDarkMode.current
         Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No apps found", color = TileSub)
+            Text("No apps found", color = if (darkMode) SteelGray else TileSub)
         }
         return
     }
@@ -104,6 +108,7 @@ private fun AppCard(
         animationSpec = tween(durationMillis = BounceDurationMs, easing = BounceEasing),
         label = "appTileScale"
     )
+    val darkMode = LocalDarkMode.current
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -123,7 +128,7 @@ private fun AppCard(
         Text(
             text = app.label,
             style = MaterialTheme.typography.labelMedium,
-            color = TileText,
+            color = if (darkMode) IceWhite else TileText,
             textAlign = TextAlign.Center,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -31,8 +31,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -125,6 +131,66 @@ fun HomeScreen(
         if (next == TopTab.APPS) appsViewModel.refresh()
     }
 
+    // ── Directional movement (shared by single presses and hold-to-scroll) ──
+    // Applies one step in the given direction for whichever grid/carousel is active and
+    // returns whether it was handled.
+    fun moveDirection(key: Key): Boolean = when (state.topTab) {
+        TopTab.GAMES -> if (!state.gameViewActive) {
+            when (key) {
+                Key.DirectionLeft  -> { systemFocusIndex = (systemFocusIndex - 1).coerceAtLeast(0); true }
+                Key.DirectionRight -> { systemFocusIndex = (systemFocusIndex + 1).coerceAtMost(state.platforms.size - 1); true }
+                else -> false
+            }
+        } else {
+            when (key) {
+                Key.DirectionLeft  -> { gridFocusIndex = (gridFocusIndex - 1).coerceAtLeast(0); true }
+                Key.DirectionRight -> { gridFocusIndex = (gridFocusIndex + 1).coerceAtMost(state.games.size - 1); true }
+                Key.DirectionUp    -> { (gridFocusIndex - gameGridColumns).let { if (it >= 0) gridFocusIndex = it }; true }
+                Key.DirectionDown  -> { (gridFocusIndex + gameGridColumns).let { if (it < state.games.size) gridFocusIndex = it }; true }
+                else -> false
+            }
+        }
+        TopTab.RECENTLY_PLAYED -> {
+            val n = state.recentlyPlayed.size
+            when (key) {
+                Key.DirectionLeft  -> { recentFocusIndex = (recentFocusIndex - 1).coerceAtLeast(0); true }
+                Key.DirectionRight -> { recentFocusIndex = (recentFocusIndex + 1).coerceAtMost(n - 1); true }
+                Key.DirectionUp    -> { (recentFocusIndex - gameGridColumns).let { if (it >= 0) recentFocusIndex = it }; true }
+                Key.DirectionDown  -> { (recentFocusIndex + gameGridColumns).let { if (it < n) recentFocusIndex = it }; true }
+                else -> false
+            }
+        }
+        TopTab.APPS -> {
+            val n = appsState.apps.size
+            when (key) {
+                Key.DirectionLeft  -> { appFocusIndex = (appFocusIndex - 1).coerceAtLeast(0); true }
+                Key.DirectionRight -> { appFocusIndex = (appFocusIndex + 1).coerceAtMost(n - 1); true }
+                Key.DirectionUp    -> { (appFocusIndex - appColumns).let { if (it >= 0) appFocusIndex = it }; true }
+                Key.DirectionDown  -> { (appFocusIndex + appColumns).let { if (it < n) appFocusIndex = it }; true }
+                else -> false
+            }
+        }
+        TopTab.RETROACHIEVEMENTS -> false
+    }
+
+    // Hold a direction to keep moving: first press fires immediately, then after a short delay
+    // the move repeats until the key is released.
+    val scope = rememberCoroutineScope()
+    var heldDirection by remember { mutableStateOf<Key?>(null) }
+    var repeatJob by remember { mutableStateOf<Job?>(null) }
+    fun stopRepeat() { repeatJob?.cancel(); repeatJob = null; heldDirection = null }
+    fun startHold(key: Key) {
+        heldDirection = key
+        repeatJob?.cancel()
+        repeatJob = scope.launch {
+            delay(320)                       // hold threshold before auto-repeat begins
+            while (isActive) {
+                if (!moveDirection(key)) break  // stop at the end of a list
+                delay(75)                    // ~13 steps/sec while held
+            }
+        }
+    }
+
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { try { focusRequester.requestFocus() } catch (_: Exception) {} }
 
@@ -135,13 +201,31 @@ fun HomeScreen(
                 .focusRequester(focusRequester)
                 .focusable()
                 .onKeyEvent { event ->
+                    val key = event.key
+                    val isDirection = key == Key.DirectionLeft || key == Key.DirectionRight ||
+                                      key == Key.DirectionUp || key == Key.DirectionDown
+
+                    // Release of a held direction stops auto-repeat.
+                    if (event.type == KeyEventType.KeyUp) {
+                        if (isDirection && key == heldDirection) { stopRepeat(); return@onKeyEvent true }
+                        return@onKeyEvent false
+                    }
                     if (event.type != KeyEventType.KeyDown) return@onKeyEvent false
+
+                    // Directional input: ignore the OS's own auto-repeat while we already drive a
+                    // hold; on first press move once and start our own steady repeat.
+                    if (isDirection) {
+                        if (key == heldDirection) return@onKeyEvent true
+                        val handled = moveDirection(key)
+                        if (handled) startHold(key)
+                        return@onKeyEvent handled
+                    }
 
                     // ── Global shortcuts ──────────────────────────────────
                     // Bumpers (LB/RB): at the top level they move between the top tabs;
                     // inside a system they cycle systems (handled in the game-view block below).
                     val inGameView = state.topTab == TopTab.GAMES && state.gameViewActive
-                    when (event.key) {
+                    when (key) {
                         GamepadL1 -> if (!inGameView) { cycleTab(-1); return@onKeyEvent true }
                         GamepadR1 -> if (!inGameView) { cycleTab(+1); return@onKeyEvent true }
                         GamepadStart -> { onSettingsClick(); return@onKeyEvent true }
@@ -150,10 +234,7 @@ fun HomeScreen(
                     when (state.topTab) {
                         // ══ GAMES ════════════════════════════════════════
                         TopTab.GAMES -> if (!state.gameViewActive) {
-                            // System carousel — left/right only
-                            when (event.key) {
-                                Key.DirectionLeft  -> { systemFocusIndex = (systemFocusIndex - 1).coerceAtLeast(0); true }
-                                Key.DirectionRight -> { systemFocusIndex = (systemFocusIndex + 1).coerceAtMost(state.platforms.size - 1); true }
+                            when (key) {
                                 GamepadA, Key.DirectionCenter, Key.Enter -> {
                                     state.platforms.getOrNull(systemFocusIndex)?.let {
                                         gridFocusIndex = 0
@@ -163,12 +244,7 @@ fun HomeScreen(
                                 else -> false
                             }
                         } else {
-                            // Game grid — 2D navigation
-                            when (event.key) {
-                                Key.DirectionLeft  -> { gridFocusIndex = (gridFocusIndex - 1).coerceAtLeast(0); true }
-                                Key.DirectionRight -> { gridFocusIndex = (gridFocusIndex + 1).coerceAtMost(state.games.size - 1); true }
-                                Key.DirectionUp    -> { (gridFocusIndex - gameGridColumns).let { if (it >= 0) gridFocusIndex = it }; true }
-                                Key.DirectionDown  -> { (gridFocusIndex + gameGridColumns).let { if (it < state.games.size) gridFocusIndex = it }; true }
+                            when (key) {
                                 GamepadA, Key.DirectionCenter, Key.Enter -> {
                                     state.games.getOrNull(gridFocusIndex)?.let { onGameClick(it.id) }; true
                                 }
@@ -180,26 +256,15 @@ fun HomeScreen(
                         }
 
                         // ══ RECENTLY PLAYED ══════════════════════════════
-                        TopTab.RECENTLY_PLAYED -> {
-                            val recents = state.recentlyPlayed
-                            when (event.key) {
-                                Key.DirectionLeft  -> { recentFocusIndex = (recentFocusIndex - 1).coerceAtLeast(0); true }
-                                Key.DirectionRight -> { recentFocusIndex = (recentFocusIndex + 1).coerceAtMost(recents.size - 1); true }
-                                Key.DirectionUp    -> { (recentFocusIndex - gameGridColumns).let { if (it >= 0) recentFocusIndex = it }; true }
-                                Key.DirectionDown  -> { (recentFocusIndex + gameGridColumns).let { if (it < recents.size) recentFocusIndex = it }; true }
-                                GamepadA, Key.DirectionCenter, Key.Enter -> {
-                                    recents.getOrNull(recentFocusIndex)?.let { onGameClick(it.id) }; true
-                                }
-                                else -> false
+                        TopTab.RECENTLY_PLAYED -> when (key) {
+                            GamepadA, Key.DirectionCenter, Key.Enter -> {
+                                state.recentlyPlayed.getOrNull(recentFocusIndex)?.let { onGameClick(it.id) }; true
                             }
+                            else -> false
                         }
 
                         // ══ APPS ═════════════════════════════════════════
-                        TopTab.APPS -> when (event.key) {
-                            Key.DirectionLeft  -> { appFocusIndex = (appFocusIndex - 1).coerceAtLeast(0); true }
-                            Key.DirectionRight -> { appFocusIndex = (appFocusIndex + 1).coerceAtMost(appsState.apps.size - 1); true }
-                            Key.DirectionUp    -> { (appFocusIndex - appColumns).let { if (it >= 0) appFocusIndex = it }; true }
-                            Key.DirectionDown  -> { (appFocusIndex + appColumns).let { if (it < appsState.apps.size) appFocusIndex = it }; true }
+                        TopTab.APPS -> when (key) {
                             GamepadA, Key.DirectionCenter, Key.Enter -> {
                                 appsState.apps.getOrNull(appFocusIndex)?.let { appsViewModel.launchApp(it.packageName) }; true
                             }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -93,11 +94,12 @@ fun HomeScreen(
     val textSecondary = if (darkMode) SteelGray else TileSub
     val bgColor       = if (darkMode) NavyBg else LightBg
 
-    // Controller focus indices for each grid
-    var systemFocusIndex by remember { mutableIntStateOf(0) }
-    var appFocusIndex    by remember { mutableIntStateOf(0) }
-    var gridFocusIndex   by remember { mutableIntStateOf(0) }
-    var recentFocusIndex by remember { mutableIntStateOf(0) }
+    // Controller focus indices for each grid. rememberSaveable so the selected console/game is
+    // restored when returning from the detail screen (the composition is disposed on navigation).
+    var systemFocusIndex by rememberSaveable { mutableIntStateOf(0) }
+    var appFocusIndex    by rememberSaveable { mutableIntStateOf(0) }
+    var gridFocusIndex   by rememberSaveable { mutableIntStateOf(0) }
+    var recentFocusIndex by rememberSaveable { mutableIntStateOf(0) }
 
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     // Match LazyVerticalGrid's column maths exactly so D-pad navigation lands on the right cell.

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -75,6 +75,7 @@ import com.gamelaunch.frontend.ui.theme.TileSub
 import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassChip
 import com.gamelaunch.frontend.ui.theme.grid.GridHomeContent
+import com.gamelaunch.frontend.ui.screen.retroachievements.RetroAchievementsScreen
 
 @Composable
 fun HomeScreen(
@@ -397,11 +398,9 @@ fun HomeScreen(
                                 modifier             = Modifier.fillMaxSize()
                             )
 
-                        else -> EmptyState(
-                            icon     = Icons.Default.EmojiEvents,
-                            title    = "RetroAchievements",
-                            subtitle = "Coming soon",
-                            modifier = Modifier.fillMaxSize()
+                        else -> RetroAchievementsScreen(
+                            onGoToSettings = onSettingsClick,
+                            modifier       = Modifier.fillMaxSize()
                         )
                     }
                 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -260,7 +261,7 @@ fun HomeScreen(
                                 }
                                 GamepadL1 -> { cyclePlatform(-1); true }
                                 GamepadR1 -> { cyclePlatform(+1); true }
-                                GamepadB -> { viewModel.exitToSystems(); true }
+                                GamepadB, Key.Back -> { viewModel.exitToSystems(); true }
                                 else -> false
                             }
                         }
@@ -307,19 +308,34 @@ fun HomeScreen(
                         Text("e",  fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = BrandBlue, letterSpacing = 2.sp)
                         Text("Or", fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = textPrimary, letterSpacing = 2.sp)
 
-                        // Inside a system, show which one (the tabs/pills are hidden here)
+                        // Inside a system, breadcrumb: eOr · <Console> → <hovered game>
                         if (state.topTab == TopTab.GAMES && state.gameViewActive) {
                             state.selectedPlatform?.let { pid ->
                                 Text(
                                     "  ·  " + platformDisplayName(pid),
                                     fontSize = 16.sp,
                                     fontWeight = FontWeight.SemiBold,
-                                    color = textPrimary.copy(alpha = 0.85f)
+                                    color = textPrimary.copy(alpha = 0.85f),
+                                    maxLines = 1
                                 )
                             }
+                            val hoveredGame = state.games.getOrNull(gridFocusIndex)
+                            if (hoveredGame != null) {
+                                Text(
+                                    "  →  " + hoveredGame.title,
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    color = BrandBlue,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f).padding(start = 2.dp)
+                                )
+                            } else {
+                                Spacer(Modifier.weight(1f))
+                            }
+                        } else {
+                            Spacer(Modifier.weight(1f))
                         }
-
-                        Spacer(Modifier.weight(1f))
 
                         IconButton(
                             onClick  = onSettingsClick,

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -66,7 +66,11 @@ import com.gamelaunch.frontend.ui.input.GamepadStart
 import com.gamelaunch.frontend.ui.theme.AmbientBackground
 import com.gamelaunch.frontend.ui.theme.BrandBlue
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.IceWhite
 import com.gamelaunch.frontend.ui.theme.LightBg
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
+import com.gamelaunch.frontend.ui.theme.NavyBg
+import com.gamelaunch.frontend.ui.theme.SteelGray
 import com.gamelaunch.frontend.ui.theme.TileSub
 import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassChip
@@ -81,6 +85,11 @@ fun HomeScreen(
 ) {
     val state     by viewModel.uiState.collectAsState()
     val appsState by appsViewModel.uiState.collectAsState()
+
+    val darkMode      = LocalDarkMode.current
+    val textPrimary   = if (darkMode) IceWhite else TileText
+    val textSecondary = if (darkMode) SteelGray else TileSub
+    val bgColor       = if (darkMode) NavyBg else LightBg
 
     // Controller focus indices for each grid
     var systemFocusIndex by remember { mutableIntStateOf(0) }
@@ -194,7 +203,7 @@ fun HomeScreen(
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { try { focusRequester.requestFocus() } catch (_: Exception) {} }
 
-    Scaffold(containerColor = LightBg) { _ ->
+    Scaffold(containerColor = bgColor) { _ ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -295,7 +304,7 @@ fun HomeScreen(
                             modifier = Modifier.size(26.dp).padding(end = 6.dp)
                         )
                         Text("e",  fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = BrandBlue, letterSpacing = 2.sp)
-                        Text("Or", fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = TileText, letterSpacing = 2.sp)
+                        Text("Or", fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = textPrimary, letterSpacing = 2.sp)
 
                         // Inside a system, show which one (the tabs/pills are hidden here)
                         if (state.topTab == TopTab.GAMES && state.gameViewActive) {
@@ -304,7 +313,7 @@ fun HomeScreen(
                                     "  ·  " + platformDisplayName(pid),
                                     fontSize = 16.sp,
                                     fontWeight = FontWeight.SemiBold,
-                                    color = TileText.copy(alpha = 0.85f)
+                                    color = textPrimary.copy(alpha = 0.85f)
                                 )
                             }
                         }
@@ -315,7 +324,7 @@ fun HomeScreen(
                             onClick  = onSettingsClick,
                             modifier = Modifier.size(40.dp).glassChip(CircleShape)
                         ) {
-                            Icon(Icons.Default.Settings, contentDescription = "Settings", tint = TileText, modifier = Modifier.size(20.dp))
+                            Icon(Icons.Default.Settings, contentDescription = "Settings", tint = textPrimary, modifier = Modifier.size(20.dp))
                         }
                     }
 
@@ -419,6 +428,8 @@ private fun ModeTabBar(
 ) {
     val pill = RoundedCornerShape(50)
     val tabs = tabSpecs.filter { it.tab != TopTab.RECENTLY_PLAYED || showRecentlyPlayed }
+    val darkMode = LocalDarkMode.current
+    val unselectedTint = if (darkMode) IceWhite.copy(alpha = 0.8f) else TileText.copy(alpha = 0.8f)
 
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
@@ -438,14 +449,14 @@ private fun ModeTabBar(
                 Icon(
                     spec.icon,
                     contentDescription = null,
-                    tint = if (isSel) Color.White else TileText.copy(alpha = 0.8f),
+                    tint = if (isSel) Color.White else unselectedTint,
                     modifier = Modifier.size(18.dp)
                 )
                 Text(
                     text = spec.label,
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = if (isSel) FontWeight.Bold else FontWeight.Normal,
-                    color = if (isSel) Color.White else TileText.copy(alpha = 0.8f)
+                    color = if (isSel) Color.White else unselectedTint
                 )
             }
         }
@@ -459,6 +470,7 @@ private fun EmptyState(
     subtitle: String,
     modifier: Modifier = Modifier
 ) {
+    val darkMode = LocalDarkMode.current
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -466,9 +478,9 @@ private fun EmptyState(
     ) {
         Icon(icon, contentDescription = null, tint = BrandBlue, modifier = Modifier.size(64.dp))
         Spacer(Modifier.size(12.dp))
-        Text(title, style = MaterialTheme.typography.titleMedium, color = TileText)
+        Text(title, style = MaterialTheme.typography.titleMedium, color = if (darkMode) IceWhite else TileText)
         Spacer(Modifier.size(4.dp))
-        Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = TileSub)
+        Text(subtitle, style = MaterialTheme.typography.bodyMedium, color = if (darkMode) SteelGray else TileSub)
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+import com.gamelaunch.frontend.domain.platform.sortedBySystems
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
@@ -57,7 +59,6 @@ class HomeViewModel @Inject constructor(
 
     init {
         observePlatforms()
-        observePlatformCounts()
         observeSettings()
         observeAllMedia()
         observeRecentlyPlayed()
@@ -71,26 +72,37 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    private var lastPlatformIdSet: Set<String> = emptySet()
+
     private fun observePlatforms() {
         viewModelScope.launch {
-            gameRepository.getDistinctPlatformIds().collect { platformIds ->
-                _uiState.update { state ->
-                    state.copy(
-                        platforms = platformIds,
-                        selectedPlatform = state.selectedPlatform ?: platformIds.firstOrNull(),
-                        isLoading = false
+            combine(
+                gameRepository.getDistinctPlatformIds(),
+                gameRepository.getPlatformCounts(),
+                settingsRepository.systemSort
+            ) { ids, counts, sorts -> Triple(ids, counts, sorts) }
+                .collect { (ids, counts, sorts) ->
+                    val sorted = ids.sortedBySystems(
+                        sorts = sorts,
+                        displayName = { PlatformDefinitions.byId[it]?.displayName ?: it },
+                        gameCount = { counts[it] ?: 0 }
                     )
+                    _uiState.update { state ->
+                        state.copy(
+                            platforms = sorted,
+                            platformCounts = counts,
+                            selectedPlatform = state.selectedPlatform ?: sorted.firstOrNull(),
+                            isLoading = false
+                        )
+                    }
+                    // Only (re)load the games list when the set of platforms actually changes,
+                    // not on every count tick during a scrape.
+                    val idSet = ids.toSet()
+                    if (idSet != lastPlatformIdSet) {
+                        lastPlatformIdSet = idSet
+                        loadGamesForPlatform(_uiState.value.selectedPlatform)
+                    }
                 }
-                loadGamesForPlatform(_uiState.value.selectedPlatform)
-            }
-        }
-    }
-
-    private fun observePlatformCounts() {
-        viewModelScope.launch {
-            gameRepository.getPlatformCounts().collect { counts ->
-                _uiState.update { it.copy(platformCounts = counts) }
-            }
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -99,12 +99,22 @@ class HomeViewModel @Inject constructor(
     }
 
     private var previewJob: Job? = null
+    // Art is randomised once per platform per ViewModel lifetime so re-focusing the same
+    // console returns the same list object — LaunchedEffect(previewArt) won't re-trigger
+    // the fan animation and images are already warm in Coil's disk cache.
+    private val previewArtCache = mutableMapOf<String, List<String>>()
 
     /** Load a handful of box-art covers to preview the system the carousel is focused on. */
     fun focusSystem(platformId: String) {
+        val cached = previewArtCache[platformId]
+        if (cached != null) {
+            _uiState.update { it.copy(systemPreviewArt = cached) }
+            return
+        }
         previewJob?.cancel()
         previewJob = viewModelScope.launch {
             val art = mediaRepository.boxArtSampleForPlatform(platformId, 8)
+            previewArtCache[platformId] = art
             _uiState.update { it.copy(systemPreviewArt = art) }
         }
     }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -49,6 +49,9 @@ import com.gamelaunch.frontend.ui.component.platformIcon
 import com.gamelaunch.frontend.ui.component.platformPadIcon
 import com.gamelaunch.frontend.ui.theme.BounceDurationMs
 import com.gamelaunch.frontend.ui.theme.BounceEasing
+import com.gamelaunch.frontend.ui.theme.IceWhite
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
+import com.gamelaunch.frontend.ui.theme.SteelGray
 import com.gamelaunch.frontend.ui.theme.TileSub
 import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassTile
@@ -65,8 +68,9 @@ fun SystemSelectionContent(
     modifier: Modifier = Modifier
 ) {
     if (platforms.isEmpty()) {
+        val darkMode = LocalDarkMode.current
         Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text("No systems configured", color = TileSub)
+            Text("No systems configured", color = if (darkMode) SteelGray else TileSub)
         }
         return
     }
@@ -212,6 +216,9 @@ private fun SystemCard(
         animationSpec = tween(durationMillis = BounceDurationMs, easing = BounceEasing),
         label = "systemTileScale"
     )
+    val darkMode = LocalDarkMode.current
+    val textPrimary = if (darkMode) IceWhite else TileText
+    val textSecondary = if (darkMode) SteelGray else TileSub
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -233,7 +240,7 @@ private fun SystemCard(
             Icon(
                 painter = painterResource(platformPadIcon(platformId)),
                 contentDescription = null,
-                tint = TileText,
+                tint = textPrimary,
                 modifier = Modifier.size(iconSize.dp)
             )
         }
@@ -242,7 +249,7 @@ private fun SystemCard(
             text = platformDisplayName(platformId),
             style = MaterialTheme.typography.titleSmall,
             fontWeight = FontWeight.SemiBold,
-            color = TileText,
+            color = textPrimary,
             textAlign = TextAlign.Center,
             maxLines = 2
         )
@@ -250,7 +257,7 @@ private fun SystemCard(
         Text(
             text = "$count game${if (count == 1) "" else "s"}",
             style = MaterialTheme.typography.labelSmall,
-            color = TileSub
+            color = textSecondary
         )
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -112,8 +112,9 @@ private fun SystemCarousel(
         // Preview covers: fill most of the band above the carousel, leaving room for the cards.
         val previewBandH = maxH - cardSize - 44.dp
         val coverHeight = (previewBandH * 0.86f).coerceIn(120.dp, 230.dp)
-        // Fan spreads wider when there's horizontal room; tighter on narrow/tall screens.
-        val spreadDp = (maxW.value * 0.22f).coerceIn(58f, 132f)
+        // Fan spread scales a little with horizontal room but stays tight — the covers
+        // should overlap into a compact fan, not spread across the screen.
+        val spreadDp = (maxW.value * 0.10f).coerceIn(42f, 80f)
 
         Column(Modifier.fillMaxSize()) {
 
@@ -146,7 +147,7 @@ private fun SystemCarousel(
                             .graphicsLayer {
                                 transformOrigin = TransformOrigin(0.5f, 1.3f)
                                 // fan opens out (rotation + horizontal spread) as the card rises
-                                rotationZ = (rel * 9f + jitter[i % jitter.size]) * cp
+                                rotationZ = (rel * 7f + jitter[i % jitter.size]) * cp
                                 translationX = rel * spreadDp.dp.toPx() * cp
                                 // rise up from below to a slightly-lifted resting arc
                                 val restY = (absRel * 10f - 20f).dp.toPx()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsScreen.kt
@@ -74,7 +74,8 @@ fun RetroAchievementsScreen(
             is RaScreenState.NotConfigured -> NotConfiguredContent(textPrimary, textSecondary, onGoToSettings)
             is RaScreenState.Loading       -> LoadingContent()
             is RaScreenState.Error         -> ErrorContent(s.message, textPrimary, textSecondary, viewModel::refresh)
-            is RaScreenState.Loaded        -> LoadedContent(s.profile, s.recentGames, textPrimary, textSecondary, darkMode, viewModel::refresh)
+            is RaScreenState.LoadedBasic   -> LoadedContent(s.profile, emptyList(), textPrimary, textSecondary, darkMode, viewModel::refresh, basicMode = true, onGoToSettings = onGoToSettings)
+            is RaScreenState.Loaded        -> LoadedContent(s.profile, s.recentGames, textPrimary, textSecondary, darkMode, viewModel::refresh, basicMode = false, onGoToSettings = onGoToSettings)
         }
     }
 }
@@ -91,7 +92,7 @@ private fun NotConfiguredContent(textPrimary: Color, textSecondary: Color, onGoT
         Text("RetroAchievements", style = MaterialTheme.typography.headlineSmall, color = textPrimary, fontWeight = FontWeight.Bold)
         Spacer(Modifier.height(8.dp))
         Text(
-            "Enter your RetroAchievements username and API key in Settings to track your progress.",
+            "Sign in with your RetroAchievements username and password in Settings to see your points and profile.",
             style = MaterialTheme.typography.bodyMedium,
             color = textSecondary,
             textAlign = TextAlign.Center
@@ -141,7 +142,9 @@ private fun LoadedContent(
     textPrimary: Color,
     textSecondary: Color,
     darkMode: Boolean,
-    onRefresh: () -> Unit
+    onRefresh: () -> Unit,
+    basicMode: Boolean,
+    onGoToSettings: () -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -150,7 +153,11 @@ private fun LoadedContent(
     ) {
         item { ProfileHeader(profile, textPrimary, textSecondary, onRefresh) }
         item { Spacer(Modifier.height(4.dp)) }
-        if (games.isEmpty()) {
+
+        if (basicMode) {
+            // Signed in with password only — prompt to add a Web API key for the full dashboard.
+            item { AddKeyHint(textPrimary, textSecondary, onGoToSettings) }
+        } else if (games.isEmpty()) {
             item {
                 Text("No recently played games found.", color = textSecondary, modifier = Modifier.padding(8.dp))
             }
@@ -163,6 +170,29 @@ private fun LoadedContent(
             }
         }
         item { Spacer(Modifier.height(24.dp)) }
+    }
+}
+
+@Composable
+private fun AddKeyHint(textPrimary: Color, textSecondary: Color, onGoToSettings: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .glassTile(RoundedCornerShape(16.dp), color = BrandBlue)
+            .clickable { onGoToSettings() }
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.EmojiEvents, contentDescription = null, tint = Gold, modifier = Modifier.size(20.dp))
+            Spacer(Modifier.width(8.dp))
+            Text("See your game progress", style = MaterialTheme.typography.titleSmall, color = textPrimary, fontWeight = FontWeight.SemiBold)
+        }
+        Spacer(Modifier.height(6.dp))
+        Text(
+            "Add a free Web API key in Settings to unlock your rank and recently-played games with achievement completion bars.",
+            style = MaterialTheme.typography.bodySmall,
+            color = textSecondary
+        )
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsScreen.kt
@@ -1,0 +1,281 @@
+package com.gamelaunch.frontend.ui.screen.retroachievements
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.gamelaunch.frontend.domain.model.RaProfile
+import com.gamelaunch.frontend.domain.model.RaRecentGame
+import com.gamelaunch.frontend.ui.theme.BrandBlue
+import com.gamelaunch.frontend.ui.theme.IceWhite
+import com.gamelaunch.frontend.ui.theme.tileColor
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
+import com.gamelaunch.frontend.ui.theme.NavySurface
+import com.gamelaunch.frontend.ui.theme.SteelGray
+import com.gamelaunch.frontend.ui.theme.TileSub
+import com.gamelaunch.frontend.ui.theme.TileText
+import com.gamelaunch.frontend.ui.theme.glassTile
+
+private val Gold  = Color(0xFFFFD700)
+private val Green = Color(0xFF4CAF50)
+
+@Composable
+fun RetroAchievementsScreen(
+    onGoToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: RetroAchievementsViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+    val darkMode = LocalDarkMode.current
+    val textPrimary   = if (darkMode) IceWhite  else TileText
+    val textSecondary = if (darkMode) SteelGray else TileSub
+
+    Box(modifier.fillMaxSize()) {
+        when (val s = state) {
+            is RaScreenState.NotConfigured -> NotConfiguredContent(textPrimary, textSecondary, onGoToSettings)
+            is RaScreenState.Loading       -> LoadingContent()
+            is RaScreenState.Error         -> ErrorContent(s.message, textPrimary, textSecondary, viewModel::refresh)
+            is RaScreenState.Loaded        -> LoadedContent(s.profile, s.recentGames, textPrimary, textSecondary, darkMode, viewModel::refresh)
+        }
+    }
+}
+
+@Composable
+private fun NotConfiguredContent(textPrimary: Color, textSecondary: Color, onGoToSettings: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(Icons.Default.EmojiEvents, contentDescription = null, tint = Gold, modifier = Modifier.size(56.dp))
+        Spacer(Modifier.height(16.dp))
+        Text("RetroAchievements", style = MaterialTheme.typography.headlineSmall, color = textPrimary, fontWeight = FontWeight.Bold)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "Enter your RetroAchievements username and API key in Settings to track your progress.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = textSecondary,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(24.dp))
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(50))
+                .background(BrandBlue)
+                .clickable { onGoToSettings() }
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Go to Settings", color = Color.White, fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(color = BrandBlue)
+    }
+}
+
+@Composable
+private fun ErrorContent(message: String, textPrimary: Color, textSecondary: Color, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text("Failed to load", style = MaterialTheme.typography.titleMedium, color = textPrimary)
+        Spacer(Modifier.height(8.dp))
+        Text(message, style = MaterialTheme.typography.bodySmall, color = textSecondary)
+        Spacer(Modifier.height(16.dp))
+        IconButton(onClick = onRetry) {
+            Icon(Icons.Default.Refresh, contentDescription = "Retry", tint = BrandBlue, modifier = Modifier.size(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun LoadedContent(
+    profile: RaProfile,
+    games: List<RaRecentGame>,
+    textPrimary: Color,
+    textSecondary: Color,
+    darkMode: Boolean,
+    onRefresh: () -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        item { ProfileHeader(profile, textPrimary, textSecondary, onRefresh) }
+        item { Spacer(Modifier.height(4.dp)) }
+        if (games.isEmpty()) {
+            item {
+                Text("No recently played games found.", color = textSecondary, modifier = Modifier.padding(8.dp))
+            }
+        } else {
+            item {
+                Text("Recently Played", style = MaterialTheme.typography.labelLarge, color = BrandBlue, modifier = Modifier.padding(start = 4.dp))
+            }
+            items(games.size, key = { games[it].gameId }) { i ->
+                GameRow(games[i], textPrimary, textSecondary, darkMode, i)
+            }
+        }
+        item { Spacer(Modifier.height(24.dp)) }
+    }
+}
+
+@Composable
+private fun ProfileHeader(profile: RaProfile, textPrimary: Color, textSecondary: Color, onRefresh: () -> Unit) {
+    val shape = RoundedCornerShape(20.dp)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .glassTile(shape, color = BrandBlue)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model             = profile.avatarUrl,
+            contentDescription = profile.username,
+            contentScale      = ContentScale.Crop,
+            modifier          = Modifier
+                .size(72.dp)
+                .clip(CircleShape)
+                .background(NavySurface)
+        )
+        Spacer(Modifier.width(16.dp))
+        Column(Modifier.weight(1f)) {
+            Text(profile.username, style = MaterialTheme.typography.titleLarge, color = textPrimary, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                StatChip(label = "Points", value = "%,d".format(profile.totalPoints), color = Gold)
+                if (profile.rank != null && profile.rank > 0) {
+                    StatChip(label = "Rank", value = "#${"%,d".format(profile.rank)}", color = BrandBlue)
+                }
+                if (profile.truePoints > 0) {
+                    StatChip(label = "True", value = "%,d".format(profile.truePoints), color = Green)
+                }
+            }
+            profile.status?.let { status ->
+                Spacer(Modifier.height(4.dp))
+                Text(status, style = MaterialTheme.typography.labelSmall, color = textSecondary)
+            }
+        }
+        IconButton(onClick = onRefresh) {
+            Icon(Icons.Default.Refresh, contentDescription = "Refresh", tint = textSecondary, modifier = Modifier.size(20.dp))
+        }
+    }
+}
+
+@Composable
+private fun StatChip(label: String, value: String, color: Color) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(value, style = MaterialTheme.typography.labelLarge, color = color, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+        Text(label, style = MaterialTheme.typography.labelSmall, color = color.copy(alpha = 0.7f))
+    }
+}
+
+@Composable
+private fun GameRow(game: RaRecentGame, textPrimary: Color, textSecondary: Color, darkMode: Boolean, index: Int = 0) {
+    val shape = RoundedCornerShape(14.dp)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .glassTile(shape, color = tileColor(index))
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model             = game.iconUrl,
+            contentDescription = game.title,
+            contentScale      = ContentScale.Crop,
+            modifier          = Modifier
+                .size(52.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(NavySurface)
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    game.title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = textPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (game.isMastered) {
+                    Spacer(Modifier.width(6.dp))
+                    Icon(Icons.Default.Star, contentDescription = "Mastered", tint = Gold, modifier = Modifier.size(14.dp))
+                }
+            }
+            Text(game.consoleName, style = MaterialTheme.typography.labelSmall, color = textSecondary)
+            Spacer(Modifier.height(6.dp))
+            LinearProgressIndicator(
+                progress          = { game.completionPercent },
+                modifier          = Modifier.fillMaxWidth().height(5.dp).clip(RoundedCornerShape(50)),
+                color             = if (game.isMastered) Gold else BrandBlue,
+                trackColor        = if (darkMode) Color.White.copy(alpha = 0.12f) else Color.Black.copy(alpha = 0.08f),
+                strokeCap         = StrokeCap.Round
+            )
+            Spacer(Modifier.height(3.dp))
+            Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    "${game.numEarned} / ${game.numAchievements} achievements",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = textSecondary
+                )
+                if (game.maxScore > 0) {
+                    Text(
+                        "${game.scoreEarned} / ${game.maxScore} pts",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = textSecondary
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsViewModel.kt
@@ -1,0 +1,78 @@
+package com.gamelaunch.frontend.ui.screen.retroachievements
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gamelaunch.frontend.domain.model.RaProfile
+import com.gamelaunch.frontend.domain.model.RaRecentGame
+import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed interface RaScreenState {
+    data object NotConfigured : RaScreenState
+    data object Loading : RaScreenState
+    data class Loaded(val profile: RaProfile, val recentGames: List<RaRecentGame>) : RaScreenState
+    data class Error(val message: String) : RaScreenState
+}
+
+@HiltViewModel
+class RetroAchievementsViewModel @Inject constructor(
+    private val raRepository: RetroAchievementsRepository,
+    private val settingsRepository: SettingsRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<RaScreenState>(RaScreenState.NotConfigured)
+    val state: StateFlow<RaScreenState> = _state
+
+    private var loadedUsername: String? = null
+
+    init {
+        viewModelScope.launch {
+            combine(settingsRepository.raUsername, settingsRepository.raApiKey) { u, k -> u to k }
+                .collect { (username, apiKey) ->
+                    if (username.isBlank() || apiKey.isBlank()) {
+                        _state.value = RaScreenState.NotConfigured
+                        loadedUsername = null
+                    } else if (username != loadedUsername) {
+                        load(username, apiKey)
+                    }
+                }
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            val username = settingsRepository.raUsername.first()
+            val apiKey   = settingsRepository.raApiKey.first()
+            if (username.isNotBlank() && apiKey.isNotBlank()) {
+                loadedUsername = null
+                load(username, apiKey)
+            }
+        }
+    }
+
+    private suspend fun load(username: String, apiKey: String) {
+        _state.value = RaScreenState.Loading
+        loadedUsername = username
+
+        val profileResult = raRepository.getUserProfile(username, apiKey)
+        val gamesResult   = raRepository.getRecentlyPlayed(username, apiKey, 20)
+
+        val profile = profileResult.getOrNull()
+        val games   = gamesResult.getOrNull()
+
+        if (profile != null && games != null) {
+            _state.value = RaScreenState.Loaded(profile, games)
+        } else {
+            val err = profileResult.exceptionOrNull() ?: gamesResult.exceptionOrNull()
+            _state.value = RaScreenState.Error(err?.message ?: "Failed to load RetroAchievements data")
+            loadedUsername = null
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/retroachievements/RetroAchievementsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.domain.model.RaProfile
 import com.gamelaunch.frontend.domain.model.RaRecentGame
+import com.gamelaunch.frontend.domain.model.RaSession
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,6 +18,9 @@ import javax.inject.Inject
 sealed interface RaScreenState {
     data object NotConfigured : RaScreenState
     data object Loading : RaScreenState
+    /** Username + password sign-in only: points + avatar, no rank or recently-played list. */
+    data class LoadedBasic(val profile: RaProfile) : RaScreenState
+    /** Web API key present: full profile + recently-played games with completion. */
     data class Loaded(val profile: RaProfile, val recentGames: List<RaRecentGame>) : RaScreenState
     data class Error(val message: String) : RaScreenState
 }
@@ -30,36 +34,75 @@ class RetroAchievementsViewModel @Inject constructor(
     private val _state = MutableStateFlow<RaScreenState>(RaScreenState.NotConfigured)
     val state: StateFlow<RaScreenState> = _state
 
-    private var loadedUsername: String? = null
+    // Tracks the username|apiKey combo currently loaded into the full dashboard so a
+    // points-only change (from a token refresh) doesn't trigger a redundant Web API reload.
+    private var loadedDashboardKey: String? = null
+
+    private data class RaCreds(
+        val username: String,
+        val token: String,
+        val apiKey: String,
+        val points: Int,
+        val softcorePoints: Int
+    )
 
     init {
         viewModelScope.launch {
-            combine(settingsRepository.raUsername, settingsRepository.raApiKey) { u, k -> u to k }
-                .collect { (username, apiKey) ->
-                    if (username.isBlank() || apiKey.isBlank()) {
-                        _state.value = RaScreenState.NotConfigured
-                        loadedUsername = null
-                    } else if (username != loadedUsername) {
-                        load(username, apiKey)
-                    }
-                }
+            combine(
+                settingsRepository.raUsername,
+                settingsRepository.raToken,
+                settingsRepository.raApiKey,
+                settingsRepository.raPoints,
+                settingsRepository.raSoftcorePoints
+            ) { username, token, apiKey, points, softcore ->
+                RaCreds(username, token, apiKey, points, softcore)
+            }.collect { creds -> applyCreds(creds) }
+        }
+    }
+
+    private suspend fun applyCreds(creds: RaCreds) {
+        // Requires a username + token, i.e. the user has signed in with their password.
+        if (creds.username.isBlank() || creds.token.isBlank()) {
+            _state.value = RaScreenState.NotConfigured
+            loadedDashboardKey = null
+            return
+        }
+
+        if (creds.apiKey.isNotBlank()) {
+            val key = "${creds.username}|${creds.apiKey}"
+            if (key != loadedDashboardKey) loadDashboard(creds.username, creds.apiKey, key)
+        } else {
+            // No key — show the basic profile built from the cached Connect-login points.
+            loadedDashboardKey = null
+            _state.value = RaScreenState.LoadedBasic(
+                RaSession(creds.username, creds.token, creds.points, creds.softcorePoints).toProfile()
+            )
         }
     }
 
     fun refresh() {
         viewModelScope.launch {
             val username = settingsRepository.raUsername.first()
+            val token    = settingsRepository.raToken.first()
             val apiKey   = settingsRepository.raApiKey.first()
-            if (username.isNotBlank() && apiKey.isNotBlank()) {
-                loadedUsername = null
-                load(username, apiKey)
+            if (username.isBlank() || token.isBlank()) return@launch
+
+            if (apiKey.isNotBlank()) {
+                loadDashboard(username, apiKey, "$username|$apiKey")
+            } else {
+                // Re-validate the token to pull fresh point totals; persisting re-emits the flow.
+                raRepository.refreshSession(username, token).onSuccess { session ->
+                    settingsRepository.setRaSession(
+                        session.username, session.token, session.points, session.softcorePoints
+                    )
+                }
             }
         }
     }
 
-    private suspend fun load(username: String, apiKey: String) {
+    private suspend fun loadDashboard(username: String, apiKey: String, key: String) {
         _state.value = RaScreenState.Loading
-        loadedUsername = username
+        loadedDashboardKey = key
 
         val profileResult = raRepository.getUserProfile(username, apiKey)
         val gamesResult   = raRepository.getRecentlyPlayed(username, apiKey, 20)
@@ -72,7 +115,7 @@ class RetroAchievementsViewModel @Inject constructor(
         } else {
             val err = profileResult.exceptionOrNull() ?: gamesResult.exceptionOrNull()
             _state.value = RaScreenState.Error(err?.message ?: "Failed to load RetroAchievements data")
-            loadedUsername = null
+            loadedDashboardKey = null
         }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scan/ScanScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scan/ScanScreen.kt
@@ -35,9 +35,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
-import com.gamelaunch.frontend.ui.theme.NavyBg
-import com.gamelaunch.frontend.ui.theme.NavyCard
 import com.gamelaunch.frontend.ui.theme.NeonPurple
+import com.gamelaunch.frontend.ui.theme.ThemedScreen
 
 @Composable
 fun ScanScreen(
@@ -64,10 +63,11 @@ fun ScanScreen(
         if (state.isComplete) onScanComplete()
     }
 
+    ThemedScreen {
     Box(
         Modifier
             .fillMaxSize()
-            .background(NavyBg),
+            .background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.Center
     ) {
         Column(
@@ -98,7 +98,7 @@ fun ScanScreen(
                         progress    = { progress.scanned.toFloat() / progress.total },
                         modifier    = Modifier.fillMaxWidth(),
                         color       = ElectricBlue,
-                        trackColor  = NavyCard
+                        trackColor  = MaterialTheme.colorScheme.surfaceVariant
                     )
                     Spacer(Modifier.height(10.dp))
                     Text(
@@ -125,7 +125,7 @@ fun ScanScreen(
                     LinearProgressIndicator(
                         modifier   = Modifier.fillMaxWidth(),
                         color      = ElectricBlue,
-                        trackColor = NavyCard
+                        trackColor = MaterialTheme.colorScheme.surfaceVariant
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
@@ -150,6 +150,7 @@ fun ScanScreen(
                 GradientButton("Go to Library Anyway", onClick = onScanComplete)
             }
         }
+    }
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.domain.usecase.ScrapeResult
+import com.gamelaunch.frontend.ui.theme.ThemedScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +58,7 @@ fun ScrapeProgressScreen(
         }
     }
 
+    ThemedScreen {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -154,5 +156,6 @@ fun ScrapeProgressScreen(
                 }
             }
         }
+    }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
@@ -141,7 +141,7 @@ fun ScrapeProgressScreen(
                 LazyColumn {
                     items(batch.results.takeLast(50)) { result ->
                         val (icon, label) = when (result) {
-                            is ScrapeResult.Success -> Icons.Default.Check to "Scraped"
+                            is ScrapeResult.Success -> Icons.Default.Check to "Scraped: ${result.title}"
                             is ScrapeResult.NotFound -> Icons.Default.Close to "Not found: ${result.romName}"
                             is ScrapeResult.RateLimited -> Icons.Default.HourglassEmpty to "Rate limited, retrying…"
                             is ScrapeResult.Error -> Icons.Default.Close to "Error: ${result.cause.message}"

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
@@ -9,13 +9,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -31,6 +34,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -43,7 +48,8 @@ fun ScrapeProgressScreen(
     onBack: () -> Unit,
     viewModel: ScrapeViewModel = hiltViewModel()
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state        by viewModel.uiState.collectAsState()
+    val hasSsCreds   by viewModel.hasSsCredentials.collectAsState()
 
     LaunchedEffect(Unit) {
         if (!state.isRunning && state.batchState == null) {
@@ -57,7 +63,7 @@ fun ScrapeProgressScreen(
                 title = { Text("Scraping Game Data") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
             )
@@ -83,6 +89,29 @@ fun ScrapeProgressScreen(
                 .padding(paddingValues)
                 .padding(16.dp)
         ) {
+            // ScreenScraper status banner
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp)
+            ) {
+                Icon(
+                    if (hasSsCreds) Icons.Default.Star else Icons.Default.HourglassEmpty,
+                    contentDescription = null,
+                    tint = if (hasSsCreds) Color(0xFF4CAF50) else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    if (hasSsCreds)
+                        "ScreenScraper active — full art, metadata & video"
+                    else
+                        "No ScreenScraper account — using libretro + LaunchBox fallbacks (add credentials in Settings for best results)",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (hasSsCreds) Color(0xFF4CAF50) else MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = if (hasSsCreds) FontWeight.SemiBold else FontWeight.Normal
+                )
+            }
+
             val batch = state.batchState
             if (batch != null) {
                 val progress = if (batch.total > 0) batch.completed.toFloat() / batch.total else 0f

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeViewModel.kt
@@ -9,8 +9,11 @@ import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -32,8 +35,15 @@ class ScrapeViewModel @Inject constructor(
 
     private var scrapeJob: Job? = null
 
+    // Whether the user has ScreenScraper credentials set (best results).
+    // Scraping still runs without them via libretro + LaunchBox fallbacks.
+    val hasSsCredentials: kotlinx.coroutines.flow.StateFlow<Boolean> =
+        settingsRepository.scraperConfig
+            .map { it.isConfigured }
+            .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), false)
+
     init {
-        // Always considered configured — LaunchBox works without credentials
+        // Always considered configured — libretro + LaunchBox work without SS credentials.
         _uiState.update { it.copy(isConfigured = true) }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/EmulatorConfigScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/EmulatorConfigScreen.kt
@@ -45,6 +45,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.domain.model.EmulatorMapping
 import com.gamelaunch.frontend.domain.model.InstalledEmulator
 import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+import com.gamelaunch.frontend.ui.theme.ThemedScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,6 +64,7 @@ fun EmulatorConfigScreen(
         }
     }
 
+    ThemedScreen {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -116,6 +118,7 @@ fun EmulatorConfigScreen(
                 )
             }
         }
+    }
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -412,10 +412,12 @@ fun SettingsScreen(
             Spacer(Modifier.height(4.dp))
 
             // ── ScreenScraper ──────────────────────────────────────────────
-            SettingsSectionHeader("ScreenScraper")
+            SettingsSectionHeader("ScreenScraper (Recommended)")
             SettingsCard {
                 Text(
-                    "Sign up at screenscraper.fr for credentials. Optional — artwork falls back to LaunchBox.",
+                    "ScreenScraper is the default scraper — it provides the best box art, screenshots, wheel logos, and video previews. " +
+                    "Create a free account at screenscraper.fr, then enter your username and password below. " +
+                    "Without credentials the app falls back to libretro thumbnails and LaunchBox.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -62,6 +63,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -72,6 +79,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
+import com.gamelaunch.frontend.ui.input.GamepadL1
+import com.gamelaunch.frontend.ui.input.GamepadR1
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
 import com.gamelaunch.frontend.ui.theme.GameColorScheme
 import com.gamelaunch.frontend.ui.theme.GameLightColorScheme
@@ -135,7 +144,31 @@ fun SettingsScreen(
     // MaterialTheme and reads LocalDarkMode for its own colours, so we override only here.
     val settingsScheme = if (LocalDarkMode.current) GameColorScheme else GameLightColorScheme
 
+    // L1 / R1 cycle between tabs (with wraparound), mirroring the home screen.
+    fun cycleTab(delta: Int) {
+        val entries = SettingsTab.entries
+        val cur = entries.indexOf(selectedTab)
+        selectedTab = entries[(cur + delta + entries.size) % entries.size]
+    }
+
+    val tabFocusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { tabFocusRequester.requestFocus() } }
+
     MaterialTheme(colorScheme = settingsScheme) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .focusRequester(tabFocusRequester)
+            .focusable()
+            .onKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onKeyEvent false
+                when (event.key) {
+                    GamepadL1 -> { cycleTab(-1); true }
+                    GamepadR1 -> { cycleTab(+1); true }
+                    else -> false
+                }
+            }
+    ) {
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         snackbarHost = {
@@ -246,6 +279,7 @@ fun SettingsScreen(
                 }
             }
         }
+    }
     }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -558,6 +558,57 @@ fun SettingsScreen(
                 )
             }
 
+            Spacer(Modifier.height(4.dp))
+
+            // ── RetroAchievements ──────────────────────────────────────────
+            SettingsSectionHeader("RetroAchievements")
+            SettingsCard {
+                Text(
+                    "Enter your RetroAchievements username and Web API Key (found at retroachievements.org → Settings → API Key).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value         = state.raUsername,
+                    onValueChange = viewModel::updateRaUsername,
+                    label         = { Text("Username") },
+                    modifier      = Modifier.fillMaxWidth(),
+                    singleLine    = true,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor   = ElectricBlue,
+                        unfocusedBorderColor = NavyBorder
+                    )
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value                = state.raApiKey,
+                    onValueChange        = viewModel::updateRaApiKey,
+                    label                = { Text("Web API Key") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier             = Modifier.fillMaxWidth(),
+                    singleLine           = true,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor   = ElectricBlue,
+                        unfocusedBorderColor = NavyBorder
+                    )
+                )
+                Spacer(Modifier.height(10.dp))
+                GradientFillButton(
+                    text     = "Save",
+                    onClick  = { viewModel.saveRaCredentials() },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                if (state.raSaved) {
+                    Spacer(Modifier.height(8.dp))
+                    StatusRow(
+                        icon  = Icons.Default.Check,
+                        text  = "Credentials saved — open the RetroAchievements tab",
+                        color = ElectricBlue
+                    )
+                }
+            }
+
             Spacer(Modifier.height(16.dp))
 
             // ── Save & Finish ──────────────────────────────────────────────

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -566,7 +566,7 @@ fun SettingsScreen(
             SettingsSectionHeader("RetroAchievements")
             SettingsCard {
                 Text(
-                    "Enter your RetroAchievements username and Web API Key (found at retroachievements.org → Settings → API Key).",
+                    "Sign in with your RetroAchievements username and password to see your points and profile.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -584,9 +584,9 @@ fun SettingsScreen(
                 )
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
-                    value                = state.raApiKey,
-                    onValueChange        = viewModel::updateRaApiKey,
-                    label                = { Text("Web API Key") },
+                    value                = state.raPassword,
+                    onValueChange        = viewModel::updateRaPassword,
+                    label                = { Text("Password") },
                     visualTransformation = PasswordVisualTransformation(),
                     modifier             = Modifier.fillMaxWidth(),
                     singleLine           = true,
@@ -597,18 +597,52 @@ fun SettingsScreen(
                 )
                 Spacer(Modifier.height(10.dp))
                 GradientFillButton(
-                    text     = "Save",
+                    text     = if (state.raLoggedIn) "Update Sign-In" else "Sign In",
                     onClick  = { viewModel.saveRaCredentials() },
+                    enabled  = !state.raLoggingIn,
+                    loading  = state.raLoggingIn,
                     modifier = Modifier.fillMaxWidth()
                 )
-                if (state.raSaved) {
+                state.raLoginResult?.let { msg ->
+                    val ok = msg.startsWith("Signed in")
                     Spacer(Modifier.height(8.dp))
                     StatusRow(
-                        icon  = Icons.Default.Check,
-                        text  = "Credentials saved — open the RetroAchievements tab",
-                        color = ElectricBlue
+                        icon  = if (ok) Icons.Default.Check else Icons.Default.Close,
+                        text  = msg,
+                        color = if (ok) ElectricBlue else MaterialTheme.colorScheme.error
                     )
                 }
+                if (state.raLoggedIn) {
+                    Spacer(Modifier.height(6.dp))
+                    GradientOutlineButton(
+                        text     = "Sign Out",
+                        onClick  = { viewModel.signOutRa() },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                Spacer(Modifier.height(12.dp))
+                CardDivider()
+                Spacer(Modifier.height(12.dp))
+
+                Text(
+                    "Optional: add a Web API Key (retroachievements.org → Settings → Keys) to also see your rank and recently-played games with completion progress.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value                = state.raApiKey,
+                    onValueChange        = viewModel::updateRaApiKey,
+                    label                = { Text("Web API Key (optional)") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier             = Modifier.fillMaxWidth(),
+                    singleLine           = true,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor   = ElectricBlue,
+                        unfocusedBorderColor = NavyBorder
+                    )
+                )
             }
 
             Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.FolderOpen
@@ -86,8 +85,7 @@ private val gradientBrush = Brush.horizontalGradient(listOf(ElectricBlue, NeonPu
 private enum class SettingsTab(val label: String, val icon: ImageVector) {
     GENERAL("General", Icons.Default.Tune),
     MEDIA("Media", Icons.Default.PermMedia),
-    SCRAPER("Scraper", Icons.Default.CloudDownload),
-    EMULATORS("Emulators", Icons.Default.VideogameAsset),
+    GAMES("Games", Icons.Default.VideogameAsset),
     RETRO_ACHIEVEMENTS("RetroAchievements", Icons.Default.EmojiEvents)
 }
 
@@ -215,19 +213,29 @@ fun SettingsScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     when (selectedTab) {
-                        SettingsTab.GENERAL -> GeneralTab(
-                            state, viewModel, storageVolumes,
-                            onPickRomFolder = { folderPicker.launch(null) },
-                            onRescanClick = onRescanClick,
-                            onScrapeAllClick = onScrapeAllClick
-                        )
-                        SettingsTab.MEDIA -> MediaTab(
-                            state, viewModel,
-                            onPickMediaFolder = { mediaFolderPicker.launch(null) }
-                        )
-                        SettingsTab.SCRAPER -> ScraperTab(state, viewModel, onScrapeAllClick)
-                        SettingsTab.EMULATORS -> EmulatorsTab(state, viewModel, onEmulatorConfigClick)
-                        SettingsTab.RETRO_ACHIEVEMENTS -> RetroAchievementsTab(state, viewModel)
+                        SettingsTab.GENERAL -> {
+                            DisplaySection(state, viewModel)
+                        }
+                        SettingsTab.MEDIA -> {
+                            ScreenScraperSection(state, viewModel, onScrapeAllClick)
+                            Spacer(Modifier.height(4.dp))
+                            ArtworkDatabaseSection(state, viewModel)
+                            Spacer(Modifier.height(4.dp))
+                            MediaImportSection(state, viewModel, onPickMediaFolder = { mediaFolderPicker.launch(null) })
+                        }
+                        SettingsTab.GAMES -> {
+                            RomLibrarySection(
+                                state, viewModel, storageVolumes,
+                                onPickRomFolder = { folderPicker.launch(null) },
+                                onRescanClick = onRescanClick,
+                                onScrapeAllClick = onScrapeAllClick
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            AndroidGamesSection(state, viewModel)
+                            Spacer(Modifier.height(4.dp))
+                            EmulatorsSection(state, viewModel, onEmulatorConfigClick)
+                        }
+                        SettingsTab.RETRO_ACHIEVEMENTS -> RetroAchievementsSection(state, viewModel)
                     }
                     Spacer(Modifier.height(24.dp))
                 }
@@ -277,10 +285,36 @@ private fun SettingsTabBar(selected: SettingsTab, onSelect: (SettingsTab) -> Uni
     }
 }
 
-// ── Tab: General (ROM Library, Display, Android Games) ────────────────────
+// ── Section: Display ──────────────────────────────────────────────────────
 
 @Composable
-private fun GeneralTab(
+private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    SettingsSectionHeader("Display")
+    SettingsCard {
+        CardSwitchRow(
+            label     = "Carousel layout",
+            checked   = state.layoutMode == LayoutMode.CAROUSEL,
+            onCheckedChange = {
+                viewModel.setLayoutMode(if (it) LayoutMode.CAROUSEL else LayoutMode.GRID)
+            }
+        )
+        CardSwitchRow(
+            label           = "Recently Played tab",
+            checked         = state.showRecentlyPlayed,
+            onCheckedChange = viewModel::setShowRecentlyPlayed
+        )
+        CardSwitchRow(
+            label           = "Dark mode",
+            checked         = state.darkMode,
+            onCheckedChange = viewModel::setDarkMode
+        )
+    }
+}
+
+// ── Section: ROM Library ──────────────────────────────────────────────────
+
+@Composable
+private fun RomLibrarySection(
     state: SettingsUiState,
     viewModel: SettingsViewModel,
     storageVolumes: List<Pair<String, String>>,
@@ -288,7 +322,6 @@ private fun GeneralTab(
     onRescanClick: () -> Unit,
     onScrapeAllClick: () -> Unit
 ) {
-    // ── ROM Library ────────────────────────────────────────────────
     SettingsSectionHeader("ROM Library")
     SettingsCard {
         if (storageVolumes.size > 1) {
@@ -359,34 +392,12 @@ private fun GeneralTab(
             )
         }
     }
+}
 
-    Spacer(Modifier.height(4.dp))
+// ── Section: Android Games ────────────────────────────────────────────────
 
-    // ── Display ────────────────────────────────────────────────────
-    SettingsSectionHeader("Display")
-    SettingsCard {
-        CardSwitchRow(
-            label     = "Carousel layout",
-            checked   = state.layoutMode == LayoutMode.CAROUSEL,
-            onCheckedChange = {
-                viewModel.setLayoutMode(if (it) LayoutMode.CAROUSEL else LayoutMode.GRID)
-            }
-        )
-        CardSwitchRow(
-            label           = "Recently Played tab",
-            checked         = state.showRecentlyPlayed,
-            onCheckedChange = viewModel::setShowRecentlyPlayed
-        )
-        CardSwitchRow(
-            label           = "Dark mode",
-            checked         = state.darkMode,
-            onCheckedChange = viewModel::setDarkMode
-        )
-    }
-
-    Spacer(Modifier.height(4.dp))
-
-    // ── Android Games ──────────────────────────────────────────────
+@Composable
+private fun AndroidGamesSection(state: SettingsUiState, viewModel: SettingsViewModel) {
     SettingsSectionHeader("Android Games")
     SettingsCard {
         Text(
@@ -411,167 +422,42 @@ private fun GeneralTab(
     }
 }
 
-// ── Tab: Media (Media Import, Artwork Database) ───────────────────────────
+// ── Section: Emulators ────────────────────────────────────────────────────
 
 @Composable
-private fun MediaTab(
+private fun EmulatorsSection(
     state: SettingsUiState,
     viewModel: SettingsViewModel,
-    onPickMediaFolder: () -> Unit
+    onEmulatorConfigClick: () -> Unit
 ) {
-    // ── Media Import ───────────────────────────────────────────────
-    SettingsSectionHeader("Media Import")
+    SettingsSectionHeader("Emulators")
     SettingsCard {
         Text(
-            "Point to your ES-DE downloaded_media folder to use art & videos you already scraped.",
+            "Auto-detect maps installed emulators to your platforms, or configure each one manually.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         Spacer(Modifier.height(10.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            OutlinedTextField(
-                value         = state.mediaFolderPath.ifEmpty { "Not configured" },
-                onValueChange = { viewModel.setMediaFolderPath(it) },
-                label         = { Text("Media Folder") },
-                modifier      = Modifier.weight(1f),
-                singleLine    = true,
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor   = ElectricBlue,
-                    unfocusedBorderColor = NavyBorder
-                )
-            )
-            Spacer(Modifier.width(8.dp))
-            IconButton(
-                onClick  = onPickMediaFolder,
-                modifier = Modifier
-                    .size(48.dp)
-                    .background(NavyCard, RoundedCornerShape(10.dp))
-            ) {
-                Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
-            }
-        }
-        Spacer(Modifier.height(4.dp))
-        Text(
-            "Tip: pick the downloaded_media folder or its parent ES-DE folder.",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(Modifier.height(10.dp))
-
-        val importing = state.esdeImportStatus is EsdeImportStatus.Scanning
         GradientFillButton(
-            text     = if (importing) "Importing…" else "Import Media",
-            onClick  = { viewModel.importEsdeMedia() },
-            enabled  = state.mediaFolderPath.isNotEmpty() && !importing,
-            loading  = importing,
+            text     = "Auto-detect Emulators",
+            onClick  = { viewModel.autoDetectEmulators() },
+            enabled  = !state.emulatorDetecting,
+            loading  = state.emulatorDetecting,
             modifier = Modifier.fillMaxWidth()
         )
-
-        when (val s = state.esdeImportStatus) {
-            is EsdeImportStatus.Complete -> {
-                Spacer(Modifier.height(6.dp))
-                StatusRow(
-                    icon  = Icons.Default.Check,
-                    text  = "Imported ${s.matched} of ${s.total} games",
-                    color = ElectricBlue
-                )
-            }
-            is EsdeImportStatus.Error -> {
-                Spacer(Modifier.height(6.dp))
-                StatusRow(
-                    icon  = Icons.Default.Close,
-                    text  = s.message,
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-            else -> {}
-        }
-    }
-
-    Spacer(Modifier.height(4.dp))
-
-    // ── Artwork Database ───────────────────────────────────────────
-    SettingsSectionHeader("Artwork Database")
-    SettingsCard {
-        Text(
-            "LaunchBox DB — box art & screenshots. ~190 MB, one-time download. No account needed.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+        Spacer(Modifier.height(8.dp))
+        GradientOutlineButton(
+            text     = "Configure Emulators Manually",
+            onClick  = onEmulatorConfigClick,
+            modifier = Modifier.fillMaxWidth()
         )
-        Spacer(Modifier.height(10.dp))
-
-        val lbSyncing = state.lbSyncStatus is LbSyncStatus.Downloading ||
-                        state.lbSyncStatus is LbSyncStatus.Parsing
-
-        GradientFillButton(
-            text     = if (lbSyncing) "Syncing…" else "Sync Artwork DB",
-            onClick  = { viewModel.syncLaunchBox() },
-            enabled  = !lbSyncing,
-            modifier = Modifier.fillMaxWidth(),
-            loading  = lbSyncing
-        )
-
-        when (val status = state.lbSyncStatus) {
-            is LbSyncStatus.Downloading -> {
-                Spacer(Modifier.height(8.dp))
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth(),
-                    color    = ElectricBlue
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Downloading database…",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            is LbSyncStatus.Parsing -> {
-                Spacer(Modifier.height(8.dp))
-                LinearProgressIndicator(
-                    modifier = Modifier.fillMaxWidth(),
-                    color    = NeonPurple
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Parsing… ${"%,d".format(status.gamesIndexed)} games indexed",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            is LbSyncStatus.Complete -> {
-                Spacer(Modifier.height(6.dp))
-                StatusRow(
-                    icon  = Icons.Default.Check,
-                    text  = "Sync complete — ${"%,d".format(status.totalGames)} games",
-                    color = ElectricBlue
-                )
-            }
-            is LbSyncStatus.Error -> {
-                Spacer(Modifier.height(6.dp))
-                StatusRow(
-                    icon  = Icons.Default.Close,
-                    text  = status.message,
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-            null -> {
-                if (state.lbGameCount > 0) {
-                    Spacer(Modifier.height(6.dp))
-                    Text(
-                        "${"%,d".format(state.lbGameCount)} games in local database",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-        }
     }
 }
 
-// ── Tab: Scraper (ScreenScraper) ──────────────────────────────────────────
+// ── Section: ScreenScraper ────────────────────────────────────────────────
 
 @Composable
-private fun ScraperTab(
+private fun ScreenScraperSection(
     state: SettingsUiState,
     viewModel: SettingsViewModel,
     onScrapeAllClick: () -> Unit
@@ -669,42 +555,168 @@ private fun ScraperTab(
     }
 }
 
-// ── Tab: Emulators ────────────────────────────────────────────────────────
+// ── Section: Artwork Database ─────────────────────────────────────────────
 
 @Composable
-private fun EmulatorsTab(
-    state: SettingsUiState,
-    viewModel: SettingsViewModel,
-    onEmulatorConfigClick: () -> Unit
-) {
-    SettingsSectionHeader("Emulators")
+private fun ArtworkDatabaseSection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    SettingsSectionHeader("Artwork Database")
     SettingsCard {
         Text(
-            "Auto-detect maps installed emulators to your platforms, or configure each one manually.",
+            "LaunchBox DB — box art & screenshots. ~190 MB, one-time download. No account needed.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         Spacer(Modifier.height(10.dp))
+
+        val lbSyncing = state.lbSyncStatus is LbSyncStatus.Downloading ||
+                        state.lbSyncStatus is LbSyncStatus.Parsing
+
         GradientFillButton(
-            text     = "Auto-detect Emulators",
-            onClick  = { viewModel.autoDetectEmulators() },
-            enabled  = !state.emulatorDetecting,
-            loading  = state.emulatorDetecting,
-            modifier = Modifier.fillMaxWidth()
+            text     = if (lbSyncing) "Syncing…" else "Sync Artwork DB",
+            onClick  = { viewModel.syncLaunchBox() },
+            enabled  = !lbSyncing,
+            modifier = Modifier.fillMaxWidth(),
+            loading  = lbSyncing
         )
-        Spacer(Modifier.height(8.dp))
-        GradientOutlineButton(
-            text     = "Configure Emulators Manually",
-            onClick  = onEmulatorConfigClick,
-            modifier = Modifier.fillMaxWidth()
-        )
+
+        when (val status = state.lbSyncStatus) {
+            is LbSyncStatus.Downloading -> {
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    color    = ElectricBlue
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Downloading database…",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is LbSyncStatus.Parsing -> {
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    color    = NeonPurple
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Parsing… ${"%,d".format(status.gamesIndexed)} games indexed",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is LbSyncStatus.Complete -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Check,
+                    text  = "Sync complete — ${"%,d".format(status.totalGames)} games",
+                    color = ElectricBlue
+                )
+            }
+            is LbSyncStatus.Error -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Close,
+                    text  = status.message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            null -> {
+                if (state.lbGameCount > 0) {
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "${"%,d".format(state.lbGameCount)} games in local database",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
     }
 }
 
-// ── Tab: RetroAchievements ────────────────────────────────────────────────
+// ── Section: Media Import ─────────────────────────────────────────────────
 
 @Composable
-private fun RetroAchievementsTab(state: SettingsUiState, viewModel: SettingsViewModel) {
+private fun MediaImportSection(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    onPickMediaFolder: () -> Unit
+) {
+    SettingsSectionHeader("Media Import")
+    SettingsCard {
+        Text(
+            "Point to your ES-DE downloaded_media folder to use art & videos you already scraped.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value         = state.mediaFolderPath.ifEmpty { "Not configured" },
+                onValueChange = { viewModel.setMediaFolderPath(it) },
+                label         = { Text("Media Folder") },
+                modifier      = Modifier.weight(1f),
+                singleLine    = true,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor   = ElectricBlue,
+                    unfocusedBorderColor = NavyBorder
+                )
+            )
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick  = onPickMediaFolder,
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(NavyCard, RoundedCornerShape(10.dp))
+            ) {
+                Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Tip: pick the downloaded_media folder or its parent ES-DE folder.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+
+        val importing = state.esdeImportStatus is EsdeImportStatus.Scanning
+        GradientFillButton(
+            text     = if (importing) "Importing…" else "Import Media",
+            onClick  = { viewModel.importEsdeMedia() },
+            enabled  = state.mediaFolderPath.isNotEmpty() && !importing,
+            loading  = importing,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        when (val s = state.esdeImportStatus) {
+            is EsdeImportStatus.Complete -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Check,
+                    text  = "Imported ${s.matched} of ${s.total} games",
+                    color = ElectricBlue
+                )
+            }
+            is EsdeImportStatus.Error -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Close,
+                    text  = s.message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            else -> {}
+        }
+    }
+}
+
+// ── Section: RetroAchievements ────────────────────────────────────────────
+
+@Composable
+private fun RetroAchievementsSection(state: SettingsUiState, viewModel: SettingsViewModel) {
     SettingsSectionHeader("RetroAchievements")
     SettingsCard {
         Text(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -225,7 +225,7 @@ fun SettingsScreen(
                             state, viewModel,
                             onPickMediaFolder = { mediaFolderPicker.launch(null) }
                         )
-                        SettingsTab.SCRAPER -> ScraperTab(state, viewModel)
+                        SettingsTab.SCRAPER -> ScraperTab(state, viewModel, onScrapeAllClick)
                         SettingsTab.EMULATORS -> EmulatorsTab(state, viewModel, onEmulatorConfigClick)
                         SettingsTab.RETRO_ACHIEVEMENTS -> RetroAchievementsTab(state, viewModel)
                     }
@@ -571,7 +571,11 @@ private fun MediaTab(
 // ── Tab: Scraper (ScreenScraper) ──────────────────────────────────────────
 
 @Composable
-private fun ScraperTab(state: SettingsUiState, viewModel: SettingsViewModel) {
+private fun ScraperTab(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    onScrapeAllClick: () -> Unit
+) {
     SettingsSectionHeader("ScreenScraper (Recommended)")
     SettingsCard {
         Text(
@@ -641,10 +645,27 @@ private fun ScraperTab(state: SettingsUiState, viewModel: SettingsViewModel) {
             fontWeight = FontWeight.SemiBold
         )
         Spacer(Modifier.height(4.dp))
+        CardSwitchRow("Metadata",       state.scrapeMetadata,      viewModel::setScrapeMetadata)
         CardSwitchRow("Box Art",        state.scrapeBoxArt,        viewModel::setScrapeBoxArt)
         CardSwitchRow("Screenshots",    state.scrapeScreenshots,   viewModel::setScrapeScreenshots)
         CardSwitchRow("Wheel Logos",    state.scrapeWheelLogos,    viewModel::setScrapeWheelLogos)
         CardSwitchRow("Video Previews", state.scrapeVideos,        viewModel::setScrapeVideos)
+
+        Spacer(Modifier.height(12.dp))
+        CardDivider()
+        Spacer(Modifier.height(12.dp))
+
+        Text(
+            "Scrapes every game that hasn't been scraped yet, using ScreenScraper first and falling back to free sources.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        GradientFillButton(
+            text     = "Scrape Now",
+            onClick  = onScrapeAllClick,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -82,11 +82,9 @@ import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
 import com.gamelaunch.frontend.ui.input.GamepadL1
 import com.gamelaunch.frontend.ui.input.GamepadR1
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
-import com.gamelaunch.frontend.ui.theme.GameColorScheme
-import com.gamelaunch.frontend.ui.theme.GameLightColorScheme
 import com.gamelaunch.frontend.ui.theme.LayoutMode
-import com.gamelaunch.frontend.ui.theme.LocalDarkMode
 import com.gamelaunch.frontend.ui.theme.NeonPurple
+import com.gamelaunch.frontend.ui.theme.ThemedScreen
 import com.gamelaunch.frontend.util.StorageUtils
 
 private val gradientBrush = Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple))
@@ -140,10 +138,6 @@ fun SettingsScreen(
         }
     }
 
-    // Honour the user's light/dark choice locally — the rest of the app keeps the dark
-    // MaterialTheme and reads LocalDarkMode for its own colours, so we override only here.
-    val settingsScheme = if (LocalDarkMode.current) GameColorScheme else GameLightColorScheme
-
     // L1 / R1 cycle between tabs (with wraparound), mirroring the home screen.
     fun cycleTab(delta: Int) {
         val entries = SettingsTab.entries
@@ -154,7 +148,8 @@ fun SettingsScreen(
     val tabFocusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { runCatching { tabFocusRequester.requestFocus() } }
 
-    MaterialTheme(colorScheme = settingsScheme) {
+    // Honour the user's light/dark choice for this screen's Material components.
+    ThemedScreen {
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,8 +24,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.PermMedia
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.VideogameAsset
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -49,12 +55,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -63,6 +74,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.LayoutMode
 import com.gamelaunch.frontend.ui.theme.NavyBorder
 import com.gamelaunch.frontend.ui.theme.NavyCard
 import com.gamelaunch.frontend.ui.theme.NavySurface
@@ -70,6 +82,14 @@ import com.gamelaunch.frontend.ui.theme.NeonPurple
 import com.gamelaunch.frontend.util.StorageUtils
 
 private val gradientBrush = Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple))
+
+private enum class SettingsTab(val label: String, val icon: ImageVector) {
+    GENERAL("General", Icons.Default.Tune),
+    MEDIA("Media", Icons.Default.PermMedia),
+    SCRAPER("Scraper", Icons.Default.CloudDownload),
+    EMULATORS("Emulators", Icons.Default.VideogameAsset),
+    RETRO_ACHIEVEMENTS("RetroAchievements", Icons.Default.EmojiEvents)
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -85,6 +105,8 @@ fun SettingsScreen(
     val state   by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val storageVolumes = remember { StorageUtils.getStorageVolumes(context) }
+
+    var selectedTab by rememberSaveable { mutableStateOf(SettingsTab.GENERAL) }
 
     LaunchedEffect(state.emulatorDetectResult) {
         state.emulatorDetectResult?.let { msg ->
@@ -143,13 +165,14 @@ fun SettingsScreen(
                     }
                 },
                 actions = {
-                    // Gradient "Go to Library" button
+                    // Gradient "Go to Library" button — also persists any typed ScreenScraper creds.
                     Box(
                         modifier = Modifier
                             .padding(end = 12.dp)
                             .clip(RoundedCornerShape(50))
                             .background(gradientBrush)
                             .clickable {
+                                viewModel.saveCredentials()
                                 viewModel.finishSetup()
                                 onGoToLibrary()
                             }
@@ -178,488 +201,569 @@ fun SettingsScreen(
             )
         }
     ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
+        Column(Modifier.fillMaxSize().padding(paddingValues)) {
 
-            // ── ROM Library ────────────────────────────────────────────────
-            SettingsSectionHeader("ROM Library")
-            SettingsCard {
-                if (storageVolumes.size > 1) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.padding(bottom = 10.dp)
-                    ) {
-                        storageVolumes.forEach { (label, path) ->
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .clip(RoundedCornerShape(10.dp))
-                                    .background(NavyCard)
-                                    .clickable { viewModel.setRomRootPath(path) }
-                                    .padding(horizontal = 12.dp, vertical = 10.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
-                            }
-                        }
-                    }
-                    CardDivider()
-                }
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(top = if (storageVolumes.size > 1) 10.dp else 0.dp)
+            SettingsTabBar(selected = selectedTab, onSelect = { selectedTab = it })
+
+            // Fresh scroll state per tab so switching tabs starts at the top.
+            key(selectedTab) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    OutlinedTextField(
-                        value       = state.romRootPath.ifEmpty { "Not configured" },
-                        onValueChange = { viewModel.setRomRootPath(it) },
-                        label       = { Text("ROM Folder") },
-                        modifier    = Modifier.weight(1f),
-                        singleLine  = true,
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor   = ElectricBlue,
-                            unfocusedBorderColor = NavyBorder
+                    when (selectedTab) {
+                        SettingsTab.GENERAL -> GeneralTab(
+                            state, viewModel, storageVolumes,
+                            onPickRomFolder = { folderPicker.launch(null) },
+                            onRescanClick = onRescanClick,
+                            onScrapeAllClick = onScrapeAllClick
                         )
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    IconButton(
-                        onClick  = { folderPicker.launch(null) },
-                        modifier = Modifier
-                            .size(48.dp)
-                            .background(NavyCard, RoundedCornerShape(10.dp))
-                    ) {
-                        Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
+                        SettingsTab.MEDIA -> MediaTab(
+                            state, viewModel,
+                            onPickMediaFolder = { mediaFolderPicker.launch(null) }
+                        )
+                        SettingsTab.SCRAPER -> ScraperTab(state, viewModel)
+                        SettingsTab.EMULATORS -> EmulatorsTab(state, viewModel, onEmulatorConfigClick)
+                        SettingsTab.RETRO_ACHIEVEMENTS -> RetroAchievementsTab(state, viewModel)
                     }
-                }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Tip: for SD card use /storage/XXXX-XXXX/ROMs",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(10.dp))
-                CardDivider()
-                Spacer(Modifier.height(10.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    GradientOutlineButton(
-                        text     = "Rescan ROMs",
-                        onClick  = onRescanClick,
-                        modifier = Modifier.weight(1f)
-                    )
-                    GradientFillButton(
-                        text     = "Scrape All",
-                        onClick  = onScrapeAllClick,
-                        modifier = Modifier.weight(1f)
-                    )
+                    Spacer(Modifier.height(24.dp))
                 }
             }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── Media Import ───────────────────────────────────────────────
-            SettingsSectionHeader("Media Import")
-            SettingsCard {
-                Text(
-                    "Point to your ES-DE downloaded_media folder to use art & videos you already scraped.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(10.dp))
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    OutlinedTextField(
-                        value         = state.mediaFolderPath.ifEmpty { "Not configured" },
-                        onValueChange = { viewModel.setMediaFolderPath(it) },
-                        label         = { Text("Media Folder") },
-                        modifier      = Modifier.weight(1f),
-                        singleLine    = true,
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor   = ElectricBlue,
-                            unfocusedBorderColor = NavyBorder
-                        )
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    IconButton(
-                        onClick  = { mediaFolderPicker.launch(null) },
-                        modifier = Modifier
-                            .size(48.dp)
-                            .background(NavyCard, RoundedCornerShape(10.dp))
-                    ) {
-                        Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
-                    }
-                }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Tip: pick the downloaded_media folder or its parent ES-DE folder.",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(10.dp))
-
-                val importing = state.esdeImportStatus is EsdeImportStatus.Scanning
-                GradientFillButton(
-                    text     = if (importing) "Importing…" else "Import Media",
-                    onClick  = { viewModel.importEsdeMedia() },
-                    enabled  = state.mediaFolderPath.isNotEmpty() && !importing,
-                    loading  = importing,
-                    modifier = Modifier.fillMaxWidth()
-                )
-
-                when (val s = state.esdeImportStatus) {
-                    is EsdeImportStatus.Complete -> {
-                        Spacer(Modifier.height(6.dp))
-                        StatusRow(
-                            icon  = Icons.Default.Check,
-                            text  = "Imported ${s.matched} of ${s.total} games",
-                            color = ElectricBlue
-                        )
-                    }
-                    is EsdeImportStatus.Error -> {
-                        Spacer(Modifier.height(6.dp))
-                        StatusRow(
-                            icon  = Icons.Default.Close,
-                            text  = s.message,
-                            color = MaterialTheme.colorScheme.error
-                        )
-                    }
-                    else -> {}
-                }
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── Artwork Database ───────────────────────────────────────────
-            SettingsSectionHeader("Artwork Database")
-            SettingsCard {
-                Text(
-                    "LaunchBox DB — box art & screenshots. ~190 MB, one-time download. No account needed.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(10.dp))
-
-                val lbSyncing = state.lbSyncStatus is LbSyncStatus.Downloading ||
-                                state.lbSyncStatus is LbSyncStatus.Parsing
-
-                GradientFillButton(
-                    text     = if (lbSyncing) "Syncing…" else "Sync Artwork DB",
-                    onClick  = { viewModel.syncLaunchBox() },
-                    enabled  = !lbSyncing,
-                    modifier = Modifier.fillMaxWidth(),
-                    loading  = lbSyncing
-                )
-
-                when (val status = state.lbSyncStatus) {
-                    is LbSyncStatus.Downloading -> {
-                        Spacer(Modifier.height(8.dp))
-                        LinearProgressIndicator(
-                            modifier = Modifier.fillMaxWidth(),
-                            color    = ElectricBlue
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            "Downloading database…",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    is LbSyncStatus.Parsing -> {
-                        Spacer(Modifier.height(8.dp))
-                        LinearProgressIndicator(
-                            modifier = Modifier.fillMaxWidth(),
-                            color    = NeonPurple
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            "Parsing… ${"%,d".format(status.gamesIndexed)} games indexed",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    is LbSyncStatus.Complete -> {
-                        Spacer(Modifier.height(6.dp))
-                        StatusRow(
-                            icon  = Icons.Default.Check,
-                            text  = "Sync complete — ${"%,d".format(status.totalGames)} games",
-                            color = ElectricBlue
-                        )
-                    }
-                    is LbSyncStatus.Error -> {
-                        Spacer(Modifier.height(6.dp))
-                        StatusRow(
-                            icon  = Icons.Default.Close,
-                            text  = status.message,
-                            color = MaterialTheme.colorScheme.error
-                        )
-                    }
-                    null -> {
-                        if (state.lbGameCount > 0) {
-                            Spacer(Modifier.height(6.dp))
-                            Text(
-                                "${"%,d".format(state.lbGameCount)} games in local database",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── ScreenScraper ──────────────────────────────────────────────
-            SettingsSectionHeader("ScreenScraper (Recommended)")
-            SettingsCard {
-                Text(
-                    "ScreenScraper is the default scraper — it provides the best box art, screenshots, wheel logos, and video previews. " +
-                    "Create a free account at screenscraper.fr, then enter your username and password below. " +
-                    "Without credentials the app falls back to libretro thumbnails and LaunchBox.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(12.dp))
-                OutlinedTextField(
-                    value         = state.ssId,
-                    onValueChange = viewModel::updateSsId,
-                    label         = { Text("Username (ssid)") },
-                    modifier      = Modifier.fillMaxWidth(),
-                    singleLine    = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = ElectricBlue,
-                        unfocusedBorderColor = NavyBorder
-                    )
-                )
-                Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value                  = state.ssPassword,
-                    onValueChange          = viewModel::updateSsPassword,
-                    label                  = { Text("Password") },
-                    visualTransformation   = PasswordVisualTransformation(),
-                    modifier               = Modifier.fillMaxWidth(),
-                    singleLine             = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = ElectricBlue,
-                        unfocusedBorderColor = NavyBorder
-                    )
-                )
-                Spacer(Modifier.height(10.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    GradientOutlineButton(
-                        text    = "Save",
-                        onClick = { viewModel.saveCredentials() },
-                        modifier = Modifier.weight(1f)
-                    )
-                    GradientFillButton(
-                        text     = "Validate",
-                        onClick  = { viewModel.validateCredentials() },
-                        enabled  = !state.credentialValidating,
-                        loading  = state.credentialValidating,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                state.credentialValid?.let { valid ->
-                    Spacer(Modifier.height(8.dp))
-                    StatusRow(
-                        icon  = if (valid) Icons.Default.Check else Icons.Default.Close,
-                        text  = if (valid) "Credentials valid" else "Invalid credentials",
-                        color = if (valid) ElectricBlue else MaterialTheme.colorScheme.error
-                    )
-                }
-
-                Spacer(Modifier.height(12.dp))
-                CardDivider()
-                Spacer(Modifier.height(12.dp))
-
-                Text(
-                    "Scrape options",
-                    style      = MaterialTheme.typography.labelLarge,
-                    color      = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.SemiBold
-                )
-                Spacer(Modifier.height(4.dp))
-                CardSwitchRow("Box Art",        state.scrapeBoxArt,        viewModel::setScrapeBoxArt)
-                CardSwitchRow("Screenshots",    state.scrapeScreenshots,   viewModel::setScrapeScreenshots)
-                CardSwitchRow("Wheel Logos",    state.scrapeWheelLogos,    viewModel::setScrapeWheelLogos)
-                CardSwitchRow("Video Previews", state.scrapeVideos,        viewModel::setScrapeVideos)
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── Emulators ──────────────────────────────────────────────────
-            SettingsSectionHeader("Emulators")
-            SettingsCard {
-                GradientFillButton(
-                    text     = "Auto-detect Emulators",
-                    onClick  = { viewModel.autoDetectEmulators() },
-                    enabled  = !state.emulatorDetecting,
-                    loading  = state.emulatorDetecting,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Spacer(Modifier.height(8.dp))
-                GradientOutlineButton(
-                    text     = "Configure Emulators Manually",
-                    onClick  = onEmulatorConfigClick,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── Android Games ──────────────────────────────────────────────
-            SettingsSectionHeader("Android Games")
-            SettingsCard {
-                Text(
-                    "Scan installed Android games (apps tagged as games) and add them to your library.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(10.dp))
-                GradientFillButton(
-                    text     = "Scan Android Games",
-                    onClick  = { viewModel.scanAndroidGames() },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                state.androidScanResult?.let { result ->
-                    Spacer(Modifier.height(6.dp))
-                    StatusRow(
-                        icon  = Icons.Default.Check,
-                        text  = result,
-                        color = ElectricBlue
-                    )
-                }
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── Display ────────────────────────────────────────────────────
-            SettingsSectionHeader("Display")
-            SettingsCard {
-                CardSwitchRow(
-                    label     = "Carousel layout",
-                    checked   = state.layoutMode == com.gamelaunch.frontend.ui.theme.LayoutMode.CAROUSEL,
-                    onCheckedChange = {
-                        viewModel.setLayoutMode(
-                            if (it) com.gamelaunch.frontend.ui.theme.LayoutMode.CAROUSEL
-                            else    com.gamelaunch.frontend.ui.theme.LayoutMode.GRID
-                        )
-                    }
-                )
-                CardSwitchRow(
-                    label           = "Recently Played tab",
-                    checked         = state.showRecentlyPlayed,
-                    onCheckedChange = viewModel::setShowRecentlyPlayed
-                )
-                CardSwitchRow(
-                    label           = "Dark mode",
-                    checked         = state.darkMode,
-                    onCheckedChange = viewModel::setDarkMode
-                )
-            }
-
-            Spacer(Modifier.height(4.dp))
-
-            // ── RetroAchievements ──────────────────────────────────────────
-            SettingsSectionHeader("RetroAchievements")
-            SettingsCard {
-                Text(
-                    "Sign in with your RetroAchievements username and password to see your points and profile.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(12.dp))
-                OutlinedTextField(
-                    value         = state.raUsername,
-                    onValueChange = viewModel::updateRaUsername,
-                    label         = { Text("Username") },
-                    modifier      = Modifier.fillMaxWidth(),
-                    singleLine    = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = ElectricBlue,
-                        unfocusedBorderColor = NavyBorder
-                    )
-                )
-                Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value                = state.raPassword,
-                    onValueChange        = viewModel::updateRaPassword,
-                    label                = { Text("Password") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    modifier             = Modifier.fillMaxWidth(),
-                    singleLine           = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = ElectricBlue,
-                        unfocusedBorderColor = NavyBorder
-                    )
-                )
-                Spacer(Modifier.height(10.dp))
-                GradientFillButton(
-                    text     = if (state.raLoggedIn) "Update Sign-In" else "Sign In",
-                    onClick  = { viewModel.saveRaCredentials() },
-                    enabled  = !state.raLoggingIn,
-                    loading  = state.raLoggingIn,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                state.raLoginResult?.let { msg ->
-                    val ok = msg.startsWith("Signed in")
-                    Spacer(Modifier.height(8.dp))
-                    StatusRow(
-                        icon  = if (ok) Icons.Default.Check else Icons.Default.Close,
-                        text  = msg,
-                        color = if (ok) ElectricBlue else MaterialTheme.colorScheme.error
-                    )
-                }
-                if (state.raLoggedIn) {
-                    Spacer(Modifier.height(6.dp))
-                    GradientOutlineButton(
-                        text     = "Sign Out",
-                        onClick  = { viewModel.signOutRa() },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-
-                Spacer(Modifier.height(12.dp))
-                CardDivider()
-                Spacer(Modifier.height(12.dp))
-
-                Text(
-                    "Optional: add a Web API Key (retroachievements.org → Settings → Keys) to also see your rank and recently-played games with completion progress.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value                = state.raApiKey,
-                    onValueChange        = viewModel::updateRaApiKey,
-                    label                = { Text("Web API Key (optional)") },
-                    visualTransformation = PasswordVisualTransformation(),
-                    modifier             = Modifier.fillMaxWidth(),
-                    singleLine           = true,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor   = ElectricBlue,
-                        unfocusedBorderColor = NavyBorder
-                    )
-                )
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            // ── Save & Finish ──────────────────────────────────────────────
-            GradientFillButton(
-                text     = "Save & Go to Library",
-                modifier = Modifier.fillMaxWidth(),
-                onClick  = {
-                    viewModel.saveCredentials()
-                    viewModel.finishSetup()
-                    onGoToLibrary()
-                }
-            )
-
-            Spacer(Modifier.height(24.dp))
         }
+    }
+}
+
+@Composable
+private fun SettingsTabBar(selected: SettingsTab, onSelect: (SettingsTab) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SettingsTab.entries.forEach { tab ->
+            val isSel = tab == selected
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50))
+                    .then(
+                        if (isSel) Modifier.background(gradientBrush)
+                        else Modifier.background(Color.White.copy(alpha = 0.07f))
+                    )
+                    .clickable { onSelect(tab) }
+                    .padding(horizontal = 14.dp, vertical = 9.dp)
+            ) {
+                Icon(
+                    tab.icon,
+                    contentDescription = null,
+                    tint = if (isSel) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp)
+                )
+                Text(
+                    tab.label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (isSel) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = if (isSel) FontWeight.SemiBold else FontWeight.Normal
+                )
+            }
+        }
+    }
+}
+
+// ── Tab: General (ROM Library, Display, Android Games) ────────────────────
+
+@Composable
+private fun GeneralTab(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    storageVolumes: List<Pair<String, String>>,
+    onPickRomFolder: () -> Unit,
+    onRescanClick: () -> Unit,
+    onScrapeAllClick: () -> Unit
+) {
+    // ── ROM Library ────────────────────────────────────────────────
+    SettingsSectionHeader("ROM Library")
+    SettingsCard {
+        if (storageVolumes.size > 1) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(bottom = 10.dp)
+            ) {
+                storageVolumes.forEach { (label, path) ->
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(NavyCard)
+                            .clickable { viewModel.setRomRootPath(path) }
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(label, style = MaterialTheme.typography.labelMedium, maxLines = 1)
+                    }
+                }
+            }
+            CardDivider()
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(top = if (storageVolumes.size > 1) 10.dp else 0.dp)
+        ) {
+            OutlinedTextField(
+                value       = state.romRootPath.ifEmpty { "Not configured" },
+                onValueChange = { viewModel.setRomRootPath(it) },
+                label       = { Text("ROM Folder") },
+                modifier    = Modifier.weight(1f),
+                singleLine  = true,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor   = ElectricBlue,
+                    unfocusedBorderColor = NavyBorder
+                )
+            )
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick  = onPickRomFolder,
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(NavyCard, RoundedCornerShape(10.dp))
+            ) {
+                Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Tip: for SD card use /storage/XXXX-XXXX/ROMs",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        CardDivider()
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            GradientOutlineButton(
+                text     = "Rescan ROMs",
+                onClick  = onRescanClick,
+                modifier = Modifier.weight(1f)
+            )
+            GradientFillButton(
+                text     = "Scrape All",
+                onClick  = onScrapeAllClick,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    // ── Display ────────────────────────────────────────────────────
+    SettingsSectionHeader("Display")
+    SettingsCard {
+        CardSwitchRow(
+            label     = "Carousel layout",
+            checked   = state.layoutMode == LayoutMode.CAROUSEL,
+            onCheckedChange = {
+                viewModel.setLayoutMode(if (it) LayoutMode.CAROUSEL else LayoutMode.GRID)
+            }
+        )
+        CardSwitchRow(
+            label           = "Recently Played tab",
+            checked         = state.showRecentlyPlayed,
+            onCheckedChange = viewModel::setShowRecentlyPlayed
+        )
+        CardSwitchRow(
+            label           = "Dark mode",
+            checked         = state.darkMode,
+            onCheckedChange = viewModel::setDarkMode
+        )
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    // ── Android Games ──────────────────────────────────────────────
+    SettingsSectionHeader("Android Games")
+    SettingsCard {
+        Text(
+            "Scan installed Android games (apps tagged as games) and add them to your library.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        GradientFillButton(
+            text     = "Scan Android Games",
+            onClick  = { viewModel.scanAndroidGames() },
+            modifier = Modifier.fillMaxWidth()
+        )
+        state.androidScanResult?.let { result ->
+            Spacer(Modifier.height(6.dp))
+            StatusRow(
+                icon  = Icons.Default.Check,
+                text  = result,
+                color = ElectricBlue
+            )
+        }
+    }
+}
+
+// ── Tab: Media (Media Import, Artwork Database) ───────────────────────────
+
+@Composable
+private fun MediaTab(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    onPickMediaFolder: () -> Unit
+) {
+    // ── Media Import ───────────────────────────────────────────────
+    SettingsSectionHeader("Media Import")
+    SettingsCard {
+        Text(
+            "Point to your ES-DE downloaded_media folder to use art & videos you already scraped.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value         = state.mediaFolderPath.ifEmpty { "Not configured" },
+                onValueChange = { viewModel.setMediaFolderPath(it) },
+                label         = { Text("Media Folder") },
+                modifier      = Modifier.weight(1f),
+                singleLine    = true,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor   = ElectricBlue,
+                    unfocusedBorderColor = NavyBorder
+                )
+            )
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick  = onPickMediaFolder,
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(NavyCard, RoundedCornerShape(10.dp))
+            ) {
+                Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Tip: pick the downloaded_media folder or its parent ES-DE folder.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+
+        val importing = state.esdeImportStatus is EsdeImportStatus.Scanning
+        GradientFillButton(
+            text     = if (importing) "Importing…" else "Import Media",
+            onClick  = { viewModel.importEsdeMedia() },
+            enabled  = state.mediaFolderPath.isNotEmpty() && !importing,
+            loading  = importing,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        when (val s = state.esdeImportStatus) {
+            is EsdeImportStatus.Complete -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Check,
+                    text  = "Imported ${s.matched} of ${s.total} games",
+                    color = ElectricBlue
+                )
+            }
+            is EsdeImportStatus.Error -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Close,
+                    text  = s.message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            else -> {}
+        }
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    // ── Artwork Database ───────────────────────────────────────────
+    SettingsSectionHeader("Artwork Database")
+    SettingsCard {
+        Text(
+            "LaunchBox DB — box art & screenshots. ~190 MB, one-time download. No account needed.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+
+        val lbSyncing = state.lbSyncStatus is LbSyncStatus.Downloading ||
+                        state.lbSyncStatus is LbSyncStatus.Parsing
+
+        GradientFillButton(
+            text     = if (lbSyncing) "Syncing…" else "Sync Artwork DB",
+            onClick  = { viewModel.syncLaunchBox() },
+            enabled  = !lbSyncing,
+            modifier = Modifier.fillMaxWidth(),
+            loading  = lbSyncing
+        )
+
+        when (val status = state.lbSyncStatus) {
+            is LbSyncStatus.Downloading -> {
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    color    = ElectricBlue
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Downloading database…",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is LbSyncStatus.Parsing -> {
+                Spacer(Modifier.height(8.dp))
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    color    = NeonPurple
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Parsing… ${"%,d".format(status.gamesIndexed)} games indexed",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            is LbSyncStatus.Complete -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Check,
+                    text  = "Sync complete — ${"%,d".format(status.totalGames)} games",
+                    color = ElectricBlue
+                )
+            }
+            is LbSyncStatus.Error -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(
+                    icon  = Icons.Default.Close,
+                    text  = status.message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+            null -> {
+                if (state.lbGameCount > 0) {
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        "${"%,d".format(state.lbGameCount)} games in local database",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Tab: Scraper (ScreenScraper) ──────────────────────────────────────────
+
+@Composable
+private fun ScraperTab(state: SettingsUiState, viewModel: SettingsViewModel) {
+    SettingsSectionHeader("ScreenScraper (Recommended)")
+    SettingsCard {
+        Text(
+            "ScreenScraper is the default scraper — it provides the best box art, screenshots, wheel logos, and video previews. " +
+            "Create a free account at screenscraper.fr, then enter your username and password below. " +
+            "Without credentials the app falls back to libretro thumbnails and LaunchBox.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value         = state.ssId,
+            onValueChange = viewModel::updateSsId,
+            label         = { Text("Username (ssid)") },
+            modifier      = Modifier.fillMaxWidth(),
+            singleLine    = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor   = ElectricBlue,
+                unfocusedBorderColor = NavyBorder
+            )
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value                  = state.ssPassword,
+            onValueChange          = viewModel::updateSsPassword,
+            label                  = { Text("Password") },
+            visualTransformation   = PasswordVisualTransformation(),
+            modifier               = Modifier.fillMaxWidth(),
+            singleLine             = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor   = ElectricBlue,
+                unfocusedBorderColor = NavyBorder
+            )
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            GradientOutlineButton(
+                text    = "Save",
+                onClick = { viewModel.saveCredentials() },
+                modifier = Modifier.weight(1f)
+            )
+            GradientFillButton(
+                text     = "Validate",
+                onClick  = { viewModel.validateCredentials() },
+                enabled  = !state.credentialValidating,
+                loading  = state.credentialValidating,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        state.credentialValid?.let { valid ->
+            Spacer(Modifier.height(8.dp))
+            StatusRow(
+                icon  = if (valid) Icons.Default.Check else Icons.Default.Close,
+                text  = if (valid) "Credentials valid" else "Invalid credentials",
+                color = if (valid) ElectricBlue else MaterialTheme.colorScheme.error
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+        CardDivider()
+        Spacer(Modifier.height(12.dp))
+
+        Text(
+            "Scrape options",
+            style      = MaterialTheme.typography.labelLarge,
+            color      = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(Modifier.height(4.dp))
+        CardSwitchRow("Box Art",        state.scrapeBoxArt,        viewModel::setScrapeBoxArt)
+        CardSwitchRow("Screenshots",    state.scrapeScreenshots,   viewModel::setScrapeScreenshots)
+        CardSwitchRow("Wheel Logos",    state.scrapeWheelLogos,    viewModel::setScrapeWheelLogos)
+        CardSwitchRow("Video Previews", state.scrapeVideos,        viewModel::setScrapeVideos)
+    }
+}
+
+// ── Tab: Emulators ────────────────────────────────────────────────────────
+
+@Composable
+private fun EmulatorsTab(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    onEmulatorConfigClick: () -> Unit
+) {
+    SettingsSectionHeader("Emulators")
+    SettingsCard {
+        Text(
+            "Auto-detect maps installed emulators to your platforms, or configure each one manually.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        GradientFillButton(
+            text     = "Auto-detect Emulators",
+            onClick  = { viewModel.autoDetectEmulators() },
+            enabled  = !state.emulatorDetecting,
+            loading  = state.emulatorDetecting,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        GradientOutlineButton(
+            text     = "Configure Emulators Manually",
+            onClick  = onEmulatorConfigClick,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+// ── Tab: RetroAchievements ────────────────────────────────────────────────
+
+@Composable
+private fun RetroAchievementsTab(state: SettingsUiState, viewModel: SettingsViewModel) {
+    SettingsSectionHeader("RetroAchievements")
+    SettingsCard {
+        Text(
+            "Sign in with your RetroAchievements username and password to see your points and profile.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value         = state.raUsername,
+            onValueChange = viewModel::updateRaUsername,
+            label         = { Text("Username") },
+            modifier      = Modifier.fillMaxWidth(),
+            singleLine    = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor   = ElectricBlue,
+                unfocusedBorderColor = NavyBorder
+            )
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value                = state.raPassword,
+            onValueChange        = viewModel::updateRaPassword,
+            label                = { Text("Password") },
+            visualTransformation = PasswordVisualTransformation(),
+            modifier             = Modifier.fillMaxWidth(),
+            singleLine           = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor   = ElectricBlue,
+                unfocusedBorderColor = NavyBorder
+            )
+        )
+        Spacer(Modifier.height(10.dp))
+        GradientFillButton(
+            text     = if (state.raLoggedIn) "Update Sign-In" else "Sign In",
+            onClick  = { viewModel.saveRaCredentials() },
+            enabled  = !state.raLoggingIn,
+            loading  = state.raLoggingIn,
+            modifier = Modifier.fillMaxWidth()
+        )
+        state.raLoginResult?.let { msg ->
+            val ok = msg.startsWith("Signed in")
+            Spacer(Modifier.height(8.dp))
+            StatusRow(
+                icon  = if (ok) Icons.Default.Check else Icons.Default.Close,
+                text  = msg,
+                color = if (ok) ElectricBlue else MaterialTheme.colorScheme.error
+            )
+        }
+        if (state.raLoggedIn) {
+            Spacer(Modifier.height(6.dp))
+            GradientOutlineButton(
+                text     = "Sign Out",
+                onClick  = { viewModel.signOutRa() },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+        CardDivider()
+        Spacer(Modifier.height(12.dp))
+
+        Text(
+            "Optional: add a Web API Key (retroachievements.org → Settings → Keys) to also see your rank and recently-played games with completion progress.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value                = state.raApiKey,
+            onValueChange        = viewModel::updateRaApiKey,
+            label                = { Text("Web API Key (optional)") },
+            visualTransformation = PasswordVisualTransformation(),
+            modifier             = Modifier.fillMaxWidth(),
+            singleLine           = true,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor   = ElectricBlue,
+                unfocusedBorderColor = NavyBorder
+            )
+        )
     }
 }
 
@@ -783,7 +887,7 @@ private fun GradientOutlineButton(
 
 @Composable
 private fun StatusRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     text: String,
     color: Color
 ) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -525,6 +525,11 @@ fun SettingsScreen(
                     checked         = state.showRecentlyPlayed,
                     onCheckedChange = viewModel::setShowRecentlyPlayed
                 )
+                CardSwitchRow(
+                    label           = "Dark mode",
+                    checked         = state.darkMode,
+                    onCheckedChange = viewModel::setDarkMode
+                )
             }
 
             Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -3,6 +3,7 @@ package com.gamelaunch.frontend.ui.screen.settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.horizontalScroll
@@ -25,7 +26,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.PermMedia
@@ -252,13 +255,26 @@ fun SettingsScreen(
                     when (selectedTab) {
                         SettingsTab.GENERAL -> {
                             DisplaySection(state, viewModel)
+                            Spacer(Modifier.height(4.dp))
+                            SystemSortSection(state, viewModel)
                         }
                         SettingsTab.MEDIA -> {
-                            ScreenScraperSection(state, viewModel, onScrapeAllClick)
-                            Spacer(Modifier.height(4.dp))
-                            ArtworkDatabaseSection(state, viewModel)
-                            Spacer(Modifier.height(4.dp))
-                            MediaImportSection(state, viewModel, onPickMediaFolder = { mediaFolderPicker.launch(null) })
+                            // The three media sources are rarely used together, so they share one
+                            // card with an inline segmented selector instead of stacking.
+                            var mediaSub by rememberSaveable { mutableStateOf(0) }
+                            SegmentedTabs(
+                                options  = listOf("ScreenScraper", "Artwork DB", "Import"),
+                                selected = mediaSub,
+                                onSelect = { mediaSub = it }
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            SettingsCard {
+                                when (mediaSub) {
+                                    0 -> ScreenScraperBody(state, viewModel, onScrapeAllClick)
+                                    1 -> ArtworkDatabaseBody(state, viewModel)
+                                    else -> MediaImportBody(state, viewModel, onPickMediaFolder = { mediaFolderPicker.launch(null) })
+                                }
+                            }
                         }
                         SettingsTab.GAMES -> {
                             RomLibrarySection(
@@ -342,11 +358,159 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
             checked         = state.showRecentlyPlayed,
             onCheckedChange = viewModel::setShowRecentlyPlayed
         )
-        CardSwitchRow(
-            label           = "Dark mode",
-            checked         = state.darkMode,
-            onCheckedChange = viewModel::setDarkMode
+        Spacer(Modifier.height(10.dp))
+        Text(
+            "Appearance",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
         )
+        Spacer(Modifier.height(8.dp))
+        ThemePicker(selectedDark = state.darkMode, onSelect = viewModel::setDarkMode)
+    }
+}
+
+// ── Section: Sort Systems ─────────────────────────────────────────────────
+
+@Composable
+private fun SystemSortSection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    SettingsSectionHeader("Sort Systems")
+    SettingsCard {
+        Text(
+            "Choose how your consoles are ordered. Pick up to two — the first is the primary sort, the second breaks ties.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        com.gamelaunch.frontend.domain.platform.SystemSort.entries.forEach { sort ->
+            val rank = state.systemSort.indexOf(sort)   // -1 if not selected
+            val isSel = rank >= 0
+            val disabled = !isSel && state.systemSort.size >= 2
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 5.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable(enabled = !disabled) { viewModel.toggleSystemSort(sort) }
+                    .padding(vertical = 8.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    if (isSel) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                    contentDescription = null,
+                    tint = when {
+                        isSel    -> ElectricBlue
+                        disabled -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                        else     -> MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    sort.label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = if (disabled) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                            else MaterialTheme.colorScheme.onSurface,
+                    fontWeight = if (isSel) FontWeight.SemiBold else FontWeight.Normal
+                )
+                Spacer(Modifier.weight(1f))
+                if (isSel) {
+                    Box(
+                        modifier = Modifier
+                            .size(22.dp)
+                            .clip(RoundedCornerShape(50))
+                            .background(gradientBrush),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            "${rank + 1}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Two visual cards — Light / Dark — each previewing the UI, with the active one highlighted. */
+@Composable
+private fun ThemePicker(selectedDark: Boolean, onSelect: (Boolean) -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+        ThemeOption("Light", dark = false, selected = !selectedDark, onClick = { onSelect(false) }, modifier = Modifier.weight(1f))
+        ThemeOption("Dark",  dark = true,  selected = selectedDark,  onClick = { onSelect(true) },  modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun ThemeOption(
+    label: String,
+    dark: Boolean,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val accent      = ElectricBlue
+    val bg          = if (dark) Color(0xFF06091A) else Color(0xFFEDEFF4)
+    val cardColor   = if (dark) Color(0xFF172044) else Color(0xFFFFFFFF)
+    val barColors   = listOf(Color(0xFF7C8CFF), Color(0xFFB07BFF), Color(0xFFFF7AA8))
+    val tileShade   = if (dark) 0.55f else 0f
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(14.dp))
+            .border(
+                width = if (selected) 2.dp else 1.dp,
+                color = if (selected) accent else MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(14.dp)
+            )
+            .clickable(onClick = onClick)
+            .padding(8.dp)
+    ) {
+        // Mini UI mock-up: background, a top accent bar and three colourful tiles.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(74.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(bg)
+                .padding(7.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Box(
+                Modifier.fillMaxWidth(0.55f).height(7.dp)
+                    .clip(RoundedCornerShape(50)).background(accent)
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(5.dp), modifier = Modifier.fillMaxWidth()) {
+                barColors.forEach { c ->
+                    Box(
+                        Modifier.weight(1f).height(30.dp)
+                            .clip(RoundedCornerShape(5.dp))
+                            .background(androidx.compose.ui.graphics.lerp(c, Color.Black, tileShade))
+                    )
+                }
+            }
+            Box(
+                Modifier.fillMaxWidth(0.8f).height(6.dp)
+                    .clip(RoundedCornerShape(50)).background(cardColor)
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                if (selected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked,
+                contentDescription = null,
+                tint = if (selected) accent else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(Modifier.width(6.dp))
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
     }
 }
 
@@ -496,13 +660,11 @@ private fun EmulatorsSection(
 // ── Section: ScreenScraper ────────────────────────────────────────────────
 
 @Composable
-private fun ScreenScraperSection(
+private fun ScreenScraperBody(
     state: SettingsUiState,
     viewModel: SettingsViewModel,
     onScrapeAllClick: () -> Unit
 ) {
-    SettingsSectionHeader("ScreenScraper (Recommended)")
-    SettingsCard {
         Text(
             "ScreenScraper is the default scraper — it provides the best box art, screenshots, wheel logos, and video previews. " +
             "Create a free account at screenscraper.fr, then enter your username and password below. " +
@@ -591,15 +753,12 @@ private fun ScreenScraperSection(
             onClick  = onScrapeAllClick,
             modifier = Modifier.fillMaxWidth()
         )
-    }
 }
 
 // ── Section: Artwork Database ─────────────────────────────────────────────
 
 @Composable
-private fun ArtworkDatabaseSection(state: SettingsUiState, viewModel: SettingsViewModel) {
-    SettingsSectionHeader("Artwork Database")
-    SettingsCard {
+private fun ArtworkDatabaseBody(state: SettingsUiState, viewModel: SettingsViewModel) {
         Text(
             "LaunchBox DB — box art & screenshots. ~190 MB, one-time download. No account needed.",
             style = MaterialTheme.typography.bodySmall,
@@ -672,19 +831,16 @@ private fun ArtworkDatabaseSection(state: SettingsUiState, viewModel: SettingsVi
                 }
             }
         }
-    }
 }
 
 // ── Section: Media Import ─────────────────────────────────────────────────
 
 @Composable
-private fun MediaImportSection(
+private fun MediaImportBody(
     state: SettingsUiState,
     viewModel: SettingsViewModel,
     onPickMediaFolder: () -> Unit
 ) {
-    SettingsSectionHeader("Media Import")
-    SettingsCard {
         Text(
             "Point to your ES-DE downloaded_media folder to use art & videos you already scraped.",
             style = MaterialTheme.typography.bodySmall,
@@ -749,7 +905,6 @@ private fun MediaImportSection(
             }
             else -> {}
         }
-    }
 }
 
 // ── Section: RetroAchievements ────────────────────────────────────────────
@@ -840,6 +995,44 @@ private fun RetroAchievementsSection(state: SettingsUiState, viewModel: Settings
 }
 
 // ── Reusable design system components ─────────────────────────────────────
+
+/** Inline segmented control — connected pill segments, the selected one filled. */
+@Composable
+private fun SegmentedTabs(
+    options: List<String>,
+    selected: Int,
+    onSelect: (Int) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        options.forEachIndexed { i, label ->
+            val isSel = i == selected
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(9.dp))
+                    .then(if (isSel) Modifier.background(gradientBrush) else Modifier)
+                    .clickable { onSelect(i) }
+                    .padding(vertical = 9.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (isSel) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontWeight = if (isSel) FontWeight.SemiBold else FontWeight.Normal,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}
 
 @Composable
 private fun SettingsSectionHeader(title: String) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -507,6 +507,32 @@ fun SettingsScreen(
 
             Spacer(Modifier.height(4.dp))
 
+            // ── Android Games ──────────────────────────────────────────────
+            SettingsSectionHeader("Android Games")
+            SettingsCard {
+                Text(
+                    "Scan installed Android games (apps tagged as games) and add them to your library.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(10.dp))
+                GradientFillButton(
+                    text     = "Scan Android Games",
+                    onClick  = { viewModel.scanAndroidGames() },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                state.androidScanResult?.let { result ->
+                    Spacer(Modifier.height(6.dp))
+                    StatusRow(
+                        icon  = Icons.Default.Check,
+                        text  = result,
+                        color = ElectricBlue
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(4.dp))
+
             // ── Display ────────────────────────────────────────────────────
             SettingsSectionHeader("Display")
             SettingsCard {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -73,10 +73,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.GameColorScheme
+import com.gamelaunch.frontend.ui.theme.GameLightColorScheme
 import com.gamelaunch.frontend.ui.theme.LayoutMode
-import com.gamelaunch.frontend.ui.theme.NavyBorder
-import com.gamelaunch.frontend.ui.theme.NavyCard
-import com.gamelaunch.frontend.ui.theme.NavySurface
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 import com.gamelaunch.frontend.util.StorageUtils
 
@@ -131,6 +131,11 @@ fun SettingsScreen(
         }
     }
 
+    // Honour the user's light/dark choice locally — the rest of the app keeps the dark
+    // MaterialTheme and reads LocalDarkMode for its own colours, so we override only here.
+    val settingsScheme = if (LocalDarkMode.current) GameColorScheme else GameLightColorScheme
+
+    MaterialTheme(colorScheme = settingsScheme) {
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         snackbarHost = {
@@ -152,7 +157,7 @@ fun SettingsScreen(
                             modifier = Modifier
                                 .padding(8.dp)
                                 .size(36.dp)
-                                .background(Color.White.copy(alpha = 0.1f), CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
                         ) {
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowBack,
@@ -194,7 +199,7 @@ fun SettingsScreen(
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = NavySurface
+                    containerColor = MaterialTheme.colorScheme.surface
                 )
             )
         }
@@ -242,6 +247,7 @@ fun SettingsScreen(
             }
         }
     }
+    }
 }
 
 @Composable
@@ -263,7 +269,7 @@ private fun SettingsTabBar(selected: SettingsTab, onSelect: (SettingsTab) -> Uni
                     .clip(RoundedCornerShape(50))
                     .then(
                         if (isSel) Modifier.background(gradientBrush)
-                        else Modifier.background(Color.White.copy(alpha = 0.07f))
+                        else Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
                     )
                     .clickable { onSelect(tab) }
                     .padding(horizontal = 14.dp, vertical = 9.dp)
@@ -334,7 +340,7 @@ private fun RomLibrarySection(
                         modifier = Modifier
                             .weight(1f)
                             .clip(RoundedCornerShape(10.dp))
-                            .background(NavyCard)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
                             .clickable { viewModel.setRomRootPath(path) }
                             .padding(horizontal = 12.dp, vertical = 10.dp),
                         contentAlignment = Alignment.Center
@@ -357,7 +363,7 @@ private fun RomLibrarySection(
                 singleLine  = true,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor   = ElectricBlue,
-                    unfocusedBorderColor = NavyBorder
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline
                 )
             )
             Spacer(Modifier.width(8.dp))
@@ -365,7 +371,7 @@ private fun RomLibrarySection(
                 onClick  = onPickRomFolder,
                 modifier = Modifier
                     .size(48.dp)
-                    .background(NavyCard, RoundedCornerShape(10.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(10.dp))
             ) {
                 Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
             }
@@ -480,7 +486,7 @@ private fun ScreenScraperSection(
             singleLine    = true,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor   = ElectricBlue,
-                unfocusedBorderColor = NavyBorder
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline
             )
         )
         Spacer(Modifier.height(8.dp))
@@ -493,7 +499,7 @@ private fun ScreenScraperSection(
             singleLine             = true,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor   = ElectricBlue,
-                unfocusedBorderColor = NavyBorder
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline
             )
         )
         Spacer(Modifier.height(10.dp))
@@ -661,7 +667,7 @@ private fun MediaImportSection(
                 singleLine    = true,
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor   = ElectricBlue,
-                    unfocusedBorderColor = NavyBorder
+                    unfocusedBorderColor = MaterialTheme.colorScheme.outline
                 )
             )
             Spacer(Modifier.width(8.dp))
@@ -669,7 +675,7 @@ private fun MediaImportSection(
                 onClick  = onPickMediaFolder,
                 modifier = Modifier
                     .size(48.dp)
-                    .background(NavyCard, RoundedCornerShape(10.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(10.dp))
             ) {
                 Icon(Icons.Default.FolderOpen, contentDescription = "Browse", tint = ElectricBlue)
             }
@@ -733,7 +739,7 @@ private fun RetroAchievementsSection(state: SettingsUiState, viewModel: Settings
             singleLine    = true,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor   = ElectricBlue,
-                unfocusedBorderColor = NavyBorder
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline
             )
         )
         Spacer(Modifier.height(8.dp))
@@ -746,7 +752,7 @@ private fun RetroAchievementsSection(state: SettingsUiState, viewModel: Settings
             singleLine           = true,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor   = ElectricBlue,
-                unfocusedBorderColor = NavyBorder
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline
             )
         )
         Spacer(Modifier.height(10.dp))
@@ -794,7 +800,7 @@ private fun RetroAchievementsSection(state: SettingsUiState, viewModel: Settings
             singleLine           = true,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor   = ElectricBlue,
-                unfocusedBorderColor = NavyBorder
+                unfocusedBorderColor = MaterialTheme.colorScheme.outline
             )
         )
     }
@@ -817,7 +823,7 @@ private fun SettingsCard(content: @Composable () -> Unit) {
     Card(
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(16.dp),
-        colors    = CardDefaults.cardColors(containerColor = NavySurface),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(0.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -828,7 +834,7 @@ private fun SettingsCard(content: @Composable () -> Unit) {
 
 @Composable
 private fun CardDivider() {
-    HorizontalDivider(color = NavyBorder.copy(alpha = 0.6f), thickness = 0.5.dp)
+    HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.6f), thickness = 0.5.dp)
 }
 
 @Composable
@@ -851,8 +857,8 @@ private fun CardSwitchRow(
             colors = SwitchDefaults.colors(
                 checkedThumbColor       = Color.White,
                 checkedTrackColor       = ElectricBlue,
-                uncheckedThumbColor     = NavyBorder,
-                uncheckedTrackColor     = NavyCard
+                uncheckedThumbColor     = MaterialTheme.colorScheme.outline,
+                uncheckedTrackColor     = MaterialTheme.colorScheme.surfaceVariant
             )
         )
     }
@@ -905,7 +911,7 @@ private fun GradientOutlineButton(
         modifier = modifier
             .height(46.dp)
             .clip(RoundedCornerShape(23.dp))
-            .background(Color.White.copy(alpha = 0.07f))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
             .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -196,33 +196,37 @@ fun SettingsScreen(
                     }
                 },
                 actions = {
-                    // Gradient "Go to Library" button — also persists any typed ScreenScraper creds.
-                    Box(
-                        modifier = Modifier
-                            .padding(end = 12.dp)
-                            .clip(RoundedCornerShape(50))
-                            .background(gradientBrush)
-                            .clickable {
-                                viewModel.saveCredentials()
-                                viewModel.finishSetup()
-                                onGoToLibrary()
+                    // Only shown during first-launch setup (no back button yet) so the user has a
+                    // way to finish and enter the library. When opened from the library the back
+                    // button already covers this, so the redundant action is hidden.
+                    if (onBack == null) {
+                        Box(
+                            modifier = Modifier
+                                .padding(end = 12.dp)
+                                .clip(RoundedCornerShape(50))
+                                .background(gradientBrush)
+                                .clickable {
+                                    viewModel.saveCredentials()
+                                    viewModel.finishSetup()
+                                    onGoToLibrary()
+                                }
+                                .padding(horizontal = 14.dp, vertical = 8.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    "Library",
+                                    style  = MaterialTheme.typography.labelLarge,
+                                    color  = Color.White
+                                )
+                                Spacer(Modifier.width(4.dp))
+                                Icon(
+                                    Icons.AutoMirrored.Filled.ArrowForward,
+                                    contentDescription = null,
+                                    tint     = Color.White,
+                                    modifier = Modifier.size(14.dp)
+                                )
                             }
-                            .padding(horizontal = 14.dp, vertical = 8.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                "Library",
-                                style  = MaterialTheme.typography.labelLarge,
-                                color  = Color.White
-                            )
-                            Spacer(Modifier.width(4.dp))
-                            Icon(
-                                Icons.AutoMirrored.Filled.ArrowForward,
-                                contentDescription = null,
-                                tint     = Color.White,
-                                modifier = Modifier.size(14.dp)
-                            )
                         }
                     }
                 },

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
 import com.gamelaunch.frontend.domain.repository.ScraperRepository
+import com.gamelaunch.frontend.domain.platform.SystemSort
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.ImportEsdeMediaUseCase
@@ -52,7 +53,8 @@ data class SettingsUiState(
     val mediaFolderPath: String = "",
     val esdeImportStatus: EsdeImportStatus? = null,
     val showRecentlyPlayed: Boolean = true,
-    val darkMode: Boolean = false
+    val darkMode: Boolean = false,
+    val systemSort: List<SystemSort> = emptyList()
 )
 
 @HiltViewModel
@@ -93,16 +95,23 @@ class SettingsViewModel @Inject constructor(
                     videoDelayMs = delay,
                     videoMuted = muted
                 )
-            }.collect { newState ->
+            }.collect { owned ->
+                // Merge only the fields this combine owns; everything else (darkMode, systemSort,
+                // RA creds, etc.) is collected separately and must be preserved.
                 _uiState.update { current ->
-                    newState.copy(
-                        emulatorDetecting = current.emulatorDetecting,
-                        emulatorDetectResult = current.emulatorDetectResult,
-                        lbSyncStatus = current.lbSyncStatus,
-                        lbGameCount = current.lbGameCount,
-                        mediaFolderPath = current.mediaFolderPath,
-                        esdeImportStatus = current.esdeImportStatus,
-                        showRecentlyPlayed = current.showRecentlyPlayed
+                    current.copy(
+                        romRootPath = owned.romRootPath,
+                        ssId = owned.ssId,
+                        ssPassword = owned.ssPassword,
+                        layoutMode = owned.layoutMode,
+                        scrapeMetadata = owned.scrapeMetadata,
+                        scrapeBoxArt = owned.scrapeBoxArt,
+                        scrapeScreenshots = owned.scrapeScreenshots,
+                        scrapeWheelLogos = owned.scrapeWheelLogos,
+                        scrapeVideos = owned.scrapeVideos,
+                        preferredRegion = owned.preferredRegion,
+                        videoDelayMs = owned.videoDelayMs,
+                        videoMuted = owned.videoMuted
                     )
                 }
             }
@@ -128,6 +137,11 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.systemSort.collect { sorts ->
+                _uiState.update { it.copy(systemSort = sorts) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.raUsername.collect { u ->
                 _uiState.update { it.copy(raUsername = u) }
             }
@@ -150,6 +164,17 @@ class SettingsViewModel @Inject constructor(
 
     fun setDarkMode(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setDarkMode(enabled) }
+    }
+
+    /** Toggle a system-sort key. Selected keys are an ordered list of up to two (primary first). */
+    fun toggleSystemSort(sort: SystemSort) {
+        val current = _uiState.value.systemSort
+        val next = when {
+            sort in current      -> current - sort
+            current.size < 2     -> current + sort
+            else                 -> current   // already two — deselect one first
+        }
+        viewModelScope.launch { settingsRepository.setSystemSort(next) }
     }
 
     fun updateRaUsername(value: String) = _uiState.update { it.copy(raUsername = value, raLoginResult = null) }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.ImportEsdeMediaUseCase
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
+import com.gamelaunch.frontend.domain.usecase.ScanAndroidGamesUseCase
 import com.gamelaunch.frontend.domain.usecase.SyncLaunchBoxUseCase
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,6 +23,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class SettingsUiState(
+    val androidScanResult: String? = null,
     val romRootPath: String = "",
     val ssId: String = "",
     val ssPassword: String = "",
@@ -52,6 +54,7 @@ class SettingsViewModel @Inject constructor(
     private val emulatorRepository: EmulatorRepository,
     private val syncLaunchBoxUseCase: SyncLaunchBoxUseCase,
     private val importEsdeMediaUseCase: ImportEsdeMediaUseCase,
+    private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
     private val launchBoxDao: LaunchBoxDao
 ) : ViewModel() {
 
@@ -225,6 +228,20 @@ class SettingsViewModel @Inject constructor(
 
     fun dismissLbSyncStatus() {
         _uiState.update { it.copy(lbSyncStatus = null) }
+    }
+
+    fun scanAndroidGames() {
+        viewModelScope.launch {
+            scanAndroidGamesUseCase().collect { progress ->
+                if (progress.scanned == progress.total) {
+                    _uiState.update { it.copy(androidScanResult = "Found ${progress.added} new Android game${if (progress.added != 1) "s" else ""}") }
+                }
+            }
+        }
+    }
+
+    fun clearAndroidScanResult() {
+        _uiState.update { it.copy(androidScanResult = null) }
     }
 
     fun finishSetup() {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.data.db.dao.LaunchBoxDao
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
+import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
 import com.gamelaunch.frontend.domain.repository.ScraperRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
@@ -28,8 +29,11 @@ data class SettingsUiState(
     val ssId: String = "",
     val ssPassword: String = "",
     val raUsername: String = "",
+    val raPassword: String = "",
     val raApiKey: String = "",
-    val raSaved: Boolean = false,
+    val raLoggingIn: Boolean = false,
+    val raLoginResult: String? = null,   // success or error message to surface
+    val raLoggedIn: Boolean = false,     // a token is stored
     val layoutMode: LayoutMode = LayoutMode.CAROUSEL,
     val scrapeBoxArt: Boolean = true,
     val scrapeScreenshots: Boolean = true,
@@ -58,6 +62,7 @@ class SettingsViewModel @Inject constructor(
     private val syncLaunchBoxUseCase: SyncLaunchBoxUseCase,
     private val importEsdeMediaUseCase: ImportEsdeMediaUseCase,
     private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
+    private val raRepository: RetroAchievementsRepository,
     private val launchBoxDao: LaunchBoxDao
 ) : ViewModel() {
 
@@ -130,6 +135,11 @@ class SettingsViewModel @Inject constructor(
                 _uiState.update { it.copy(raApiKey = k) }
             }
         }
+        viewModelScope.launch {
+            settingsRepository.raToken.collect { t ->
+                _uiState.update { it.copy(raLoggedIn = t.isNotBlank()) }
+            }
+        }
     }
 
     fun setShowRecentlyPlayed(enabled: Boolean) {
@@ -140,19 +150,60 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { settingsRepository.setDarkMode(enabled) }
     }
 
-    fun updateRaUsername(value: String) = _uiState.update { it.copy(raUsername = value, raSaved = false) }
-    fun updateRaApiKey(value: String) = _uiState.update { it.copy(raApiKey = value, raSaved = false) }
+    fun updateRaUsername(value: String) = _uiState.update { it.copy(raUsername = value, raLoginResult = null) }
+    fun updateRaPassword(value: String) = _uiState.update { it.copy(raPassword = value, raLoginResult = null) }
+    fun updateRaApiKey(value: String) = _uiState.update { it.copy(raApiKey = value, raLoginResult = null) }
 
+    /**
+     * Log in to RetroAchievements with username + password via the Connect API.
+     * On success we persist the username + token (never the raw password) plus the optional
+     * Web API key, which unlocks the full recently-played dashboard.
+     */
     fun saveRaCredentials() {
         val s = _uiState.value
+        val username = s.raUsername.trim()
+        val password = s.raPassword
+        if (username.isBlank() || password.isBlank()) {
+            _uiState.update { it.copy(raLoginResult = "Enter both username and password") }
+            return
+        }
+        _uiState.update { it.copy(raLoggingIn = true, raLoginResult = null) }
         viewModelScope.launch {
-            settingsRepository.setRaCredentials(s.raUsername.trim(), s.raApiKey.trim())
-            _uiState.update { it.copy(raSaved = true) }
+            // Persist the optional Web API key first so the dashboard can use it after login.
+            settingsRepository.setRaApiKey(s.raApiKey.trim())
+
+            val result = raRepository.login(username, password)
+            result.onSuccess { session ->
+                settingsRepository.setRaSession(
+                    username       = session.username,
+                    token          = session.token,
+                    points         = session.points,
+                    softcorePoints = session.softcorePoints
+                )
+                _uiState.update {
+                    it.copy(
+                        raLoggingIn  = false,
+                        raPassword   = "",   // clear from memory once exchanged for a token
+                        raLoginResult = "Signed in as ${session.username}"
+                    )
+                }
+            }.onFailure { e ->
+                _uiState.update {
+                    it.copy(raLoggingIn = false, raLoginResult = e.message ?: "Login failed")
+                }
+            }
         }
     }
 
-    fun clearRaSaved() {
-        _uiState.update { it.copy(raSaved = false) }
+    fun signOutRa() {
+        viewModelScope.launch {
+            settingsRepository.clearRaCredentials()
+            _uiState.update { it.copy(raPassword = "", raApiKey = "", raLoginResult = null) }
+        }
+    }
+
+    fun clearRaLoginResult() {
+        _uiState.update { it.copy(raLoginResult = null) }
     }
 
     fun updateSsId(value: String) = _uiState.update { it.copy(ssId = value, credentialValid = null) }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -27,6 +27,9 @@ data class SettingsUiState(
     val romRootPath: String = "",
     val ssId: String = "",
     val ssPassword: String = "",
+    val raUsername: String = "",
+    val raApiKey: String = "",
+    val raSaved: Boolean = false,
     val layoutMode: LayoutMode = LayoutMode.CAROUSEL,
     val scrapeBoxArt: Boolean = true,
     val scrapeScreenshots: Boolean = true,
@@ -117,6 +120,16 @@ class SettingsViewModel @Inject constructor(
                 _uiState.update { it.copy(darkMode = dark) }
             }
         }
+        viewModelScope.launch {
+            settingsRepository.raUsername.collect { u ->
+                _uiState.update { it.copy(raUsername = u) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.raApiKey.collect { k ->
+                _uiState.update { it.copy(raApiKey = k) }
+            }
+        }
     }
 
     fun setShowRecentlyPlayed(enabled: Boolean) {
@@ -125,6 +138,21 @@ class SettingsViewModel @Inject constructor(
 
     fun setDarkMode(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setDarkMode(enabled) }
+    }
+
+    fun updateRaUsername(value: String) = _uiState.update { it.copy(raUsername = value, raSaved = false) }
+    fun updateRaApiKey(value: String) = _uiState.update { it.copy(raApiKey = value, raSaved = false) }
+
+    fun saveRaCredentials() {
+        val s = _uiState.value
+        viewModelScope.launch {
+            settingsRepository.setRaCredentials(s.raUsername.trim(), s.raApiKey.trim())
+            _uiState.update { it.copy(raSaved = true) }
+        }
+    }
+
+    fun clearRaSaved() {
+        _uiState.update { it.copy(raSaved = false) }
     }
 
     fun updateSsId(value: String) = _uiState.update { it.copy(ssId = value, credentialValid = null) }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -35,6 +35,7 @@ data class SettingsUiState(
     val raLoginResult: String? = null,   // success or error message to surface
     val raLoggedIn: Boolean = false,     // a token is stored
     val layoutMode: LayoutMode = LayoutMode.CAROUSEL,
+    val scrapeMetadata: Boolean = true,
     val scrapeBoxArt: Boolean = true,
     val scrapeScreenshots: Boolean = true,
     val scrapeWheelLogos: Boolean = true,
@@ -83,6 +84,7 @@ class SettingsViewModel @Inject constructor(
                     ssId = config.ssid,
                     ssPassword = config.sspassword,
                     layoutMode = layout,
+                    scrapeMetadata = config.scrapeMetadata,
                     scrapeBoxArt = config.scrapeBoxArt,
                     scrapeScreenshots = config.scrapeScreenshots,
                     scrapeWheelLogos = config.scrapeWheelLogos,
@@ -255,6 +257,7 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch { settingsRepository.setLayoutMode(mode) }
     }
 
+    fun setScrapeMetadata(v: Boolean) = _uiState.update { it.copy(scrapeMetadata = v) }.also { saveOptions() }
     fun setScrapeBoxArt(v: Boolean) = _uiState.update { it.copy(scrapeBoxArt = v) }.also { saveOptions() }
     fun setScrapeScreenshots(v: Boolean) = _uiState.update { it.copy(scrapeScreenshots = v) }.also { saveOptions() }
     fun setScrapeWheelLogos(v: Boolean) = _uiState.update { it.copy(scrapeWheelLogos = v) }.also { saveOptions() }
@@ -263,7 +266,9 @@ class SettingsViewModel @Inject constructor(
     private fun saveOptions() {
         val s = _uiState.value
         viewModelScope.launch {
-            settingsRepository.updateScraperOptions(s.scrapeBoxArt, s.scrapeScreenshots, s.scrapeWheelLogos, s.scrapeVideos)
+            settingsRepository.updateScraperOptions(
+                s.scrapeMetadata, s.scrapeBoxArt, s.scrapeScreenshots, s.scrapeWheelLogos, s.scrapeVideos
+            )
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -41,7 +41,8 @@ data class SettingsUiState(
     val lbGameCount: Int = 0,
     val mediaFolderPath: String = "",
     val esdeImportStatus: EsdeImportStatus? = null,
-    val showRecentlyPlayed: Boolean = true
+    val showRecentlyPlayed: Boolean = true,
+    val darkMode: Boolean = false
 )
 
 @HiltViewModel
@@ -108,10 +109,19 @@ class SettingsViewModel @Inject constructor(
                 _uiState.update { it.copy(showRecentlyPlayed = show) }
             }
         }
+        viewModelScope.launch {
+            settingsRepository.darkMode.collect { dark ->
+                _uiState.update { it.copy(darkMode = dark) }
+            }
+        }
     }
 
     fun setShowRecentlyPlayed(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setShowRecentlyPlayed(enabled) }
+    }
+
+    fun setDarkMode(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setDarkMode(enabled) }
     }
 
     fun updateSsId(value: String) = _uiState.update { it.copy(ssId = value, credentialValid = null) }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
@@ -3,6 +3,7 @@ package com.gamelaunch.frontend.ui.theme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
@@ -21,7 +22,7 @@ val IceWhite     = Color(0xFFE8EDF8)
 val SteelGray    = Color(0xFF8899C0)
 val NavyBorder   = Color(0xFF253060)
 
-private val GameColorScheme = darkColorScheme(
+val GameColorScheme = darkColorScheme(
     primary              = ElectricBlue,
     onPrimary            = Color.White,
     primaryContainer     = Color(0xFF1A2F5C),
@@ -46,6 +47,33 @@ private val GameColorScheme = darkColorScheme(
     outlineVariant       = Color(0xFF182045),
     surfaceTint          = ElectricBlue,
     scrim                = Color(0xCC000000)
+)
+
+// Light counterpart — used by screens that opt into the user's light/dark choice
+// (e.g. Settings wraps itself in this when LocalDarkMode is false).
+val GameLightColorScheme = lightColorScheme(
+    primary              = ElectricBlue,
+    onPrimary            = Color.White,
+    primaryContainer     = Color(0xFFD8E2FF),
+    onPrimaryContainer   = Color(0xFF001A41),
+    secondary            = NeonPurple,
+    onSecondary          = Color.White,
+    secondaryContainer   = Color(0xFFEADDFF),
+    onSecondaryContainer = Color(0xFF24005A),
+    tertiary             = Color(0xFF0091B3),
+    onTertiary           = Color.White,
+    error                = Color(0xFFD23B4E),
+    onError              = Color.White,
+    background           = LightBg,
+    onBackground         = TileText,
+    surface              = Color(0xFFFFFFFF),
+    onSurface            = TileText,
+    surfaceVariant       = Color(0xFFE4E8F1),
+    onSurfaceVariant     = TileSub,
+    outline              = Color(0xFFC4CCDB),
+    outlineVariant       = Color(0xFFD7DDE9),
+    surfaceTint          = ElectricBlue,
+    scrim                = Color(0x66000000)
 )
 
 private val GameTypography = Typography(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -63,10 +64,15 @@ private val GameTypography = Typography(
 )
 
 @Composable
-fun AppTheme(content: @Composable () -> Unit) {
-    MaterialTheme(
-        colorScheme = GameColorScheme,
-        typography  = GameTypography,
-        content     = content
-    )
+fun AppTheme(
+    darkMode: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    CompositionLocalProvider(LocalDarkMode provides darkMode) {
+        MaterialTheme(
+            colorScheme = GameColorScheme,
+            typography  = GameTypography,
+            content     = content
+        )
+    }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
@@ -104,3 +104,18 @@ fun AppTheme(
         )
     }
 }
+
+/**
+ * Wrap a screen so its Material colours follow the user's light/dark choice. The app's root
+ * MaterialTheme stays dark and most screens read [LocalDarkMode] for their own colours; screens
+ * built largely from Material components (Settings, detail, scan, etc.) wrap their content in this
+ * so TopAppBar / Card / OutlinedTextField / Text adapt automatically.
+ */
+@Composable
+fun ThemedScreen(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = if (LocalDarkMode.current) GameColorScheme else GameLightColorScheme,
+        typography  = GameTypography,
+        content     = content
+    )
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
@@ -137,10 +137,11 @@ fun Modifier.glassChip(
     accent: Color = BrandBlue
 ): Modifier {
     val dark = LocalDarkMode.current
+    // Opaque fills so the drop shadow stays behind the chip instead of bleeding through it.
     val unselectedGradient = if (dark)
-        listOf(Color.White.copy(alpha = 0.16f), Color.White.copy(alpha = 0.08f))
+        listOf(Color(0xFF1E2A4D), Color(0xFF161F3C))
     else
-        listOf(Color.White.copy(alpha = 0.72f), Color.White.copy(alpha = 0.48f))
+        listOf(Color(0xFFFFFFFF), Color(0xFFEDF0F7))
     val shadowColor = if (selected) accent else if (dark) Color(0xFF000820) else Color(0xFF2A3550)
     return this
         .shadow(
@@ -160,7 +161,8 @@ fun Modifier.glassChip(
         .border(
             width = 1.dp,
             brush = Brush.verticalGradient(
-                listOf(Color.White.copy(alpha = 0.9f), Color.White.copy(alpha = 0.3f))
+                if (dark) listOf(Color.White.copy(alpha = 0.22f), Color.White.copy(alpha = 0.06f))
+                else listOf(Color.White.copy(alpha = 0.9f), Color.White.copy(alpha = 0.3f))
             ),
             shape = shape
         )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
@@ -17,6 +18,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.dp
+
+/** Provided at the root by AppTheme; read anywhere in the tree to choose light vs. dark colours. */
+val LocalDarkMode = compositionLocalOf { false }
 
 // ── Light, playful liquid-glass + 3DS palette ───────────────────────────────
 val LightBg   = Color(0xFFEDEFF4)   // very light cool grey base
@@ -41,16 +45,18 @@ fun tileColor(index: Int): Color = TilePalette[index % TilePalette.size]
 val BounceEasing = CubicBezierEasing(0.34f, 1.8f, 0.45f, 1f)
 const val BounceDurationMs = 420
 
-/** Soft pastel ambient over a light grey base — gentle colour washes for depth. */
+/** Ambient background — light pastels in light mode, dark navy glows in dark mode. */
 @Composable
 fun AmbientBackground(
     modifier: Modifier = Modifier,
     content: @Composable BoxScope.() -> Unit
 ) {
+    val dark = LocalDarkMode.current
+    val bg = if (dark) NavyBg else LightBg
     Box(
         modifier
             .fillMaxSize()
-            .background(LightBg)
+            .background(bg)
             .drawBehind {
                 fun glow(color: Color, cx: Float, cy: Float, r: Float) = drawRect(
                     Brush.radialGradient(
@@ -59,10 +65,16 @@ fun AmbientBackground(
                         radius = size.minDimension * r
                     )
                 )
-                glow(Color(0xFF6FC4FF).copy(alpha = 0.22f), 0.08f, 0.02f, 0.95f)
-                glow(Color(0xFFB58CFF).copy(alpha = 0.20f), 0.98f, 0.08f, 1.05f)
-                glow(Color(0xFF59E0B8).copy(alpha = 0.16f), 0.55f, 1.05f, 1.05f)
-                glow(Color(0xFFFF9CC0).copy(alpha = 0.14f), 0.18f, 0.95f, 0.75f)
+                if (dark) {
+                    glow(Color(0xFF3D6FFF).copy(alpha = 0.18f), 0.08f, 0.02f, 0.95f)
+                    glow(Color(0xFF7B4FFF).copy(alpha = 0.15f), 0.98f, 0.08f, 1.05f)
+                    glow(Color(0xFF00CFFF).copy(alpha = 0.10f), 0.55f, 1.05f, 1.05f)
+                } else {
+                    glow(Color(0xFF6FC4FF).copy(alpha = 0.22f), 0.08f, 0.02f, 0.95f)
+                    glow(Color(0xFFB58CFF).copy(alpha = 0.20f), 0.98f, 0.08f, 1.05f)
+                    glow(Color(0xFF59E0B8).copy(alpha = 0.16f), 0.55f, 1.05f, 1.05f)
+                    glow(Color(0xFFFF9CC0).copy(alpha = 0.14f), 0.18f, 0.95f, 0.75f)
+                }
             },
         content = content
     )
@@ -102,32 +114,41 @@ fun Modifier.glassTile(
 }
 
 /**
- * Neutral frosted chip for tabs and icon buttons. Frosted white by default; an accent fill when
- * selected.
+ * Neutral frosted chip for tabs and icon buttons. Frosted white in light mode, frosted dark in
+ * dark mode; accent fill when selected.
  */
+@Composable
 fun Modifier.glassChip(
     shape: Shape,
     selected: Boolean = false,
     accent: Color = BrandBlue
-): Modifier = this
-    .shadow(
-        elevation = if (selected) 10.dp else 3.dp,
-        shape = shape,
-        ambientColor = if (selected) accent else Color(0xFF2A3550),
-        spotColor = if (selected) accent else Color(0xFF2A3550),
-        clip = false
-    )
-    .clip(shape)
-    .background(
-        Brush.verticalGradient(
-            if (selected) listOf(accent.copy(alpha = 0.95f), accent.copy(alpha = 0.78f))
-            else listOf(Color.White.copy(alpha = 0.72f), Color.White.copy(alpha = 0.48f))
+): Modifier {
+    val dark = LocalDarkMode.current
+    val unselectedGradient = if (dark)
+        listOf(Color.White.copy(alpha = 0.16f), Color.White.copy(alpha = 0.08f))
+    else
+        listOf(Color.White.copy(alpha = 0.72f), Color.White.copy(alpha = 0.48f))
+    val shadowColor = if (selected) accent else if (dark) Color(0xFF000820) else Color(0xFF2A3550)
+    return this
+        .shadow(
+            elevation = if (selected) 10.dp else 3.dp,
+            shape = shape,
+            ambientColor = shadowColor,
+            spotColor = shadowColor,
+            clip = false
         )
-    )
-    .border(
-        width = 1.dp,
-        brush = Brush.verticalGradient(
-            listOf(Color.White.copy(alpha = 0.9f), Color.White.copy(alpha = 0.3f))
-        ),
-        shape = shape
-    )
+        .clip(shape)
+        .background(
+            Brush.verticalGradient(
+                if (selected) listOf(accent.copy(alpha = 0.95f), accent.copy(alpha = 0.78f))
+                else unselectedGradient
+            )
+        )
+        .border(
+            width = 1.dp,
+            brush = Brush.verticalGradient(
+                listOf(Color.White.copy(alpha = 0.9f), Color.White.copy(alpha = 0.3f))
+            ),
+            shape = shape
+        )
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
@@ -82,33 +82,46 @@ fun AmbientBackground(
 
 /**
  * Colourful glass tile: a solid colour fill with a soft top-to-bottom sheen, a thin bright edge
- * highlight and a soft floating shadow (colour-tinted when focused). Unselected tiles use a light
- * pastel shade; focused tiles deepen to the full colour and lift, 3DS-style. The fill is opaque so
- * the shadow never bleeds through.
+ * highlight and a soft floating shadow (colour-tinted when focused). In light mode unselected tiles
+ * use a light pastel shade; in dark mode they use a darker shade of the same colour so the cards
+ * match the dark theme. Focused tiles deepen to the full colour and lift, 3DS-style. The fill is
+ * opaque so the shadow never bleeds through.
  */
+@Composable
 fun Modifier.glassTile(
     shape: Shape,
     color: Color,
     selected: Boolean = false
 ): Modifier {
-    val base = if (selected) color else lerp(color, Color.White, 0.5f)
+    val dark = LocalDarkMode.current
+
+    // Light: unselected tiles lighten toward white (pastel). Dark: tiles darken toward black so
+    // they read as a darker shade of the same colour and sit naturally on the dark background.
+    val base = if (dark) {
+        if (selected) lerp(color, Color.Black, 0.15f) else lerp(color, Color.Black, 0.60f)
+    } else {
+        if (selected) color else lerp(color, Color.White, 0.5f)
+    }
+    val sheen        = lerp(base, Color.White, if (dark) 0.10f else 0.18f)
+    val borderTop    = Color.White.copy(alpha = if (dark) 0.18f else 0.5f)
+    val borderBottom = Color.White.copy(alpha = if (dark) 0.04f else 0.1f)
+    val restShadow   = if (dark) Color(0xFF000820) else Color(0xFF2A3550)
+
     return this
         .shadow(
             elevation = if (selected) 18.dp else 7.dp,
             shape = shape,
-            ambientColor = if (selected) color else Color(0xFF2A3550),
-            spotColor = if (selected) color else Color(0xFF2A3550),
+            ambientColor = if (selected) color else restShadow,
+            spotColor = if (selected) color else restShadow,
             clip = false
         )
         .clip(shape)
         .background(
-            Brush.verticalGradient(listOf(lerp(base, Color.White, 0.18f), base))
+            Brush.verticalGradient(listOf(sheen, base))
         )
         .border(
             width = 1.dp,
-            brush = Brush.verticalGradient(
-                listOf(Color.White.copy(alpha = 0.5f), Color.White.copy(alpha = 0.1f))
-            ),
+            brush = Brush.verticalGradient(listOf(borderTop, borderBottom)),
             shape = shape
         )
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -2,7 +2,9 @@ package com.gamelaunch.frontend.ui.theme.grid
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,6 +32,8 @@ import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.theme.BounceDurationMs
+import com.gamelaunch.frontend.ui.theme.BounceEasing
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 import kotlinx.coroutines.delay
@@ -57,11 +62,20 @@ fun GridGameCard(
         }
     }
 
+    // Focused card pops with the same bounce-scale as the console cards.
+    val scale by animateFloatAsState(
+        targetValue   = if (isFocused) 1.07f else 1f,
+        animationSpec = tween(durationMillis = BounceDurationMs, easing = BounceEasing),
+        label = "gridGameScale"
+    )
+
     Box(
         modifier = Modifier
             .graphicsLayer {
                 translationY = (1f - enter.value) * 72.dp.toPx()
                 alpha = enter.value.coerceIn(0f, 1f)
+                scaleX = scale
+                scaleY = scale
             }
             .then(
                 if (isFocused)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -39,15 +39,22 @@ fun GridGameCard(
     index: Int = 0,
     media: GameMedia? = null,
     isFocused: Boolean = false,
+    animateOnEntry: Boolean = true,
     onClick: () -> Unit
 ) {
     val shape = RoundedCornerShape(12.dp)
 
     // Entrance: rise up from the bottom with a slight spring bounce, staggered by position.
-    val enter = remember { Animatable(0f) }
+    // Only the cards present when the system loads should animate — capture that decision at
+    // first composition so cards recycled into view while scrolling appear instantly instead
+    // of re-playing the rise.
+    val shouldAnimate = remember { animateOnEntry }
+    val enter = remember { Animatable(if (shouldAnimate) 0f else 1f) }
     LaunchedEffect(Unit) {
-        delay(index.coerceAtMost(18) * 28L)
-        enter.animateTo(1f, spring(dampingRatio = 0.58f, stiffness = Spring.StiffnessMediumLow))
+        if (shouldAnimate) {
+            delay(index.coerceAtMost(18) * 28L)
+            enter.animateTo(1f, spring(dampingRatio = 0.58f, stiffness = Spring.StiffnessMediumLow))
+        }
     }
 
     Box(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -11,11 +11,16 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
+import kotlinx.coroutines.delay
 
 @Composable
 fun GridHomeContent(
@@ -42,6 +47,16 @@ fun GridHomeContent(
         }
     }
 
+    // The entrance animation should fire once, when we load into a system — not every time a
+    // card is recycled into view on scroll. Keep a short window open right after the games list
+    // changes; cards composed during it animate, cards composed later appear instantly.
+    var entranceWindowOpen by remember(games) { mutableStateOf(true) }
+    LaunchedEffect(games) {
+        entranceWindowOpen = true
+        delay(900L)   // long enough for the staggered rise of the initially-visible cards
+        entranceWindowOpen = false
+    }
+
     LazyVerticalGrid(
         columns               = GridCells.Fixed(columns),
         state                 = gridState,
@@ -52,11 +67,12 @@ fun GridHomeContent(
     ) {
         itemsIndexed(games, key = { _, g -> g.id }) { index, game ->
             GridGameCard(
-                game      = game,
-                index     = index,
-                media     = mediaForGames[game.id],
-                isFocused = index == focusedGameIndex,
-                onClick   = { onGameClick(game.id) }
+                game           = game,
+                index          = index,
+                media          = mediaForGames[game.id],
+                isFocused      = index == focusedGameIndex,
+                animateOnEntry = entranceWindowOpen,
+                onClick        = { onGameClick(game.id) }
             )
         }
     }

--- a/app/src/main/res/drawable/ic_sys_android.xml
+++ b/app/src/main/res/drawable/ic_sys_android.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android Games — game controller in front of an Android device. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp" android:height="120dp"
+    android:viewportWidth="600" android:viewportHeight="600">
+
+    <!-- Phone body -->
+    <path android:fillColor="#3DDC84"
+          android:pathData="M200,60 L400,60 Q430,60 430,90 L430,510 Q430,540 400,540 L200,540 Q170,540 170,510 L170,90 Q170,60 200,60 Z"/>
+
+    <!-- Screen area -->
+    <path android:fillColor="#1A1A2E"
+          android:pathData="M190,110 L410,110 L410,460 L190,460 Z"/>
+
+    <!-- Home indicator -->
+    <path android:fillColor="#2EAA6C"
+          android:pathData="M270,480 L330,480 Q335,480 335,485 L335,495 Q335,500 330,500 L270,500 Q265,500 265,495 L265,485 Q265,480 270,480 Z"/>
+
+    <!-- Camera dot -->
+    <path android:fillColor="#2EAA6C"
+          android:pathData="M300,80 m-8,0 a8,8 0 1 0 16,0 a8,8 0 1 0 -16,0"/>
+
+    <!-- Game controller on screen -->
+    <!-- Controller body -->
+    <path android:fillColor="#4D7FFF"
+          android:pathData="M225,200 L375,200 Q390,200 395,215 L410,255 Q415,270 405,278 L380,295 Q368,302 365,318 L365,345 L235,345 L235,318 Q232,302 220,295 L195,278 Q185,270 190,255 L205,215 Q210,200 225,200 Z"/>
+
+    <!-- Left grip -->
+    <path android:fillColor="#3E7BFF"
+          android:pathData="M205,235 L188,265 Q180,280 185,298 L200,316 L228,302 L228,235 Z"/>
+
+    <!-- Right grip -->
+    <path android:fillColor="#3E7BFF"
+          android:pathData="M395,235 L412,265 Q420,280 415,298 L400,316 L372,302 L372,235 Z"/>
+
+    <!-- Left stick -->
+    <path android:fillColor="#1E3F6F"
+          android:pathData="M256,248 m-18,0 a18,18 0 1 0 36,0 a18,18 0 1 0 -36,0"/>
+
+    <!-- Right stick -->
+    <path android:fillColor="#1E3F6F"
+          android:pathData="M340,292 m-18,0 a18,18 0 1 0 36,0 a18,18 0 1 0 -36,0"/>
+
+    <!-- A button (green) -->
+    <path android:fillColor="#3DDC84"
+          android:pathData="M368,242 m-9,0 a9,9 0 1 0 18,0 a9,9 0 1 0 -18,0"/>
+
+    <!-- B button (red) -->
+    <path android:fillColor="#FF3C28"
+          android:pathData="M387,261 m-9,0 a9,9 0 1 0 18,0 a9,9 0 1 0 -18,0"/>
+
+    <!-- X button (blue) -->
+    <path android:fillColor="#0AB9E6"
+          android:pathData="M349,261 m-9,0 a9,9 0 1 0 18,0 a9,9 0 1 0 -18,0"/>
+
+    <!-- Y button (yellow) -->
+    <path android:fillColor="#FFDD00"
+          android:pathData="M368,280 m-9,0 a9,9 0 1 0 18,0 a9,9 0 1 0 -18,0"/>
+</vector>

--- a/app/src/main/res/drawable/ic_sys_steam.xml
+++ b/app/src/main/res/drawable/ic_sys_steam.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- PC / Steam — flat monitor with a game controller on-screen. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="120dp" android:height="120dp"
+    android:viewportWidth="600" android:viewportHeight="600">
+
+    <!-- Monitor bezel -->
+    <path android:fillColor="#2B2B2B"
+          android:pathData="M80,100 L520,100 Q540,100 540,120 L540,390 Q540,410 520,410 L80,410 Q60,410 60,390 L60,120 Q60,100 80,100 Z"/>
+
+    <!-- Screen (blue-grey) -->
+    <path android:fillColor="#1A3A5C"
+          android:pathData="M90,120 L510,120 L510,390 L90,390 Z"/>
+
+    <!-- Monitor stand / neck -->
+    <path android:fillColor="#2B2B2B"
+          android:pathData="M280,410 L320,410 L320,460 L280,460 Z"/>
+
+    <!-- Monitor base -->
+    <path android:fillColor="#2B2B2B"
+          android:pathData="M200,460 L400,460 Q410,460 410,470 L410,485 Q410,495 400,495 L200,495 Q190,495 190,485 L190,470 Q190,460 200,460 Z"/>
+
+    <!-- Controller body on screen -->
+    <path android:fillColor="#4D7FFF"
+          android:pathData="M210,220 L390,220 Q400,220 405,230 L420,270 Q425,282 415,290 L385,315 Q375,322 370,335 L370,360 L230,360 L230,335 Q225,322 215,315 L185,290 Q175,282 180,270 L195,230 Q200,220 210,220 Z"/>
+
+    <!-- Left grip -->
+    <path android:fillColor="#3E7BFF"
+          android:pathData="M195,255 L175,285 Q165,300 170,320 L185,340 L215,325 L215,255 Z"/>
+
+    <!-- Right grip -->
+    <path android:fillColor="#3E7BFF"
+          android:pathData="M405,255 L425,285 Q435,300 430,320 L415,340 L385,325 L385,255 Z"/>
+
+    <!-- Left analog stick -->
+    <path android:fillColor="#1E3F6F"
+          android:pathData="M255,265 m-22,0 a22,22 0 1 0 44,0 a22,22 0 1 0 -44,0"/>
+
+    <!-- Right analog stick -->
+    <path android:fillColor="#1E3F6F"
+          android:pathData="M340,305 m-22,0 a22,22 0 1 0 44,0 a22,22 0 1 0 -44,0"/>
+
+    <!-- Face buttons (A B X Y) -->
+    <path android:fillColor="#0AB9E6"
+          android:pathData="M360,255 m-11,0 a11,11 0 1 0 22,0 a11,11 0 1 0 -22,0"/>
+    <path android:fillColor="#FF3C28"
+          android:pathData="M382,277 m-11,0 a11,11 0 1 0 22,0 a11,11 0 1 0 -22,0"/>
+    <path android:fillColor="#FFDD00"
+          android:pathData="M338,277 m-11,0 a11,11 0 1 0 22,0 a11,11 0 1 0 -22,0"/>
+    <path android:fillColor="#3FD3A6"
+          android:pathData="M360,299 m-11,0 a11,11 0 1 0 22,0 a11,11 0 1 0 -22,0"/>
+
+    <!-- Center button (Steam-like circle) -->
+    <path android:fillColor="#FFFFFF"
+          android:pathData="M300,285 m-16,0 a16,16 0 1 0 32,0 a16,16 0 1 0 -32,0"/>
+    <path android:fillColor="#4D7FFF"
+          android:pathData="M300,285 m-9,0 a9,9 0 1 0 18,0 a9,9 0 1 0 -18,0"/>
+</vector>


### PR DESCRIPTION
Brings `main` up to date with everything shipped through **v1.3.0** (28 commits).

## Highlights since v1.1.x
- **RetroAchievements** tab (username/password sign-in + optional API key)
- **ScreenScraper** as default scraper (dev account), Scrape Now, metadata toggle, skip-already-complete
- **Settings** redesigned into General / Media / Games / RetroAchievements tabs (L1/R1 navigable)
- **Light/Dark theming** across all screens + visual theme picker + darker console cards in dark mode
- **System sorting** (alphabetical / release date / console type / brand / number of games, dual sort)
- **Media tab** consolidated into one segmented card
- **Android games scan** finds store games (category-based detection)
- **Dolphin** GameCube/Wii auto-boot via AutoStartFile intent
- **Back navigation** from detail → grid → systems with preserved scroll/selection
- Hold-to-scroll release fix, fan-art reshuffle fix, grid selection scale, opaque header chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)