### PR TITLE
Don't crash the scraper when storage is full

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/BatchScrapeUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/BatchScrapeUseCase.kt
@@ -1,10 +1,13 @@
 package com.gamelaunch.frontend.domain.usecase
 
+import android.database.sqlite.SQLiteFullException
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.GameRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import java.io.IOException
 import javax.inject.Inject
 
 data class BatchScrapeState(
@@ -15,8 +18,21 @@ data class BatchScrapeState(
     val errors: Int,
     val currentGameTitle: String = "",
     val isFinished: Boolean = false,
+    val storageFull: Boolean = false,
     val results: List<ScrapeResult> = emptyList()
 )
+
+/** True when a throwable (or any of its causes) is an out-of-disk-space error. */
+private fun Throwable.isOutOfSpace(): Boolean {
+    var t: Throwable? = this
+    while (t != null) {
+        if (t is SQLiteFullException) return true
+        if (t is IOException && (t.message?.contains("ENOSPC", true) == true ||
+                                 t.message?.contains("No space left", true) == true)) return true
+        t = t.cause
+    }
+    return false
+}
 
 class BatchScrapeUseCase @Inject constructor(
     private val gameRepository: GameRepository,
@@ -46,7 +62,20 @@ class BatchScrapeUseCase @Inject constructor(
         games.forEachIndexed { index, game ->
             emit(BatchScrapeState(total, index, succeeded, notFound, errors, game.title, results = results.toList()))
 
-            val result = scrapeGameUseCase(game, config)
+            val result = try {
+                scrapeGameUseCase(game, config)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // Out of disk space: every remaining write will fail too, so stop now and tell
+                // the user instead of crashing the app.
+                if (e.isOutOfSpace()) {
+                    emit(BatchScrapeState(total, index, succeeded, notFound, errors,
+                        isFinished = true, storageFull = true, results = results.toList()))
+                    return@flow
+                }
+                ScrapeResult.Error(game.id, e)
+            }
             results.add(result)
 
             when (result) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
@@ -132,6 +132,20 @@ fun ScrapeProgressScreen(
                     OutlinedButton(onClick = viewModel::cancelScrape, modifier = Modifier.fillMaxWidth()) {
                         Text("Cancel")
                     }
+                } else if (batch.storageFull) {
+                    Text(
+                        "Storage full",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "Your device is out of space, so scraping was stopped. Free up some storage and try again.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = onBack, modifier = Modifier.fillMaxWidth()) { Text("Done") }
                 } else if (batch.isFinished) {
                     Text("Scraping complete!", style = MaterialTheme.typography.titleMedium)
                     Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeViewModel.kt
@@ -55,8 +55,18 @@ class ScrapeViewModel @Inject constructor(
 
             _uiState.update { it.copy(isRunning = true) }
             scrapeJob = launch {
-                batchScrapeUseCase(config).collect { state ->
-                    _uiState.update { it.copy(batchState = state) }
+                try {
+                    batchScrapeUseCase(config).collect { state ->
+                        _uiState.update { it.copy(batchState = state) }
+                    }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    // Last-resort guard so an unexpected failure (e.g. disk full) can't crash the app.
+                    _uiState.update {
+                        it.copy(batchState = (it.batchState ?: com.gamelaunch.frontend.domain.usecase.BatchScrapeState(0, 0, 0, 0, 0))
+                            .copy(isFinished = true, storageFull = true))
+                    }
                 }
             }
             scrapeJob?.join()


### PR DESCRIPTION
Catches SQLiteFullException/ENOSPC during scraping and shows a 'Storage full' message instead of crashing the app.