### PR TITLE
Optional custom media storage folder (SD card)

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -23,6 +23,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     private object Keys {
         val ROM_ROOT_PATH = stringPreferencesKey("rom_root_path")
         val MEDIA_FOLDER_PATH = stringPreferencesKey("media_folder_path")
+        val MEDIA_STORAGE_PATH = stringPreferencesKey("media_storage_path")
         val LAYOUT_MODE = stringPreferencesKey("layout_mode")
         val SS_ID = stringPreferencesKey("ss_id")
         val SS_PASSWORD = stringPreferencesKey("ss_password")
@@ -47,6 +48,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
 
     val romRootPath: Flow<String> = context.dataStore.data.map { it[Keys.ROM_ROOT_PATH] ?: "" }
     val mediaFolderPath: Flow<String> = context.dataStore.data.map { it[Keys.MEDIA_FOLDER_PATH] ?: "" }
+    // Where scraped media is saved. Empty = app's internal default folder.
+    val mediaStoragePath: Flow<String> = context.dataStore.data.map { it[Keys.MEDIA_STORAGE_PATH] ?: "" }
     val layoutMode: Flow<String> = context.dataStore.data.map { it[Keys.LAYOUT_MODE] ?: "CAROUSEL" }
     val ssId: Flow<String> = context.dataStore.data.map { it[Keys.SS_ID] ?: "" }
     val ssPassword: Flow<String> = context.dataStore.data.map { it[Keys.SS_PASSWORD] ?: "" }
@@ -73,6 +76,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
 
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
+    suspend fun setMediaStoragePath(path: String) = context.dataStore.edit { it[Keys.MEDIA_STORAGE_PATH] = path }
     suspend fun setLayoutMode(mode: String) = context.dataStore.edit { it[Keys.LAYOUT_MODE] = mode }
     suspend fun setSsCredentials(id: String, password: String) = context.dataStore.edit {
         it[Keys.SS_ID] = id

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/MediaRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/MediaRepositoryImpl.kt
@@ -3,11 +3,13 @@ package com.gamelaunch.frontend.data.repository
 import android.content.Context
 import com.gamelaunch.frontend.data.db.dao.GameMediaDao
 import com.gamelaunch.frontend.data.db.entity.GameMediaEntity
+import com.gamelaunch.frontend.data.preferences.AppDataStore
 import com.gamelaunch.frontend.domain.model.GameMedia
 import com.gamelaunch.frontend.domain.repository.MediaRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -20,11 +22,26 @@ import javax.inject.Singleton
 class MediaRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val gameMediaDao: GameMediaDao,
+    private val dataStore: AppDataStore,
     private val okHttpClient: OkHttpClient
 ) : MediaRepository {
 
-    private val mediaDir: File
+    private val defaultMediaDir: File
         get() = File(context.filesDir, "media").also { it.mkdirs() }
+
+    /**
+     * Folder where scraped media is written. Uses the user's chosen folder (e.g. an SD card) when
+     * set and writable — an "eor_media" subfolder inside it — otherwise the app's internal default.
+     */
+    private suspend fun mediaDir(): File {
+        val custom = dataStore.mediaStoragePath.first()
+        if (custom.isNotBlank() && !custom.startsWith("content://")) {
+            val dir = File(custom, "eor_media")
+            val ok = runCatching { dir.mkdirs(); dir.exists() && dir.canWrite() }.getOrDefault(false)
+            if (ok) return dir
+        }
+        return defaultMediaDir
+    }
 
     override suspend fun getMediaForGame(gameId: Long): GameMedia? =
         gameMediaDao.getMediaForGame(gameId)?.toDomain()
@@ -60,27 +77,30 @@ class MediaRepositoryImpl @Inject constructor(
     }
 
     override suspend fun downloadAndCacheBoxArt(gameId: Long, url: String): String? =
-        downloadFile(url, File(mediaDir, "boxart/${gameId}.jpg"))?.also { path ->
+        downloadFile(url, File(mediaDir(), "boxart/${gameId}.jpg"))?.also { path ->
             gameMediaDao.updateBoxArtLocalPath(gameId, path)
         }
 
     override suspend fun downloadAndCacheVideo(gameId: Long, url: String): String? =
-        downloadFile(url, File(mediaDir, "videos/${gameId}.mp4"))?.also { path ->
+        downloadFile(url, File(mediaDir(), "videos/${gameId}.mp4"))?.also { path ->
             gameMediaDao.updateVideoLocalPath(gameId, path)
         }
 
     override suspend fun downloadAndCacheScreenshot(gameId: Long, url: String): String? =
-        downloadFile(url, File(mediaDir, "screenshots/${gameId}.jpg"))
+        downloadFile(url, File(mediaDir(), "screenshots/${gameId}.jpg"))
 
     override suspend fun downloadAndCacheWheelLogo(gameId: Long, url: String): String? =
-        downloadFile(url, File(mediaDir, "wheels/${gameId}.png"))
+        downloadFile(url, File(mediaDir(), "wheels/${gameId}.png"))
 
     override suspend fun deleteMediaForGame(gameId: Long) {
         gameMediaDao.deleteMediaForGame(gameId)
-        listOf("boxart", "videos", "screenshots", "wheels").forEach { dir ->
-            File(mediaDir, "$dir/$gameId.*").parentFile?.listFiles()
-                ?.filter { it.nameWithoutExtension == gameId.toString() }
-                ?.forEach { it.delete() }
+        // Media may live in either the current folder or the internal default (if the user moved it).
+        listOf(mediaDir(), defaultMediaDir).distinct().forEach { base ->
+            listOf("boxart", "videos", "screenshots", "wheels").forEach { dir ->
+                File(base, dir).listFiles()
+                    ?.filter { it.nameWithoutExtension == gameId.toString() }
+                    ?.forEach { it.delete() }
+            }
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -18,6 +18,7 @@ class SettingsRepositoryImpl @Inject constructor(
 
     override val romRootPath: Flow<String> = dataStore.romRootPath
     override val mediaFolderPath: Flow<String> = dataStore.mediaFolderPath
+    override val mediaStoragePath: Flow<String> = dataStore.mediaStoragePath
 
     override val layoutMode: Flow<LayoutMode> = dataStore.layoutMode.map { name ->
         runCatching { LayoutMode.valueOf(name) }.getOrDefault(LayoutMode.CAROUSEL)
@@ -60,6 +61,7 @@ class SettingsRepositoryImpl @Inject constructor(
 
     override suspend fun setRomRootPath(path: String) { dataStore.setRomRootPath(path) }
     override suspend fun setMediaFolderPath(path: String) { dataStore.setMediaFolderPath(path) }
+    override suspend fun setMediaStoragePath(path: String) { dataStore.setMediaStoragePath(path) }
 
     override suspend fun setLayoutMode(mode: LayoutMode) { dataStore.setLayoutMode(mode.name) }
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 interface SettingsRepository {
     val romRootPath: Flow<String>
     val mediaFolderPath: Flow<String>
+    val mediaStoragePath: Flow<String>
     val layoutMode: Flow<LayoutMode>
     val scraperConfig: Flow<ScraperConfig>
     val videoAutoplayDelayMs: Flow<Long>
@@ -24,6 +25,7 @@ interface SettingsRepository {
 
     suspend fun setRomRootPath(path: String)
     suspend fun setMediaFolderPath(path: String)
+    suspend fun setMediaStoragePath(path: String)
     suspend fun setLayoutMode(mode: LayoutMode)
     suspend fun setScraperCredentials(ssid: String, sspassword: String)
     suspend fun updateScraperOptions(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -141,6 +141,15 @@ fun SettingsScreen(
         }
     }
 
+    val mediaStoragePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let {
+            val path = StorageUtils.resolveTreeUriToPath(it) ?: it.toString()
+            viewModel.setMediaStoragePath(path)
+        }
+    }
+
     // L1 / R1 cycle between tabs (with wraparound), mirroring the home screen.
     fun cycleTab(delta: Int) {
         val entries = SettingsTab.entries
@@ -275,6 +284,12 @@ fun SettingsScreen(
                                     else -> MediaImportBody(state, viewModel, onPickMediaFolder = { mediaFolderPicker.launch(null) })
                                 }
                             }
+                            Spacer(Modifier.height(4.dp))
+                            MediaStorageSection(
+                                state,
+                                onPickFolder = { mediaStoragePicker.launch(null) },
+                                onUseDefault = viewModel::clearMediaStoragePath
+                            )
                         }
                         SettingsTab.GAMES -> {
                             RomLibrarySection(
@@ -1028,6 +1043,58 @@ private fun SegmentedTabs(
                     color = if (isSel) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
                     fontWeight = if (isSel) FontWeight.SemiBold else FontWeight.Normal,
                     maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+// ── Section: Media Storage ────────────────────────────────────────────────
+
+@Composable
+private fun MediaStorageSection(
+    state: SettingsUiState,
+    onPickFolder: () -> Unit,
+    onUseDefault: () -> Unit
+) {
+    SettingsSectionHeader("Media Storage")
+    SettingsCard {
+        Text(
+            "Choose where scraped box art, screenshots and videos are saved — for example your SD card. " +
+            "Optional: if you don't pick a folder, media is kept in the app's internal storage. " +
+            "Changing this only affects newly scraped media.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Default.FolderOpen,
+                contentDescription = null,
+                tint = ElectricBlue,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text  = state.mediaStoragePath.ifBlank { "Default — internal storage" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            GradientFillButton(
+                text     = "Choose Folder",
+                onClick  = onPickFolder,
+                modifier = Modifier.weight(1f)
+            )
+            if (state.mediaStoragePath.isNotBlank()) {
+                GradientOutlineButton(
+                    text     = "Use Default",
+                    onClick  = onUseDefault,
+                    modifier = Modifier.weight(1f)
                 )
             }
         }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -51,6 +51,7 @@ data class SettingsUiState(
     val lbSyncStatus: LbSyncStatus? = null,
     val lbGameCount: Int = 0,
     val mediaFolderPath: String = "",
+    val mediaStoragePath: String = "",
     val esdeImportStatus: EsdeImportStatus? = null,
     val showRecentlyPlayed: Boolean = true,
     val darkMode: Boolean = false,
@@ -124,6 +125,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.mediaFolderPath.collect { path ->
                 _uiState.update { it.copy(mediaFolderPath = path) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.mediaStoragePath.collect { path ->
+                _uiState.update { it.copy(mediaStoragePath = path) }
             }
         }
         viewModelScope.launch {
@@ -261,6 +267,14 @@ class SettingsViewModel @Inject constructor(
 
     fun setMediaFolderPath(path: String) {
         viewModelScope.launch { settingsRepository.setMediaFolderPath(path) }
+    }
+
+    fun setMediaStoragePath(path: String) {
+        viewModelScope.launch { settingsRepository.setMediaStoragePath(path) }
+    }
+
+    fun clearMediaStoragePath() {
+        viewModelScope.launch { settingsRepository.setMediaStoragePath("") }
     }
 
     fun importEsdeMedia() {


### PR DESCRIPTION
Adds a Media Storage option in Settings → Media to pick where scraped media is saved (via the Android folder picker). Optional; defaults to internal storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)