### PR TITLE
Emphasize selected card (bigger scale + slow wiggle) + README definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Your retro library, beautifully organized.
 
-**eOr** is a fast, gorgeous game launcher for Android handhelds and phones. Point it at your ROMs, let it pull box art, screenshots and video previews automatically, and launch straight into your emulators — all wrapped in a polished, controller-first interface.
+**eOr** — short for *emulation, organized* — is a fast, gorgeous game launcher for Android handhelds and phones. Point it at your ROMs, let it pull box art, screenshots and video previews automatically, and launch straight into your emulators — all wrapped in a polished, controller-first interface.
 
 [![Latest release](https://img.shields.io/github/v/release/keweis2/eOr?style=flat-square&color=4D7FFF)](https://github.com/keweis2/eOr/releases/latest)
 [![Platform](https://img.shields.io/badge/platform-Android%208.0%2B-3DDC84?style=flat-square&logo=android&logoColor=white)](#requirements)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -2,7 +2,11 @@ package com.gamelaunch.frontend.ui.screen.home
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -212,9 +216,20 @@ private fun SystemCard(
 ) {
     val shape = RoundedCornerShape(24.dp)
     val scale by animateFloatAsState(
-        targetValue = if (isFocused) 1.07f else 1f,
+        targetValue = if (isFocused) 1.16f else 1f,
         animationSpec = tween(durationMillis = BounceDurationMs, easing = BounceEasing),
         label = "systemTileScale"
+    )
+    // A slow, never-ending slight wiggle so the focused card always reads as "selected".
+    val wiggle = rememberInfiniteTransition(label = "systemWiggle")
+    val wiggleRot by wiggle.animateFloat(
+        initialValue = -1.6f,
+        targetValue = 1.6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1900, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "systemWiggleRot"
     )
     val darkMode = LocalDarkMode.current
     val textPrimary = if (darkMode) IceWhite else TileText
@@ -224,7 +239,12 @@ private fun SystemCard(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
         modifier = modifier
-            .graphicsLayer { scaleX = scale; scaleY = scale }
+            .zIndex(if (isFocused) 1f else 0f)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                rotationZ = if (isFocused) wiggleRot else 0f
+            }
             .glassTile(shape, color = color, selected = isFocused)
             .clickable(onClick = onClick)
             .padding(14.dp)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -1,8 +1,13 @@
 package com.gamelaunch.frontend.ui.theme.grid
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -27,6 +32,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
@@ -64,18 +70,31 @@ fun GridGameCard(
 
     // Focused card pops with the same bounce-scale as the console cards.
     val scale by animateFloatAsState(
-        targetValue   = if (isFocused) 1.07f else 1f,
+        targetValue   = if (isFocused) 1.16f else 1f,
         animationSpec = tween(durationMillis = BounceDurationMs, easing = BounceEasing),
         label = "gridGameScale"
+    )
+    // Slow, never-ending slight wiggle on the focused card.
+    val wiggle = rememberInfiniteTransition(label = "gridWiggle")
+    val wiggleRot by wiggle.animateFloat(
+        initialValue = -1.6f,
+        targetValue = 1.6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1900, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "gridWiggleRot"
     )
 
     Box(
         modifier = Modifier
+            .zIndex(if (isFocused) 1f else 0f)
             .graphicsLayer {
                 translationY = (1f - enter.value) * 72.dp.toPx()
                 alpha = enter.value.coerceIn(0f, 1f)
                 scaleX = scale
                 scaleY = scale
+                rotationZ = if (isFocused) wiggleRot else 0f
             }
             .then(
                 if (isFocused)


### PR DESCRIPTION
- Focused console/game cards scale to 1.16x and draw above neighbours so the selection is obvious.
- Slow, never-ending ±1.6° wiggle on the focused card (carousel + grid).
- README intro defines eOr as "emulation, organized".

🤖 Generated with [Claude Code](https://claude.com/claude-code)