### PR TITLE
Replace carousel layout toggle with RetroAchievements tab toggle

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -37,6 +37,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val VIDEO_MUTED = booleanPreferencesKey("video_muted")
         val FIRST_LAUNCH = booleanPreferencesKey("first_launch")
         val SHOW_RECENTLY_PLAYED = booleanPreferencesKey("show_recently_played")
+        val SHOW_RETRO_ACHIEVEMENTS = booleanPreferencesKey("show_retro_achievements")
         val DARK_MODE = booleanPreferencesKey("dark_mode")
         val SYSTEM_SORT = stringPreferencesKey("system_sort")
         val RA_USERNAME = stringPreferencesKey("ra_username")
@@ -63,6 +64,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val videoMuted: Flow<Boolean> = context.dataStore.data.map { it[Keys.VIDEO_MUTED] ?: true }
     val isFirstLaunch: Flow<Boolean> = context.dataStore.data.map { it[Keys.FIRST_LAUNCH] ?: true }
     val showRecentlyPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RECENTLY_PLAYED] ?: true }
+    val showRetroAchievements: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RETRO_ACHIEVEMENTS] ?: true }
     val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
     // Up to two sort keys, comma-joined (e.g. "RELEASE_DATE,BRAND"). Empty = default order.
     val systemSort: Flow<List<String>> = context.dataStore.data.map {
@@ -92,6 +94,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setVideoMuted(muted: Boolean) = context.dataStore.edit { it[Keys.VIDEO_MUTED] = muted }
     suspend fun setFirstLaunchComplete() = context.dataStore.edit { it[Keys.FIRST_LAUNCH] = false }
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
+    suspend fun setShowRetroAchievements(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RETRO_ACHIEVEMENTS] = enabled }
     suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
     suspend fun setSystemSort(keys: List<String>) = context.dataStore.edit { it[Keys.SYSTEM_SORT] = keys.joinToString(",") }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -50,6 +50,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override val videoMuted: Flow<Boolean> = dataStore.videoMuted
     override val isFirstLaunch: Flow<Boolean> = dataStore.isFirstLaunch
     override val showRecentlyPlayed: Flow<Boolean> = dataStore.showRecentlyPlayed
+    override val showRetroAchievements: Flow<Boolean> = dataStore.showRetroAchievements
     override val darkMode: Flow<Boolean> = dataStore.darkMode
     override val systemSort: Flow<List<SystemSort>> =
         dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
