### PR TITLE
Fix top padding for floating header buttons

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -160,7 +160,7 @@ fun GameDetailScreen(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .statusBarsPadding()
-                        .padding(12.dp)
+                        .padding(start = 14.dp, top = 20.dp, end = 14.dp, bottom = 14.dp)
                         .size(40.dp)
                         .background(glassColor, CircleShape)
                 ) {
@@ -177,8 +177,8 @@ fun GameDetailScreen(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
                         .statusBarsPadding()
-                        .padding(12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        .padding(start = 14.dp, top = 20.dp, end = 14.dp, bottom = 14.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     if (media?.effectiveVideo != null) {
                         IconButton(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -298,7 +298,7 @@ fun HomeScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .statusBarsPadding()
-                            .padding(horizontal = 16.dp, vertical = 6.dp),
+                            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(


### PR DESCRIPTION
Adds top breathing room (home header + detail buttons) so they don't touch the screen top, and more space between the detail mute/favorite pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)