### PR TITLE
Reduce idle vertical bob

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -250,7 +250,7 @@ private fun SystemCard(
                 scaleX = scale + pulse
                 scaleY = scale + pulse
                 rotationZ = if (isFocused) tilt * 0.9f else 0f
-                translationY = if (isFocused) bob * 4.dp.toPx() else 0f
+                translationY = if (isFocused) bob * 2.5.dp.toPx() else 0f
             }
             .glassTile(shape, color = color, selected = isFocused)
             .clickable(onClick = onClick)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -96,7 +96,7 @@ fun GridGameCard(
             .graphicsLayer {
                 val pulse = if (isFocused) breath * 0.012f else 0f
                 translationY = (1f - enter.value) * 72.dp.toPx() +
-                    (if (isFocused) bob * 3.dp.toPx() else 0f)
+                    (if (isFocused) bob * 1.8.dp.toPx() else 0f)
                 alpha = enter.value.coerceIn(0f, 1f)
                 scaleX = scale + pulse
                 scaleY = scale + pulse


### PR DESCRIPTION
Softens the focused-card float (carousel 4dp->2.5dp, grid 3dp->1.8dp) to ease motion sensitivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)