### PR TITLE
v1.3.1 — Exclude emulators from Android games scan

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 12
-        versionName = "1.3.0"
+        versionCode = 13
+        versionName = "1.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
@@ -15,7 +15,8 @@ import javax.inject.Inject
 
 class ScanAndroidGamesUseCase @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val gameRepository: GameRepository
+    private val gameRepository: GameRepository,
+    private val packageManagerHelper: com.gamelaunch.frontend.launcher.PackageManagerHelper
 ) {
     // Package prefixes that belong to the OS or this launcher — skip them.
     private val systemPrefixes = setOf(
@@ -41,6 +42,8 @@ class ScanAndroidGamesUseCase @Inject constructor(
 
         val packages = (categoryGamePkgs + launchablePkgs).distinct().filter { pkg ->
             if (systemPrefixes.any { pkg == it || pkg.startsWith("$it.") }) return@filter false
+            // Emulators/launchers are categorised as games too — keep them out of the library.
+            if (pkg in packageManagerHelper.emulatorPackages) return@filter false
             runCatching {
                 val ai = pm.getApplicationInfo(pkg, 0)
                 // Skip pre-installed system apps (unless the user updated one from the store).

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
@@ -64,6 +64,9 @@ class PackageManagerHelper @Inject constructor(
         "ru.playsoftware.j2meloader"         to "J2ME Loader"
     )
 
+    /** Packages eOr treats as emulators/launchers — excluded from the Android games scan. */
+    val emulatorPackages: Set<String> = knownEmulators.map { it.first }.toSet()
+
     // Ordered preference list per platform — first installed entry wins during auto-detect.
     // Each list puts the Retroid Pocket-specific variant first, then the standard variant, then
     // RetroArch as the universal fallback (also as two variants).


### PR DESCRIPTION
Excludes emulators/launchers from the Android games scan and bumps to v1.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)