### PR TITLE
Anchor grid focus to second row and fix video exit hitch

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/VideoPlayer.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/VideoPlayer.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -20,6 +21,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import com.gamelaunch.frontend.R
 import java.io.File
 
 @Composable
@@ -76,7 +78,8 @@ fun VideoPlayer(
 
     AndroidView(
         factory = { ctx ->
-            PlayerView(ctx).apply {
+            // Inflated from XML because surface_type (texture_view) has no programmatic setter.
+            (LayoutInflater.from(ctx).inflate(R.layout.texture_player_view, null) as PlayerView).apply {
                 player = exoPlayer
                 useController = false
                 resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
@@ -86,6 +89,11 @@ fun VideoPlayer(
                 isFocusableInTouchMode = false
                 descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
             }
+        },
+        onRelease = { view ->
+            // Detach the player from the view before release so ExoPlayer never has to wait on
+            // a surface that is being torn down mid-navigation.
+            view.player = null
         },
         modifier = modifier
     )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -40,10 +40,12 @@ fun GridHomeContent(
 
     val gridState = rememberLazyGridState()
 
-    // Scroll so the controller-focused card is always visible
-    LaunchedEffect(focusedGameIndex) {
+    // Scroll so the controller-focused card is always visible. Anchor the focused card to the
+    // second visible row (one row of context above it) instead of pinning it to the top row —
+    // scrolling only kicks in once focus moves past the second row.
+    LaunchedEffect(focusedGameIndex, columns) {
         if (focusedGameIndex in games.indices) {
-            gridState.animateScrollToItem(focusedGameIndex)
+            gridState.animateScrollToItem((focusedGameIndex - columns).coerceAtLeast(0))
         }
     }
 

--- a/app/src/main/res/layout/texture_player_view.xml
+++ b/app/src/main/res/layout/texture_player_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- surface_type can only be set from XML, hence this one-view layout. TextureView instead of
+     the default SurfaceView: it releases without a blocking main-thread surface handshake
+     (no hitch when leaving the detail screen) and it animates with screen transitions. -->
+<androidx.media3.ui.PlayerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:surface_type="texture_view"
+    app:use_controller="false" />


### PR DESCRIPTION
## What
- **Game grid scroll:** the controller-focused card is now anchored to the **second** visible row (keeping one row of context above it) instead of being pinned to the top row. Scrolling kicks in once focus moves past the second row.
- **Game detail exit hang:** `VideoPlayer` now uses a TextureView-backed `PlayerView` (inflated from XML — `surface_type` has no programmatic setter) and detaches the player in `AndroidView.onRelease`. The default SurfaceView forced a blocking main-thread surface handshake during release, which caused the brief hang when backing out of the detail screen; SurfaceView also can't participate in the nav crossfade.

## Testing
- Verified on a Retroid Pocket 4 Pro: D-pad down from row 0 → row 1 no longer scrolls; from row 1 → row 2 scrolls one row, keeping the previous row visible above the selection.
- Detail screen back-out no longer hitches with a video playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)