### PR TITLE
Add first-launch onboarding wizard with staged library setup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
         tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <!-- "Library ready" notification when the first-run media download finishes in the background -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>
         <!-- RetroArch — aarch64 build ships on Retroid Pocket; standard is the Play Store build -->

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -103,7 +103,7 @@ class MainActivity : ComponentActivity() {
                     }
                     else -> {
                         val startDestination =
-                            if (firstLaunch) Screen.Settings.route else Screen.Home.route
+                            if (firstLaunch) Screen.Onboarding.route else Screen.Home.route
                         AppNavGraph(
                             navController    = navController,
                             startDestination = startDestination

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/FirstRunSetupManager.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/FirstRunSetupManager.kt
@@ -1,0 +1,192 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.gamelaunch.frontend.R
+import com.gamelaunch.frontend.domain.repository.EmulatorRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** One item on the first-run setup checklist. */
+sealed class SetupStep {
+    object Pending : SetupStep()
+    data class Running(val done: Int = 0, val total: Int = 0, val detail: String = "") : SetupStep()
+    data class Done(val summary: String) : SetupStep()
+    data class Failed(val message: String) : SetupStep()
+
+    val isSettled: Boolean get() = this is Done || this is Failed
+}
+
+data class FirstRunSetupState(
+    val started: Boolean = false,
+    val romScan: SetupStep = SetupStep.Pending,
+    val emulatorDetect: SetupStep = SetupStep.Pending,
+    val androidScan: SetupStep = SetupStep.Pending,
+    val mediaScan: SetupStep = SetupStep.Pending
+) {
+    /** The scans the user must wait for before entering the app (everything but media). */
+    val requiredStepsSettled: Boolean
+        get() = romScan.isSettled && emulatorDetect.isSettled && androidScan.isSettled
+}
+
+/**
+ * Runs the first-launch setup pipeline: ROM scan → emulator detection → Android games scan →
+ * media import/download. Lives in its own application-scoped coroutine (not a viewModelScope) so
+ * the media download keeps going when the user leaves onboarding early; if they do, we post a
+ * notification when it finishes.
+ */
+@Singleton
+class FirstRunSetupManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val scanRomsUseCase: ScanRomsUseCase,
+    private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
+    private val batchScrapeUseCase: BatchScrapeUseCase,
+    private val importEsdeMediaUseCase: ImportEsdeMediaUseCase,
+    private val emulatorRepository: EmulatorRepository,
+    private val settingsRepository: SettingsRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(FirstRunSetupState())
+    val state: StateFlow<FirstRunSetupState> = _state
+
+    @Volatile private var notifyWhenMediaDone = false
+
+    /** Kick off the pipeline. Safe to call more than once — only the first call starts it. */
+    fun start() {
+        if (_state.value.started) return
+        _state.update { it.copy(started = true) }
+        scope.launch { runPipeline() }
+    }
+
+    /**
+     * The user entered the app while the media scan was still running: finish it in the
+     * background and post a notification when it completes.
+     */
+    fun notifyWhenMediaScanFinishes() {
+        if (_state.value.mediaScan.isSettled) return
+        notifyWhenMediaDone = true
+    }
+
+    private suspend fun runPipeline() {
+        // 1 · ROM library scan
+        runCatching {
+            val romPath = settingsRepository.romRootPath.first()
+            var added = 0
+            scanRomsUseCase(romPath).collect { p ->
+                added = p.added
+                _state.update { it.copy(romScan = SetupStep.Running(p.scanned, p.total, p.currentFile)) }
+            }
+            _state.update { it.copy(romScan = SetupStep.Done("Found $added game${if (added == 1) "" else "s"}")) }
+        }.onFailure { e ->
+            _state.update { it.copy(romScan = SetupStep.Failed(e.message ?: "ROM scan failed")) }
+        }
+
+        // 2 · Emulator detection for the scanned systems
+        runCatching {
+            _state.update { it.copy(emulatorDetect = SetupStep.Running(detail = "Looking for installed emulators…")) }
+            val configured = emulatorRepository.autoDetectAndAssign()
+            val found = emulatorRepository.getInstalledEmulators().count { it.isInstalled }
+            _state.update {
+                it.copy(emulatorDetect = SetupStep.Done(
+                    "Found $found emulator${if (found == 1) "" else "s"} · configured $configured system${if (configured == 1) "" else "s"}"
+                ))
+            }
+        }.onFailure { e ->
+            _state.update { it.copy(emulatorDetect = SetupStep.Failed(e.message ?: "Emulator detection failed")) }
+        }
+
+        // 3 · Installed Android games
+        runCatching {
+            var added = 0
+            scanAndroidGamesUseCase().collect { p ->
+                added = p.added
+                _state.update { it.copy(androidScan = SetupStep.Running(p.scanned, p.total, p.currentFile)) }
+            }
+            _state.update { it.copy(androidScan = SetupStep.Done("Found $added Android game${if (added == 1) "" else "s"}")) }
+        }.onFailure { e ->
+            _state.update { it.copy(androidScan = SetupStep.Failed(e.message ?: "Android game scan failed")) }
+        }
+
+        // 4 · Media: import anything already in the media folder, then scrape the rest
+        runCatching {
+            var imported = 0
+            val mediaPath = settingsRepository.mediaStoragePath.first()
+            if (mediaPath.isNotBlank()) {
+                _state.update { it.copy(mediaScan = SetupStep.Running(detail = "Checking folder for existing media…")) }
+                importEsdeMediaUseCase(mediaPath).collect { status ->
+                    if (status is EsdeImportStatus.Complete) imported = status.matched
+                }
+            }
+
+            val config = settingsRepository.scraperConfig.first()
+            var last: BatchScrapeState? = null
+            batchScrapeUseCase(config).collect { s ->
+                last = s
+                _state.update { it.copy(mediaScan = SetupStep.Running(s.completed, s.total, s.currentGameTitle)) }
+            }
+            val summary = buildString {
+                append("Downloaded media for ${last?.succeeded ?: 0} game${if (last?.succeeded == 1) "" else "s"}")
+                if (imported > 0) append(" · imported $imported")
+            }
+            _state.update { it.copy(mediaScan = SetupStep.Done(summary)) }
+            if (notifyWhenMediaDone) postMediaDoneNotification(summary)
+        }.onFailure { e ->
+            _state.update { it.copy(mediaScan = SetupStep.Failed(e.message ?: "Media download failed")) }
+            if (notifyWhenMediaDone) postMediaDoneNotification("Media download stopped: ${e.message ?: "error"}")
+        }
+    }
+
+    private fun postMediaDoneNotification(summary: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) return
+
+        val nm = NotificationManagerCompat.from(context)
+        nm.createNotificationChannel(
+            NotificationChannelCompat.Builder(CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_DEFAULT)
+                .setName("Setup")
+                .setDescription("First-time setup progress")
+                .build()
+        )
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+        val contentIntent = launchIntent?.let {
+            PendingIntent.getActivity(context, 0, it, PendingIntent.FLAG_IMMUTABLE)
+        }
+        runCatching {
+            nm.notify(
+                NOTIFICATION_ID,
+                NotificationCompat.Builder(context, CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_donkey_silhouette)
+                    .setContentTitle("Your library is ready")
+                    .setContentText(summary)
+                    .setContentIntent(contentIntent)
+                    .setAutoCancel(true)
+                    .build()
+            )
+        }
+    }
+
+    private companion object {
+        const val CHANNEL_ID = "first_run_setup"
+        const val NOTIFICATION_ID = 2001
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.gamelaunch.frontend.ui.screen.detail.GameDetailScreen
 import com.gamelaunch.frontend.ui.screen.home.HomeScreen
+import com.gamelaunch.frontend.ui.screen.onboarding.OnboardingScreen
 import com.gamelaunch.frontend.ui.screen.scan.ScanScreen
 import com.gamelaunch.frontend.ui.screen.scrape.ScrapeProgressScreen
 import com.gamelaunch.frontend.ui.screen.settings.EmulatorConfigScreen
@@ -19,6 +20,16 @@ fun AppNavGraph(
     startDestination: String
 ) {
     NavHost(navController = navController, startDestination = startDestination) {
+
+        composable(Screen.Onboarding.route) {
+            OnboardingScreen(
+                onFinished = {
+                    navController.navigate(Screen.Home.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                }
+            )
+        }
 
         composable(Screen.Scan.route) {
             ScanScreen(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/Screen.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.ui.navigation
 
 sealed class Screen(val route: String) {
+    object Onboarding : Screen("onboarding")
     object Home : Screen("home")
     object Scan : Screen("scan")
     object Settings : Screen("settings")

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/onboarding/OnboardingScreen.kt
@@ -1,0 +1,576 @@
+package com.gamelaunch.frontend.ui.screen.onboarding
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.gamelaunch.frontend.R
+import com.gamelaunch.frontend.domain.usecase.FirstRunSetupState
+import com.gamelaunch.frontend.domain.usecase.SetupStep
+import com.gamelaunch.frontend.ui.input.GamepadA
+import com.gamelaunch.frontend.ui.input.GamepadB
+import com.gamelaunch.frontend.ui.theme.BrandBlue
+import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.NeonPurple
+import com.gamelaunch.frontend.ui.theme.ThemedScreen
+import com.gamelaunch.frontend.util.StorageUtils
+
+/**
+ * First-launch wizard: ROM folder → media folder + ScreenScraper account → theme → setup
+ * checklist. Shown once; [onFinished] navigates into the app after the first-launch flag is
+ * cleared.
+ */
+@Composable
+fun OnboardingScreen(
+    onFinished: () -> Unit,
+    viewModel: OnboardingViewModel = hiltViewModel()
+) {
+    val state      by viewModel.uiState.collectAsState()
+    val setupState by viewModel.setupState.collectAsState()
+
+    val romPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        uri?.let { viewModel.setRomPath(StorageUtils.resolveTreeUriToPath(it) ?: it.toString()) }
+    }
+    val mediaPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        uri?.let { viewModel.setMediaPath(StorageUtils.resolveTreeUriToPath(it) ?: it.toString()) }
+    }
+
+    // Gamepad: A advances the current step, B goes back (never once setup has started).
+    fun primaryAction() {
+        when (state.step) {
+            OnboardingStep.ROM_FOLDER -> viewModel.confirmRomStep()
+            OnboardingStep.MEDIA      -> viewModel.confirmMediaStep()
+            OnboardingStep.THEME      -> viewModel.confirmThemeStep()
+            OnboardingStep.SETUP      ->
+                if (setupState.requiredStepsSettled) viewModel.finishOnboarding(onFinished)
+        }
+    }
+
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { focusRequester.requestFocus() } }
+
+    ThemedScreen {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .focusRequester(focusRequester)
+                .focusable()
+                .onKeyEvent { event ->
+                    if (event.type != KeyEventType.KeyDown) return@onKeyEvent false
+                    when (event.key) {
+                        GamepadA -> { primaryAction(); true }
+                        GamepadB -> {
+                            if (state.step != OnboardingStep.SETUP && state.step != OnboardingStep.ROM_FOLDER) {
+                                viewModel.backStep(); true
+                            } else false
+                        }
+                        else -> false
+                    }
+                }
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding()
+                    .padding(horizontal = 28.dp, vertical = 18.dp)
+            ) {
+                BrandHeader(step = state.step)
+                Spacer(Modifier.height(14.dp))
+
+                AnimatedContent(targetState = state.step, label = "onboarding_step") { step ->
+                    Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+                        when (step) {
+                            OnboardingStep.ROM_FOLDER -> RomFolderStep(
+                                state         = state,
+                                onPickFolder  = { romPicker.launch(null) },
+                                onContinue    = viewModel::confirmRomStep
+                            )
+                            OnboardingStep.MEDIA -> MediaStep(
+                                state            = state,
+                                onPickFolder     = { mediaPicker.launch(null) },
+                                onSsIdChange     = viewModel::updateSsId,
+                                onSsPassChange   = viewModel::updateSsPassword,
+                                onBack           = viewModel::backStep,
+                                onContinue       = viewModel::confirmMediaStep
+                            )
+                            OnboardingStep.THEME -> ThemeStep(
+                                darkMode    = state.darkMode,
+                                onSetDark   = viewModel::setDarkMode,
+                                onBack      = viewModel::backStep,
+                                onContinue  = viewModel::confirmThemeStep
+                            )
+                            OnboardingStep.SETUP -> SetupStepContent(
+                                setup      = setupState,
+                                onContinue = { viewModel.finishOnboarding(onFinished) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Header: brand + step dots ─────────────────────────────────────────────
+
+@Composable
+private fun BrandHeader(step: OnboardingStep) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            painter = painterResource(R.drawable.ic_donkey_silhouette),
+            contentDescription = null,
+            tint = BrandBlue,
+            modifier = Modifier.size(30.dp).padding(end = 6.dp)
+        )
+        Text("e",  fontSize = 24.sp, fontWeight = FontWeight.ExtraBold, color = BrandBlue, letterSpacing = 2.sp)
+        Text("Or", fontSize = 24.sp, fontWeight = FontWeight.ExtraBold,
+             color = MaterialTheme.colorScheme.onSurface, letterSpacing = 2.sp)
+        Spacer(Modifier.weight(1f))
+        OnboardingStep.entries.forEach { s ->
+            Box(
+                Modifier
+                    .padding(horizontal = 3.dp)
+                    .size(if (s == step) 10.dp else 8.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (s.ordinal <= step.ordinal) ElectricBlue
+                        else MaterialTheme.colorScheme.surfaceVariant
+                    )
+            )
+        }
+    }
+}
+
+// ── Step 1: ROM library folder ────────────────────────────────────────────
+
+@Composable
+private fun RomFolderStep(
+    state: OnboardingUiState,
+    onPickFolder: () -> Unit,
+    onContinue: () -> Unit
+) {
+    StepTitle("Welcome to eOr", "First, where do your games live?")
+    StepCard {
+        Text(
+            "Pick the folder that holds your ROMs — for example a ROMs folder on your SD card. " +
+            "No library yet? Leave it blank and we'll create a ROMs folder for you, with a " +
+            "sub-folder for every console eOr supports.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        FolderRow(
+            path        = state.romPath,
+            placeholder = "No folder selected — we'll create one"
+        )
+        if (state.createdRomFolder) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "Created ${state.romPath} with folders for each console",
+                style = MaterialTheme.typography.labelSmall,
+                color = ElectricBlue
+            )
+        }
+        Spacer(Modifier.height(14.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            OutlineButton("Choose Folder", onPickFolder, Modifier.weight(1f))
+            FillButton(
+                text     = if (state.romPath.isBlank()) "Create For Me" else "Continue",
+                onClick  = onContinue,
+                loading  = state.working,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+// ── Step 2: media folder + ScreenScraper account ──────────────────────────
+
+@Composable
+private fun MediaStep(
+    state: OnboardingUiState,
+    onPickFolder: () -> Unit,
+    onSsIdChange: (String) -> Unit,
+    onSsPassChange: (String) -> Unit,
+    onBack: () -> Unit,
+    onContinue: () -> Unit
+) {
+    StepTitle("Artwork & videos", "Where should box art, screenshots and videos be saved?")
+    StepCard {
+        Text(
+            "Pick a media folder — if it already contains an ES-DE library we'll import it. " +
+            "Leave it blank and we'll create one for you.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        FolderRow(
+            path        = state.mediaPath,
+            placeholder = "No folder selected — we'll create one"
+        )
+        Spacer(Modifier.height(10.dp))
+        OutlineButton("Choose Folder", onPickFolder, Modifier.fillMaxWidth())
+
+        Spacer(Modifier.height(18.dp))
+        Text(
+            "ScreenScraper account (optional)",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "A free screenscraper.fr account gives the best art and video previews. Without one, " +
+            "eOr falls back to libretro thumbnails and LaunchBox.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        OutlinedTextField(
+            value = state.ssId,
+            onValueChange = onSsIdChange,
+            label = { Text("Username (ssid)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        OutlinedTextField(
+            value = state.ssPassword,
+            onValueChange = onSsPassChange,
+            label = { Text("Password") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(14.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            OutlineButton("Back", onBack, Modifier.weight(1f))
+            FillButton(
+                text     = if (state.mediaPath.isBlank()) "Create For Me" else "Continue",
+                onClick  = onContinue,
+                loading  = state.working,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+// ── Step 3: appearance ────────────────────────────────────────────────────
+
+@Composable
+private fun ThemeStep(
+    darkMode: Boolean,
+    onSetDark: (Boolean) -> Unit,
+    onBack: () -> Unit,
+    onContinue: () -> Unit
+) {
+    StepTitle("Pick your look", "You can change this any time in Settings.")
+    StepCard {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            ThemeChoice("Light", Icons.Default.LightMode, selected = !darkMode,
+                        onClick = { onSetDark(false) }, modifier = Modifier.weight(1f))
+            ThemeChoice("Dark", Icons.Default.DarkMode, selected = darkMode,
+                        onClick = { onSetDark(true) }, modifier = Modifier.weight(1f))
+        }
+        Spacer(Modifier.height(14.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            OutlineButton("Back", onBack, Modifier.weight(1f))
+            FillButton("Continue", onContinue, modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun ThemeChoice(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .border(
+                width = 2.dp,
+                color = if (selected) ElectricBlue else Color.Transparent,
+                shape = RoundedCornerShape(14.dp)
+            )
+            .clickable(onClick = onClick)
+            .padding(vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            icon, contentDescription = label,
+            tint = if (selected) ElectricBlue else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(30.dp)
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            label,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+// ── Step 4: setup checklist ───────────────────────────────────────────────
+
+@Composable
+private fun SetupStepContent(
+    setup: FirstRunSetupState,
+    onContinue: () -> Unit
+) {
+    // The media download can outlive this screen — ask for notification permission up front so
+    // the "library ready" notification can be delivered if the user continues early.
+    val notifPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { }
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notifPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    StepTitle("Building your library", "This runs once — media keeps downloading in the background if you skip ahead.")
+    StepCard {
+        SetupRow("ROM library scan",  setup.romScan)
+        SetupRow("Emulator detection", setup.emulatorDetect)
+        SetupRow("Android games",      setup.androidScan)
+        SetupRow("Artwork & videos",   setup.mediaScan)
+
+        Spacer(Modifier.height(16.dp))
+
+        val mediaRunning = setup.requiredStepsSettled && !setup.mediaScan.isSettled
+        FillButton(
+            text = when {
+                !setup.requiredStepsSettled -> "Scanning…"
+                mediaRunning                -> "Continue — finish media in background"
+                else                        -> "Enter eOr"
+            },
+            onClick  = onContinue,
+            enabled  = setup.requiredStepsSettled,
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (mediaRunning) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "We'll send a notification when the media download finishes.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun SetupRow(label: String, step: SetupStep) {
+    Column(Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            when (step) {
+                is SetupStep.Pending -> Icon(
+                    Icons.Default.RadioButtonUnchecked, contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(20.dp)
+                )
+                is SetupStep.Running -> CircularProgressIndicator(
+                    color = ElectricBlue, strokeWidth = 2.dp, modifier = Modifier.size(20.dp)
+                )
+                is SetupStep.Done -> Icon(
+                    Icons.Default.CheckCircle, contentDescription = "Done",
+                    tint = ElectricBlue, modifier = Modifier.size(20.dp)
+                )
+                is SetupStep.Failed -> Icon(
+                    Icons.Default.ErrorOutline, contentDescription = "Failed",
+                    tint = MaterialTheme.colorScheme.error, modifier = Modifier.size(20.dp)
+                )
+            }
+            Spacer(Modifier.width(10.dp))
+            Text(label, style = MaterialTheme.typography.titleSmall,
+                 color = MaterialTheme.colorScheme.onSurface, modifier = Modifier.weight(1f))
+            when (step) {
+                is SetupStep.Running -> if (step.total > 0) Text(
+                    "${step.done} / ${step.total}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                else -> {}
+            }
+        }
+        when (step) {
+            is SetupStep.Running -> {
+                Spacer(Modifier.height(6.dp))
+                if (step.total > 0) {
+                    LinearProgressIndicator(
+                        progress = { step.done.toFloat() / step.total },
+                        color    = ElectricBlue,
+                        modifier = Modifier.fillMaxWidth().padding(start = 30.dp)
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        color    = ElectricBlue,
+                        modifier = Modifier.fillMaxWidth().padding(start = 30.dp)
+                    )
+                }
+                if (step.detail.isNotBlank()) {
+                    Spacer(Modifier.height(4.dp))
+                    DetailText(step.detail)
+                }
+            }
+            is SetupStep.Done   -> DetailText(step.summary)
+            is SetupStep.Failed -> DetailText(step.message, MaterialTheme.colorScheme.error)
+            else -> {}
+        }
+    }
+}
+
+@Composable
+private fun DetailText(text: String, color: Color = MaterialTheme.colorScheme.onSurfaceVariant) {
+    Text(
+        text, style = MaterialTheme.typography.labelSmall, color = color,
+        maxLines = 1, modifier = Modifier.padding(start = 30.dp)
+    )
+}
+
+// ── Shared bits ───────────────────────────────────────────────────────────
+
+@Composable
+private fun StepTitle(title: String, subtitle: String) {
+    Text(title, style = MaterialTheme.typography.headlineSmall,
+         fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+    Spacer(Modifier.height(4.dp))
+    Text(subtitle, style = MaterialTheme.typography.bodyMedium,
+         color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Spacer(Modifier.height(14.dp))
+}
+
+@Composable
+private fun StepCard(content: @Composable () -> Unit) {
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(16.dp),
+        colors    = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Column(Modifier.padding(18.dp)) { content() }
+    }
+}
+
+@Composable
+private fun FolderRow(path: String, placeholder: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(Icons.Default.FolderOpen, contentDescription = null,
+             tint = ElectricBlue, modifier = Modifier.size(20.dp))
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text  = path.ifBlank { placeholder },
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (path.isBlank()) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun FillButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    loading: Boolean = false
+) {
+    val alpha = if (enabled) 1f else 0.5f
+    Box(
+        modifier = modifier
+            .height(46.dp)
+            .clip(RoundedCornerShape(23.dp))
+            .background(Brush.horizontalGradient(
+                listOf(ElectricBlue.copy(alpha = alpha), NeonPurple.copy(alpha = alpha))
+            ))
+            .then(if (enabled && !loading) Modifier.clickable(onClick = onClick) else Modifier),
+        contentAlignment = Alignment.Center
+    ) {
+        if (loading) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp), color = Color.White, strokeWidth = 2.dp)
+        } else {
+            Text(text, style = MaterialTheme.typography.labelLarge, color = Color.White,
+                 maxLines = 1, modifier = Modifier.padding(horizontal = 12.dp))
+        }
+    }
+}
+
+@Composable
+private fun OutlineButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .height(46.dp)
+            .clip(RoundedCornerShape(23.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text, style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,135 @@
+package com.gamelaunch.frontend.ui.screen.onboarding
+
+import android.os.Environment
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.domain.usecase.FirstRunSetupManager
+import com.gamelaunch.frontend.domain.usecase.FirstRunSetupState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+
+enum class OnboardingStep { ROM_FOLDER, MEDIA, THEME, SETUP }
+
+data class OnboardingUiState(
+    val step: OnboardingStep = OnboardingStep.ROM_FOLDER,
+    val romPath: String = "",
+    val createdRomFolder: Boolean = false,   // we made a starter ROMs folder for the user
+    val mediaPath: String = "",
+    val createdMediaFolder: Boolean = false,
+    val ssId: String = "",
+    val ssPassword: String = "",
+    val darkMode: Boolean = false,
+    val working: Boolean = false             // folder creation / persistence in flight
+)
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val settingsRepository: SettingsRepository,
+    private val setupManager: FirstRunSetupManager
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OnboardingUiState())
+    val uiState: StateFlow<OnboardingUiState> = _uiState
+
+    val setupState: StateFlow<FirstRunSetupState> = setupManager.state
+
+    fun setRomPath(path: String) = _uiState.update { it.copy(romPath = path, createdRomFolder = false) }
+    fun setMediaPath(path: String) = _uiState.update { it.copy(mediaPath = path, createdMediaFolder = false) }
+    fun updateSsId(value: String) = _uiState.update { it.copy(ssId = value) }
+    fun updateSsPassword(value: String) = _uiState.update { it.copy(ssPassword = value) }
+
+    /** Persist the theme immediately so the whole app previews it live. */
+    fun setDarkMode(dark: Boolean) {
+        _uiState.update { it.copy(darkMode = dark) }
+        viewModelScope.launch { settingsRepository.setDarkMode(dark) }
+    }
+
+    fun backStep() {
+        _uiState.update {
+            val prev = OnboardingStep.entries.getOrNull(it.step.ordinal - 1) ?: it.step
+            it.copy(step = prev)
+        }
+    }
+
+    /**
+     * Leave the ROM step. A blank selection means the user has no library yet, so we create a
+     * starter ROMs folder on internal storage with one sub-folder per supported console.
+     */
+    fun confirmRomStep() {
+        if (_uiState.value.working) return
+        _uiState.update { it.copy(working = true) }
+        viewModelScope.launch {
+            var path = _uiState.value.romPath
+            if (path.isBlank()) {
+                path = createDefaultRomFolders()
+                _uiState.update { it.copy(romPath = path, createdRomFolder = true) }
+            }
+            settingsRepository.setRomRootPath(path)
+            _uiState.update { it.copy(working = false, step = OnboardingStep.MEDIA) }
+        }
+    }
+
+    /**
+     * Leave the media step. Blank selection → create a media folder for the user. Credentials are
+     * optional; when present they're saved so the media scan uses ScreenScraper directly.
+     */
+    fun confirmMediaStep() {
+        if (_uiState.value.working) return
+        _uiState.update { it.copy(working = true) }
+        viewModelScope.launch {
+            val s = _uiState.value
+            var path = s.mediaPath
+            if (path.isBlank()) {
+                path = createDefaultMediaFolder()
+                _uiState.update { it.copy(mediaPath = path, createdMediaFolder = true) }
+            }
+            settingsRepository.setMediaStoragePath(path)
+            if (s.ssId.isNotBlank() && s.ssPassword.isNotBlank()) {
+                settingsRepository.setScraperCredentials(s.ssId.trim(), s.ssPassword)
+            }
+            _uiState.update { it.copy(working = false, step = OnboardingStep.THEME) }
+        }
+    }
+
+    /** Theme picked — move to the setup checklist and start the pipeline. */
+    fun confirmThemeStep() {
+        _uiState.update { it.copy(step = OnboardingStep.SETUP) }
+        setupManager.start()
+    }
+
+    /**
+     * Enter the app. If the media scan is still running it continues in the background and posts
+     * a notification when done. `onDone` fires only after the first-launch flag is persisted, so
+     * a relaunch can never land back in onboarding.
+     */
+    fun finishOnboarding(onDone: () -> Unit) {
+        setupManager.notifyWhenMediaScanFinishes()
+        viewModelScope.launch {
+            settingsRepository.setFirstLaunchComplete()
+            onDone()
+        }
+    }
+
+    private suspend fun createDefaultRomFolders(): String = withContext(Dispatchers.IO) {
+        val root = File(Environment.getExternalStorageDirectory(), "ROMs")
+        PlatformDefinitions.ALL.forEach { platform ->
+            runCatching { File(root, platform.folderNames.first()).mkdirs() }
+        }
+        root.absolutePath
+    }
+
+    private suspend fun createDefaultMediaFolder(): String = withContext(Dispatchers.IO) {
+        val folder = File(Environment.getExternalStorageDirectory(), "eOr/media")
+        runCatching { folder.mkdirs() }
+        folder.absolutePath
+    }
+}


### PR DESCRIPTION
## What
A first-time-user onboarding flow, shown only on the very first launch (replaces the old behavior of landing on Settings):

1. **ROM library folder** — SAF folder picker. Left blank, eOr creates a starter `ROMs` folder on internal storage with a sub-folder for every supported console.
2. **Media folder + ScreenScraper account** — folder picker (an existing ES-DE library is imported automatically); blank creates an `eOr/media` folder. ScreenScraper credentials are optional — without them scraping falls back to libretro/LaunchBox.
3. **Appearance** — light/dark choice, applied live.
4. **Setup checklist** — runs with per-item progress indicators, in order: ROM library scan, emulator detection, Android games scan, then artwork/video download.

The user must wait for the three scans, but can continue into the app while the media download is still running. `FirstRunSetupManager` runs the pipeline in an application-scoped coroutine (not a viewModelScope), so the download survives leaving onboarding and posts a **"Your library is ready"** notification when it finishes (`POST_NOTIFICATIONS` requested on the setup step for API 33+).

Gamepad support: A advances a step, B goes back.

## Testing
Verified end-to-end on a Retroid Pocket 4 Pro with a cleared first-launch flag: wizard steps render and advance, real ROM/media folders selected via SAF, setup checklist ran a full 9,720-file ROM scan with live progress, and the persisted paths were confirmed in DataStore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)