@@ -88,6 +89,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setVideoMuted(muted: Boolean) { dataStore.setVideoMuted(muted) }
     override suspend fun setFirstLaunchComplete() { dataStore.setFirstLaunchComplete() }
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
+    override suspend fun setShowRetroAchievements(enabled: Boolean) { dataStore.setShowRetroAchievements(enabled) }
     override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
     override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
     override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -15,6 +15,7 @@ interface SettingsRepository {
     val videoMuted: Flow<Boolean>
     val isFirstLaunch: Flow<Boolean>
     val showRecentlyPlayed: Flow<Boolean>
+    val showRetroAchievements: Flow<Boolean>
     val darkMode: Flow<Boolean>
     val systemSort: Flow<List<SystemSort>>
     val raUsername: Flow<String>
@@ -40,6 +41,7 @@ interface SettingsRepository {
     suspend fun setVideoMuted(muted: Boolean)
     suspend fun setFirstLaunchComplete()
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
+    suspend fun setShowRetroAchievements(enabled: Boolean)
     suspend fun setDarkMode(enabled: Boolean)
     suspend fun setSystemSort(keys: List<SystemSort>)
     suspend fun setRaApiKey(apiKey: String)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -132,9 +132,10 @@ fun HomeScreen(
         next?.let { viewModel.selectPlatform(it) }
     }
 
-    // Recently Played sits between Games and Apps, but only when enabled in settings.
+    // Recently Played and RetroAchievements tabs each appear only when enabled in settings.
     val visibleTabs = TopTab.entries.filter {
-        it != TopTab.RECENTLY_PLAYED || state.showRecentlyPlayed
+        (it != TopTab.RECENTLY_PLAYED  || state.showRecentlyPlayed) &&
+        (it != TopTab.RETROACHIEVEMENTS || state.showRetroAchievements)
     }
 
     fun cycleTab(delta: Int) {
@@ -352,6 +353,7 @@ fun HomeScreen(
                         ModeTabBar(
                             selected = state.topTab,
                             showRecentlyPlayed = state.showRecentlyPlayed,
+                            showRetroAchievements = state.showRetroAchievements,
                             onSelect = { tab ->
                                 viewModel.selectTopTab(tab)
                                 if (tab == TopTab.APPS) appsViewModel.refresh()
@@ -441,10 +443,14 @@ private val tabSpecs = listOf(
 private fun ModeTabBar(
     selected: TopTab,
     showRecentlyPlayed: Boolean,
+    showRetroAchievements: Boolean,
     onSelect: (TopTab) -> Unit
 ) {
     val pill = RoundedCornerShape(50)
-    val tabs = tabSpecs.filter { it.tab != TopTab.RECENTLY_PLAYED || showRecentlyPlayed }
+    val tabs = tabSpecs.filter {
+        (it.tab != TopTab.RECENTLY_PLAYED  || showRecentlyPlayed) &&
+        (it.tab != TopTab.RETROACHIEVEMENTS || showRetroAchievements)
+    }
     val darkMode = LocalDarkMode.current
     val unselectedTint = if (darkMode) IceWhite.copy(alpha = 0.8f) else TileText.copy(alpha = 0.8f)
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -33,6 +33,7 @@ data class HomeUiState(
     val systemPreviewArt: List<String> = emptyList(),  // box art for the focused system card
     val selectedPlatform: String? = null,
     val showRecentlyPlayed: Boolean = true,
+    val showRetroAchievements: Boolean = true,
     val recentlyPlayed: List<Game> = emptyList(),
     val games: List<Game> = emptyList(),
     val selectedGameIndex: Int = 0,
@@ -163,16 +164,23 @@ class HomeViewModel @Inject constructor(
                 settingsRepository.layoutMode,
                 settingsRepository.videoMuted,
                 settingsRepository.videoAutoplayDelayMs,
-                settingsRepository.showRecentlyPlayed
-            ) { layout, muted, delay, showRecent ->
+                settingsRepository.showRecentlyPlayed,
+                settingsRepository.showRetroAchievements
+            ) { layout, muted, delay, showRecent, showRa ->
                 _uiState.update {
+                    // if a tab gets hidden while selected, fall back to Games
+                    val fallbackTab = when {
+                        !showRecent && it.topTab == TopTab.RECENTLY_PLAYED   -> TopTab.GAMES
+                        !showRa && it.topTab == TopTab.RETROACHIEVEMENTS      -> TopTab.GAMES
+                        else                                                 -> it.topTab
+                    }
                     it.copy(
                         layoutMode = layout,
                         videoMuted = muted,
                         videoDelayMs = delay,
                         showRecentlyPlayed = showRecent,
-                        // if the tab gets hidden while selected, fall back to Games
-                        topTab = if (!showRecent && it.topTab == TopTab.RECENTLY_PLAYED) TopTab.GAMES else it.topTab
+                        showRetroAchievements = showRa,
+                        topTab = fallbackTab
                     )
                 }
             }.collect { }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -353,16 +353,14 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
     SettingsSectionHeader("Display")
     SettingsCard {
         CardSwitchRow(
-            label     = "Carousel layout",
-            checked   = state.layoutMode == LayoutMode.CAROUSEL,
-            onCheckedChange = {
-                viewModel.setLayoutMode(if (it) LayoutMode.CAROUSEL else LayoutMode.GRID)
-            }
-        )
-        CardSwitchRow(
             label           = "Recently Played tab",
             checked         = state.showRecentlyPlayed,
             onCheckedChange = viewModel::setShowRecentlyPlayed
+        )
+        CardSwitchRow(
+            label           = "RetroAchievements tab",
+            checked         = state.showRetroAchievements,
+            onCheckedChange = viewModel::setShowRetroAchievements
         )
         Spacer(Modifier.height(10.dp))
         Text(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -54,6 +54,7 @@ data class SettingsUiState(
     val mediaStoragePath: String = "",
     val esdeImportStatus: EsdeImportStatus? = null,
     val showRecentlyPlayed: Boolean = true,
+    val showRetroAchievements: Boolean = true,
     val darkMode: Boolean = false,
     val systemSort: List<SystemSort> = emptyList()
 )
@@ -138,6 +139,11 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.showRetroAchievements.collect { show ->
+                _uiState.update { it.copy(showRetroAchievements = show) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.darkMode.collect { dark ->
                 _uiState.update { it.copy(darkMode = dark) }
             }
@@ -166,6 +172,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setShowRecentlyPlayed(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setShowRecentlyPlayed(enabled) }
+    }
+
+    fun setShowRetroAchievements(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setShowRetroAchievements(enabled) }
     }
 
     fun setDarkMode(enabled: Boolean) {


### PR DESCRIPTION
Removes the **Carousel layout** switch from Settings → General → Display and replaces it with a **RetroAchievements tab** switch.

- New `showRetroAchievements` preference plumbed through DataStore → SettingsRepository → both Settings and Home view models (default **on**).
- The switch shows/hides the **RetroAchievements** top-level tab on Home, mirroring the existing **Recently Played tab** toggle (both the `ModeTabBar` render filter and the L1/R1 cycle list respect it).
- If the tab is turned off while it's the active tab, Home falls back to **Games**.

Verified on-device: toggling off hides the RetroAchievements tab from the Home tab bar; toggling on restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)