### PR TITLE
Move Media Storage above the media tabs

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -268,6 +268,12 @@ fun SettingsScreen(
                             SystemSortSection(state, viewModel)
                         }
                         SettingsTab.MEDIA -> {
+                            MediaStorageSection(
+                                state,
+                                onPickFolder = { mediaStoragePicker.launch(null) },
+                                onUseDefault = viewModel::clearMediaStoragePath
+                            )
+                            Spacer(Modifier.height(8.dp))
                             // The three media sources are rarely used together, so they share one
                             // card with an inline segmented selector instead of stacking.
                             var mediaSub by rememberSaveable { mutableStateOf(0) }
@@ -284,12 +290,6 @@ fun SettingsScreen(
                                     else -> MediaImportBody(state, viewModel, onPickMediaFolder = { mediaFolderPicker.launch(null) })
                                 }
                             }
-                            Spacer(Modifier.height(4.dp))
-                            MediaStorageSection(
-                                state,
-                                onPickFolder = { mediaStoragePicker.launch(null) },
-                                onUseDefault = viewModel::clearMediaStoragePath
-                            )
                         }
                         SettingsTab.GAMES -> {
                             RomLibrarySection(


### PR DESCRIPTION
Places the Media Storage card at the top of the Media settings tab, above the ScreenScraper/Artwork DB/Import selector.