### PR TITLE
Branded launch screen + carousel art prefetch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ ksp {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:theme="@style/Theme.GameLauncher.Splash"
             android:launchMode="singleTask"
             android:stateNotNeeded="true"
             android:windowSoftInputMode="adjustResize"

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -15,7 +15,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.compose.foundation.background
@@ -25,18 +27,37 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.rememberNavController
+import coil.imageLoader
+import coil.request.ImageRequest
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+import com.gamelaunch.frontend.domain.platform.sortedBySystems
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.ui.navigation.AppNavGraph
 import com.gamelaunch.frontend.ui.navigation.Screen
 import com.gamelaunch.frontend.ui.theme.AppTheme
 import com.gamelaunch.frontend.ui.theme.NavyBg
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     @Inject lateinit var settingsRepository: SettingsRepository
+    @Inject lateinit var gameRepository: GameRepository
+    @Inject lateinit var mediaRepository: MediaRepository
+
+    // The branded splash stays up until cold-start data is loaded and the first screen's box art
+    // is warmed in Coil's cache, so Home appears populated instead of grey-then-crossfading in.
+    @Volatile private var splashReady = false
 
     // Track last axis values so we only fire once per threshold crossing
     private var lastAxisX   = 0f
@@ -49,7 +70,15 @@ class MainActivity : ComponentActivity() {
     ) { /* storage permissions handled — ROM folder picker and all-files access are the fallback */ }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // installSplashScreen() reads the theme and must run before super.onCreate(); the keep
+        // condition and warm-up run after, once Hilt has injected the repositories.
+        val splash = installSplashScreen()
         super.onCreate(savedInstanceState)
+
+        // Hold the splash until the first screen is warm (bounded so it can never hang), then let
+        // Android cross-fade it away.
+        splash.setKeepOnScreenCondition { !splashReady }
+        warmFirstScreen()
 
         // Edge-to-edge + full immersive: hide status bar and nav bar
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -88,6 +117,59 @@ class MainActivity : ComponentActivity() {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Warm the cold-start path behind the splash: resolve the launch destination and, for returning
+     * users landing on Home, prefetch the box art of the first systems shown so the carousel/grid
+     * renders with art already resident. Bounded by a hard timeout so a slow disk or huge library
+     * never leaves the user staring at the logo.
+     */
+    private fun warmFirstScreen() {
+        lifecycleScope.launch {
+            withTimeoutOrNull(1200L) {
+                if (!settingsRepository.isFirstLaunch.first()) {
+                    prewarmFirstScreenArt()
+                }
+            }
+            splashReady = true
+        }
+    }
+
+    private suspend fun prewarmFirstScreenArt() {
+        val ids = gameRepository.getDistinctPlatformIds().first()
+        if (ids.isEmpty()) return
+        val counts = gameRepository.getPlatformCounts().first()
+        val sorts  = settingsRepository.systemSort.first()
+        // Same ordering Home uses, so we warm the systems that actually appear first.
+        val firstSystems = ids.sortedBySystems(
+            sorts = sorts,
+            displayName = { PlatformDefinitions.byId[it]?.displayName ?: it },
+            gameCount   = { counts[it] ?: 0 }
+        ).take(8)
+
+        val paths = firstSystems
+            .flatMap { mediaRepository.boxArtSampleForPlatform(it, 4) }
+            .filter { it.isNotBlank() }
+            .distinct()
+
+        val loader = imageLoader
+        coroutineScope {
+            paths.map { path ->
+                async {
+                    runCatching {
+                        loader.execute(
+                            ImageRequest.Builder(this@MainActivity)
+                                .data(File(path))
+                                // Match AsyncGameArtwork's key so the warmed bitmap is a cache hit
+                                // (and paints with no grey placeholder) when Home composes.
+                                .memoryCacheKey(path)
+                                .build()
+                        )
+                    }
+                }
+            }.awaitAll()
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
@@ -36,9 +36,22 @@ fun AsyncGameArtwork(
         }
     }
 
+    // A stable, size-independent memory-cache key so a cover decoded once (e.g. prewarmed behind
+    // the splash, or seen at a different tile size) is reused everywhere. Without this, Coil's
+    // default key includes the request size, so the same art re-decodes per size and flashes the
+    // grey placeholder before crossfading in.
+    val cacheKey = remember(data) {
+        when (data) {
+            is File   -> data.absolutePath
+            is String -> data
+            else      -> null
+        }
+    }
+
     SubcomposeAsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
             .data(data)
+            .memoryCacheKey(cacheKey)
             .crossfade(true)
             .build(),
         contentDescription = contentDescription,

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -1,7 +1,10 @@
 package com.gamelaunch.frontend.ui.screen.home
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import coil.imageLoader
+import coil.request.ImageRequest
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
 import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
@@ -11,6 +14,7 @@ import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +25,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
 enum class TopTab { GAMES, RECENTLY_PLAYED, APPS, RETROACHIEVEMENTS }
@@ -48,6 +53,7 @@ data class HomeUiState(
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     private val gameRepository: GameRepository,
     private val mediaRepository: MediaRepository,
     private val settingsRepository: SettingsRepository
@@ -116,19 +122,61 @@ class HomeViewModel @Inject constructor(
     // console returns the same list object — LaunchedEffect(previewArt) won't re-trigger
     // the fan animation and images are already warm in Coil's disk cache.
     private val previewArtCache = mutableMapOf<String, List<String>>()
+    private val prefetchedSystems = mutableSetOf<String>()
 
     /** Load a handful of box-art covers to preview the system the carousel is focused on. */
     fun focusSystem(platformId: String) {
         val cached = previewArtCache[platformId]
         if (cached != null) {
             _uiState.update { it.copy(systemPreviewArt = cached) }
+            prefetchNeighbours(platformId)
             return
         }
         previewJob?.cancel()
         previewJob = viewModelScope.launch {
-            val art = mediaRepository.boxArtSampleForPlatform(platformId, 8)
-            previewArtCache[platformId] = art
+            val art = artForSystem(platformId)
             _uiState.update { it.copy(systemPreviewArt = art) }
+            prefetchNeighbours(platformId)
+        }
+    }
+
+    /**
+     * The covers shown for a system, sampled once and cached. Both the visible fan and the
+     * look-ahead prefetch read this same list, so a neighbour we warm is exactly the art that
+     * renders when the user lands on it (the underlying query is `ORDER BY RANDOM()`, so without
+     * caching each call would return different covers and the prefetch would miss).
+     */
+    private suspend fun artForSystem(platformId: String): List<String> =
+        previewArtCache[platformId] ?: mediaRepository.boxArtSampleForPlatform(platformId, 8)
+            .also { previewArtCache[platformId] = it }
+
+    /**
+     * Warm the fan art of the systems on either side of the focused one into Coil's memory cache,
+     * so scrolling the carousel left/right shows covers immediately instead of grey placeholders.
+     * Each system is warmed at most once; the memory-cache key matches AsyncGameArtwork's so the
+     * UI request is a synchronous hit.
+     */
+    private fun prefetchNeighbours(platformId: String) {
+        val platforms = _uiState.value.platforms
+        val idx = platforms.indexOf(platformId)
+        if (idx < 0) return
+        val neighbours = listOfNotNull(
+            platforms.getOrNull(idx - 1),
+            platforms.getOrNull(idx + 1),
+            platforms.getOrNull(idx + 2),
+        )
+        neighbours.forEach { pid ->
+            if (!prefetchedSystems.add(pid)) return@forEach
+            viewModelScope.launch {
+                val loader = appContext.imageLoader
+                artForSystem(pid).take(5).forEach { art ->
+                    val req = ImageRequest.Builder(appContext)
+                        .data(if (art.startsWith("http")) art else File(art))
+                        .memoryCacheKey(art)
+                        .build()
+                    loader.enqueue(req)   // async, non-blocking
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,4 +6,13 @@
         <item name="android:navigationBarColor">#00000000</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
+
+    <!-- Branded launch screen (Android 12+ SplashScreen API). The donkey launcher art sits on
+         the brand navy while cold-start work runs and the first screen's box art is warmed; the
+         app then swaps to the real theme via postSplashScreenTheme. -->
+    <style name="Theme.GameLauncher.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">#06091A</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/Theme.GameLauncher</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ coil = "2.6.0"
 datastore = "1.1.1"
 coroutines = "1.8.1"
 coreKtx = "1.13.1"
+coreSplashscreen = "1.0.1"
 lifecycleRuntimeKtx = "2.8.2"
 junit = "4.13.2"
 androidxTestExt = "1.1.5"
@@ -22,6 +23,7 @@ espresso = "3.5.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
Adds the launch loading state and fixes the grey-placeholder pop when navigating between consoles.

- **Branded launch screen** (Android 12+ SplashScreen API) — the donkey logo on the brand navy covers cold-start work (Hilt graph, Room open, first DataStore read) and warms the first screen's box art before Home appears. Bounded by a hard timeout so it can never hang.
- **Look-ahead prefetch** — focusing a system warms the fan art of its carousel neighbours into Coil's memory cache, so scrolling to a new console shows covers immediately instead of grey-then-crossfade. Each system is warmed at most once; the sampled cover list is cached so the prefetched art is exactly what renders (the query is `ORDER BY RANDOM()`).
- **Stable memory-cache key** in `AsyncGameArtwork` — size-independent, so a cover decoded once is reused at any tile size and the prefetch is a synchronous UI hit.

Verified on-device: Home launches warm, and stepping to an adjacent console renders box art with no grey pop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)