### PR TITLE
Release v1.5.0 — custom branded background, update notifications, grid paging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 17
-        versionName = "1.4.0"
+        versionCode = 18
+        versionName = "1.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -1,7 +1,12 @@
 package com.gamelaunch.frontend
 
 import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -25,7 +30,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.navigation.compose.rememberNavController
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -34,16 +47,23 @@ import com.gamelaunch.frontend.domain.platform.sortedBySystems
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.domain.usecase.AppUpdate
+import com.gamelaunch.frontend.domain.usecase.CheckForUpdateUseCase
+import com.gamelaunch.frontend.ui.component.UpdateBanner
 import com.gamelaunch.frontend.ui.navigation.AppNavGraph
 import com.gamelaunch.frontend.ui.navigation.Screen
 import com.gamelaunch.frontend.ui.theme.AppTheme
+import com.gamelaunch.frontend.ui.theme.BackgroundBranding
+import com.gamelaunch.frontend.ui.theme.BackgroundImageMode
 import com.gamelaunch.frontend.ui.theme.NavyBg
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import javax.inject.Inject
@@ -54,6 +74,10 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var settingsRepository: SettingsRepository
     @Inject lateinit var gameRepository: GameRepository
     @Inject lateinit var mediaRepository: MediaRepository
+    @Inject lateinit var checkForUpdateUseCase: CheckForUpdateUseCase
+
+    // Set when a newer GitHub release is found; drives the in-app update banner.
+    private val updateState = mutableStateOf<AppUpdate?>(null)
 
     // The branded splash stays up until cold-start data is loaded and the first screen's box art
     // is warmed in Coil's cache, so Home appears populated instead of grey-then-crossfading in.
@@ -86,10 +110,38 @@ class MainActivity : ComponentActivity() {
 
         requestStoragePermissions()
         requestAllFilesAccessIfNeeded()
+        checkForUpdate()
 
         setContent {
             val darkMode by settingsRepository.darkMode.collectAsState(initial = false)
-            AppTheme(darkMode = darkMode) {
+
+            // User's optional branded background: decode the processed mask off the main thread,
+            // re-decoding only when the path changes, and hand it to the theme for AmbientBackground.
+            val bgEnabled by settingsRepository.backgroundImageEnabled.collectAsState(initial = false)
+            val bgPath by settingsRepository.backgroundImagePath.collectAsState(initial = "")
+            val bgMode by settingsRepository.backgroundImageMode.collectAsState(initial = "FILL")
+            val bgOpacity by settingsRepository.backgroundImageOpacity.collectAsState(initial = 0.15f)
+            val brandingMask by produceState<ImageBitmap?>(null, bgEnabled, bgPath) {
+                value = when {
+                    !bgEnabled -> null
+                    // A user-picked image takes precedence…
+                    bgPath.isNotBlank() -> withContext(Dispatchers.IO) {
+                        runCatching { BitmapFactory.decodeFile(bgPath)?.asImageBitmap() }.getOrNull()
+                    }
+                    // …otherwise fall back to the eOr donkey silhouette as a branded default.
+                    else -> withContext(Dispatchers.IO) { donkeySilhouetteMask() }
+                }
+            }
+            val branding = BackgroundBranding(
+                enabled = bgEnabled && brandingMask != null,
+                mask    = brandingMask,
+                mode    = runCatching { BackgroundImageMode.valueOf(bgMode) }
+                    .getOrDefault(BackgroundImageMode.FILL),
+                opacity = bgOpacity
+            )
+
+            AppTheme(darkMode = darkMode, branding = branding) {
+                Box(Modifier.fillMaxSize()) {
                 val navController = rememberNavController()
                 // Use null as initial so NavHost isn't created until we know the real value.
                 // With initial = true (old code) the NavHost always initialized at Settings,
@@ -115,6 +167,21 @@ class MainActivity : ComponentActivity() {
                         // onKeyEvent first, so this only runs when nothing else consumed it.
                         BackHandler { navController.popBackStack() }
                     }
+                }
+
+                updateState.value?.let { up ->
+                    UpdateBanner(
+                        versionName = up.versionName,
+                        onOpen = {
+                            runCatching {
+                                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(up.releaseUrl)))
+                            }
+                            updateState.value = null
+                        },
+                        onDismiss = { updateState.value = null },
+                        modifier = Modifier.align(Alignment.TopCenter)
+                    )
+                }
                 }
             }
         }
@@ -171,6 +238,61 @@ class MainActivity : ComponentActivity() {
                 }
             }.awaitAll()
         }
+    }
+
+    /**
+     * Rasterise the eOr donkey silhouette drawable into a square bitmap used as the default branded
+     * background when the user enables a custom background without picking their own image. The
+     * shape's alpha channel is what matters — [AmbientBackground] recolours it with the theme tint.
+     */
+    private fun donkeySilhouetteMask(): ImageBitmap? = runCatching {
+        ContextCompat.getDrawable(this, R.drawable.ic_donkey_silhouette)
+            ?.toBitmap(width = 512, height = 512)
+            ?.asImageBitmap()
+    }.getOrNull()
+
+    /**
+     * On launch, ask GitHub whether a newer release exists. If so, surface an in-app banner and —
+     * once per new version — a system notification so users hear about it even outside the app.
+     */
+    private fun checkForUpdate() {
+        lifecycleScope.launch {
+            val update = checkForUpdateUseCase() ?: return@launch
+            updateState.value = update
+            val prefs = getSharedPreferences("app_updates", MODE_PRIVATE)
+            if (prefs.getString("notified_version", null) != update.versionName) {
+                notifyUpdate(update)
+                prefs.edit().putString("notified_version", update.versionName).apply()
+            }
+        }
+    }
+
+    private fun notifyUpdate(update: AppUpdate) {
+        val channelId = "app_updates"
+        val nm = getSystemService(NotificationManager::class.java) ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            nm.createNotificationChannel(
+                NotificationChannel(channelId, "App updates", NotificationManager.IMPORTANCE_DEFAULT)
+            )
+        }
+        // Android 13+ requires the runtime POST_NOTIFICATIONS grant to post.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) return
+
+        val pending = PendingIntent.getActivity(
+            this, 0,
+            Intent(Intent.ACTION_VIEW, Uri.parse(update.releaseUrl)),
+            PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_donkey_silhouette)
+            .setContentTitle("Update available")
+            .setContentText("eOr ${update.versionName} is available — tap to download")
+            .setAutoCancel(true)
+            .setContentIntent(pending)
+            .build()
+        nm.notify(1001, notification)
     }
 
     // Re-hide bars if Android temporarily shows them (e.g. swipe-from-edge)
@@ -240,7 +362,8 @@ class MainActivity : ComponentActivity() {
         val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             arrayOf(
                 Manifest.permission.READ_MEDIA_IMAGES,
-                Manifest.permission.READ_MEDIA_VIDEO
+                Manifest.permission.READ_MEDIA_VIDEO,
+                Manifest.permission.POST_NOTIFICATIONS
             )
         } else {
             arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -39,6 +40,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val SHOW_RECENTLY_PLAYED = booleanPreferencesKey("show_recently_played")
         val SHOW_RETRO_ACHIEVEMENTS = booleanPreferencesKey("show_retro_achievements")
         val DARK_MODE = booleanPreferencesKey("dark_mode")
+        val BG_IMAGE_ENABLED = booleanPreferencesKey("background_image_enabled")
+        val BG_IMAGE_PATH = stringPreferencesKey("background_image_path")
+        val BG_IMAGE_MODE = stringPreferencesKey("background_image_mode")
+        val BG_IMAGE_OPACITY = floatPreferencesKey("background_image_opacity")
         val SYSTEM_SORT = stringPreferencesKey("system_sort")
         val RA_USERNAME = stringPreferencesKey("ra_username")
         val RA_API_KEY = stringPreferencesKey("ra_api_key")
@@ -66,6 +71,12 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val showRecentlyPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RECENTLY_PLAYED] ?: true }
     val showRetroAchievements: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RETRO_ACHIEVEMENTS] ?: true }
     val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
+    // Optional user-supplied branded background. Path points at the processed single-colour
+    // mask PNG in filesDir; mode is FILL (one full-width silhouette) or TILE (repeating pattern).
+    val backgroundImageEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.BG_IMAGE_ENABLED] ?: false }
+    val backgroundImagePath: Flow<String> = context.dataStore.data.map { it[Keys.BG_IMAGE_PATH] ?: "" }
+    val backgroundImageMode: Flow<String> = context.dataStore.data.map { it[Keys.BG_IMAGE_MODE] ?: "FILL" }
+    val backgroundImageOpacity: Flow<Float> = context.dataStore.data.map { it[Keys.BG_IMAGE_OPACITY] ?: 0.15f }
     // Up to two sort keys, comma-joined (e.g. "RELEASE_DATE,BRAND"). Empty = default order.
     val systemSort: Flow<List<String>> = context.dataStore.data.map {
         it[Keys.SYSTEM_SORT]?.split(",")?.filter { s -> s.isNotBlank() } ?: emptyList()
@@ -96,6 +107,15 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
     suspend fun setShowRetroAchievements(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RETRO_ACHIEVEMENTS] = enabled }
     suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
+    suspend fun setBackgroundImageEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.BG_IMAGE_ENABLED] = enabled }
+    suspend fun setBackgroundImagePath(path: String) = context.dataStore.edit { it[Keys.BG_IMAGE_PATH] = path }
+    suspend fun setBackgroundImageMode(mode: String) = context.dataStore.edit { it[Keys.BG_IMAGE_MODE] = mode }
+    suspend fun setBackgroundImageOpacity(opacity: Float) = context.dataStore.edit { it[Keys.BG_IMAGE_OPACITY] = opacity }
+    // Drop only the user's image (revert to the default silhouette); the enabled flag is controlled
+    // independently by its own toggle.
+    suspend fun clearBackgroundImage() = context.dataStore.edit {
+        it.remove(Keys.BG_IMAGE_PATH)
+    }
     suspend fun setSystemSort(keys: List<String>) = context.dataStore.edit { it[Keys.SYSTEM_SORT] = keys.joinToString(",") }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
         it[Keys.RA_API_KEY] = apiKey

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -52,6 +52,10 @@ class SettingsRepositoryImpl @Inject constructor(
     override val showRecentlyPlayed: Flow<Boolean> = dataStore.showRecentlyPlayed
     override val showRetroAchievements: Flow<Boolean> = dataStore.showRetroAchievements
     override val darkMode: Flow<Boolean> = dataStore.darkMode
+    override val backgroundImageEnabled: Flow<Boolean> = dataStore.backgroundImageEnabled
+    override val backgroundImagePath: Flow<String> = dataStore.backgroundImagePath
+    override val backgroundImageMode: Flow<String> = dataStore.backgroundImageMode
+    override val backgroundImageOpacity: Flow<Float> = dataStore.backgroundImageOpacity
     override val systemSort: Flow<List<SystemSort>> =
         dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
     override val raUsername: Flow<String> = dataStore.raUsername
@@ -91,6 +95,11 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
     override suspend fun setShowRetroAchievements(enabled: Boolean) { dataStore.setShowRetroAchievements(enabled) }
     override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
+    override suspend fun setBackgroundImageEnabled(enabled: Boolean) { dataStore.setBackgroundImageEnabled(enabled) }
+    override suspend fun setBackgroundImagePath(path: String) { dataStore.setBackgroundImagePath(path) }
+    override suspend fun setBackgroundImageMode(mode: String) { dataStore.setBackgroundImageMode(mode) }
+    override suspend fun setBackgroundImageOpacity(opacity: Float) { dataStore.setBackgroundImageOpacity(opacity) }
+    override suspend fun clearBackgroundImage() { dataStore.clearBackgroundImage() }
     override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
     override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }
     override suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) {

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -17,6 +17,10 @@ interface SettingsRepository {
     val showRecentlyPlayed: Flow<Boolean>
     val showRetroAchievements: Flow<Boolean>
     val darkMode: Flow<Boolean>
+    val backgroundImageEnabled: Flow<Boolean>
+    val backgroundImagePath: Flow<String>
+    val backgroundImageMode: Flow<String>
+    val backgroundImageOpacity: Flow<Float>
     val systemSort: Flow<List<SystemSort>>
     val raUsername: Flow<String>
     val raApiKey: Flow<String>
@@ -43,6 +47,11 @@ interface SettingsRepository {
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
     suspend fun setShowRetroAchievements(enabled: Boolean)
     suspend fun setDarkMode(enabled: Boolean)
+    suspend fun setBackgroundImageEnabled(enabled: Boolean)
+    suspend fun setBackgroundImagePath(path: String)
+    suspend fun setBackgroundImageMode(mode: String)
+    suspend fun setBackgroundImageOpacity(opacity: Float)
+    suspend fun clearBackgroundImage()
     suspend fun setSystemSort(keys: List<SystemSort>)
     suspend fun setRaApiKey(apiKey: String)
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/CheckForUpdateUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/CheckForUpdateUseCase.kt
@@ -1,0 +1,68 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import javax.inject.Inject
+
+/** A newer published GitHub release than the installed build. */
+data class AppUpdate(val versionName: String, val releaseUrl: String)
+
+/**
+ * Checks the project's GitHub "latest release" and reports it when it's newer than the installed
+ * app version. No backend required — it's a plain read of the public Releases API on app launch.
+ */
+class CheckForUpdateUseCase @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val client = OkHttpClient()
+
+    suspend operator fun invoke(): AppUpdate? = withContext(Dispatchers.IO) {
+        runCatching {
+            val current = context.packageManager
+                .getPackageInfo(context.packageName, 0).versionName ?: return@runCatching null
+
+            val request = Request.Builder()
+                .url(LATEST_RELEASE_URL)
+                .header("Accept", "application/vnd.github+json")
+                .build()
+
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) return@runCatching null
+                val body = resp.body?.string() ?: return@runCatching null
+                val json = JSONObject(body)
+                // Ignore drafts / pre-releases — only ship stable versions to users.
+                if (json.optBoolean("draft") || json.optBoolean("prerelease")) return@runCatching null
+
+                val tag = json.optString("tag_name").ifBlank { return@runCatching null }
+                val latest = tag.trimStart('v', 'V')
+                if (!isNewer(latest, current)) return@runCatching null
+
+                val url = json.optString("html_url").ifBlank { RELEASES_PAGE }
+                AppUpdate(latest, url)
+            }
+        }.getOrNull()
+    }
+
+    /** Numeric, dot-separated version compare (e.g. "1.5.0" > "1.4.0"); non-numeric parts ignored. */
+    private fun isNewer(latest: String, current: String): Boolean {
+        val l = latest.split('.', '-').mapNotNull { it.toIntOrNull() }
+        val c = current.split('.', '-').mapNotNull { it.toIntOrNull() }
+        for (i in 0 until maxOf(l.size, c.size)) {
+            val a = l.getOrElse(i) { 0 }
+            val b = c.getOrElse(i) { 0 }
+            if (a != b) return a > b
+        }
+        return false
+    }
+
+    companion object {
+        private const val REPO = "keweis2/eOr"
+        private const val LATEST_RELEASE_URL = "https://api.github.com/repos/$REPO/releases/latest"
+        private const val RELEASES_PAGE = "https://github.com/$REPO/releases/latest"
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ConvertBackgroundImageUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ConvertBackgroundImageUseCase.kt
@@ -1,0 +1,107 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * Turns a user-picked photo into a single-colour "branding" silhouette that can be tinted to match
+ * light/dark mode at draw time.
+ *
+ * The picked image is downsampled, then reduced to an alpha mask: each pixel's distance from white
+ * (covering both dark and saturated-colour subjects) becomes its opacity, while near-white/near-
+ * transparent areas drop out. Colour is discarded (RGB forced to white) so the mask can be recoloured
+ * with any theme tint via [androidx.compose.ui.graphics.ColorFilter.tint]. The result is saved as a
+ * PNG in filesDir and its path returned.
+ */
+class ConvertBackgroundImageUseCase @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val MAX_DIMENSION = 1080     // cap the mask size to keep memory/draw cheap
+        private const val THRESHOLD = 0.14f        // below this "ink" level a pixel is fully transparent
+        private const val CONTRAST_GAMMA = 0.85f   // <1 lifts mid-tones so faint subjects stay visible
+        private val MAX_DIST = sqrt(3f) * 255f      // distance from white for pure black/opposite colour
+    }
+
+    /** @return absolute path of the saved mask PNG, or null if the image could not be processed. */
+    suspend operator fun invoke(uri: Uri): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val source = decodeDownsampled(uri) ?: return@runCatching null
+            val mask = toAlphaMask(source)
+            if (mask !== source) source.recycle()
+
+            val dir = File(context.filesDir, "branding").apply { mkdirs() }
+            // Clear any previous mask so we don't accumulate files, and so the new path differs
+            // (a stable filename would defeat the path-keyed decode cache in the UI).
+            dir.listFiles()?.forEach { it.delete() }
+            val dest = File(dir, "background_mask_${System.currentTimeMillis()}.png")
+            dest.outputStream().use { out ->
+                mask.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+            mask.recycle()
+            dest.absolutePath
+        }.getOrNull()
+    }
+
+    /** Decode the URI, downsampling so the longest edge is at most [MAX_DIMENSION]. */
+    private fun decodeDownsampled(uri: Uri): Bitmap? {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        context.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, bounds)
+        }
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+        var sample = 1
+        val longest = maxOf(bounds.outWidth, bounds.outHeight)
+        while (longest / sample > MAX_DIMENSION) sample *= 2
+
+        val opts = BitmapFactory.Options().apply {
+            inSampleSize = sample
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+        }
+        return context.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, opts)
+        }
+    }
+
+    /** Map each pixel to white-with-alpha, where alpha follows how far the pixel is from white. */
+    private fun toAlphaMask(src: Bitmap): Bitmap {
+        val w = src.width
+        val h = src.height
+        val pixels = IntArray(w * h)
+        src.getPixels(pixels, 0, w, 0, 0, w, h)
+
+        for (i in pixels.indices) {
+            val p = pixels[i]
+            val a = (p ushr 24) and 0xFF
+            val r = (p ushr 16) and 0xFF
+            val g = (p ushr 8) and 0xFF
+            val b = p and 0xFF
+
+            val dr = 255 - r
+            val dg = 255 - g
+            val db = 255 - b
+            val dist = sqrt((dr * dr + dg * dg + db * db).toFloat()) / MAX_DIST
+
+            var ink = ((dist - THRESHOLD) / (1f - THRESHOLD)).coerceIn(0f, 1f)
+            ink = ink.pow(CONTRAST_GAMMA)
+            val outAlpha = (ink * (a / 255f) * 255f).toInt().coerceIn(0, 255)
+
+            // White RGB + computed alpha; the tint is applied later at draw time.
+            pixels[i] = (outAlpha shl 24) or 0x00FFFFFF
+        }
+
+        val out = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        out.setPixels(pixels, 0, w, 0, 0, w, h)
+        return out
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/UpdateBanner.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/UpdateBanner.kt
@@ -1,0 +1,71 @@
+package com.gamelaunch.frontend.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.NeonPurple
+
+/**
+ * A slim top banner shown when a newer GitHub release is available. Tapping it opens the release
+ * page; the × dismisses it for the session.
+ */
+@Composable
+fun UpdateBanner(
+    versionName: String,
+    onOpen: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple)))
+            .clickable(onClick = onOpen)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Icon(Icons.Default.SystemUpdate, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
+        Text(
+            "Update available — eOr $versionName. Tap to download.",
+            color = Color.White,
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f)
+        )
+        Icon(
+            Icons.Default.Close,
+            contentDescription = "Dismiss",
+            tint = Color.White,
+            modifier = Modifier
+                .size(22.dp)
+                .clip(RoundedCornerShape(50))
+                .clickable(onClick = onDismiss)
+                .padding(2.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -64,6 +64,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
 import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.component.VideoPlayer
+import com.gamelaunch.frontend.ui.theme.AmbientBackground
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 import com.gamelaunch.frontend.ui.theme.ThemedScreen
@@ -84,7 +85,9 @@ fun GameDetailScreen(
     }
 
     ThemedScreen {
-    Scaffold(containerColor = MaterialTheme.colorScheme.surface) { _ ->
+    // Carry the branded background through to detail, blurred & faded so it stays subtle.
+    AmbientBackground(Modifier.fillMaxSize(), patternSubdued = true) {
+    Scaffold(containerColor = Color.Transparent) { _ ->
         if (state.isLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(color = ElectricBlue)
@@ -287,6 +290,7 @@ fun GameDetailScreen(
                 }
             )
         }
+    }
     }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -63,7 +63,9 @@ import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.input.GamepadA
 import com.gamelaunch.frontend.ui.input.GamepadB
 import com.gamelaunch.frontend.ui.input.GamepadL1
+import com.gamelaunch.frontend.ui.input.GamepadL2
 import com.gamelaunch.frontend.ui.input.GamepadR1
+import com.gamelaunch.frontend.ui.input.GamepadR2
 import com.gamelaunch.frontend.ui.input.GamepadStart
 import com.gamelaunch.frontend.ui.theme.AmbientBackground
 import com.gamelaunch.frontend.ui.theme.BrandBlue
@@ -100,6 +102,8 @@ fun HomeScreen(
     var appFocusIndex    by rememberSaveable { mutableIntStateOf(0) }
     var gridFocusIndex   by rememberSaveable { mutableIntStateOf(0) }
     var recentFocusIndex by rememberSaveable { mutableIntStateOf(0) }
+    // A screenful of games (whole visible rows × columns), reported by the grid, for L2/R2 paging.
+    var gridPageSize     by remember { mutableIntStateOf(0) }
 
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     // Match LazyVerticalGrid's column maths exactly so D-pad navigation lands on the right cell.
@@ -264,6 +268,15 @@ fun HomeScreen(
                                 }
                                 GamepadL1 -> { cyclePlatform(-1); true }
                                 GamepadR1 -> { cyclePlatform(+1); true }
+                                // L2/R2 jump the selection a full page (screenful of rows) at a time.
+                                GamepadL2 -> {
+                                    val page = gridPageSize.takeIf { it > 0 } ?: gameGridColumns
+                                    gridFocusIndex = (gridFocusIndex - page).coerceAtLeast(0); true
+                                }
+                                GamepadR2 -> {
+                                    val page = gridPageSize.takeIf { it > 0 } ?: gameGridColumns
+                                    gridFocusIndex = (gridFocusIndex + page).coerceAtMost(state.games.size - 1); true
+                                }
                                 GamepadB, Key.Back -> { viewModel.exitToSystems(); true }
                                 else -> false
                             }
@@ -290,7 +303,11 @@ fun HomeScreen(
                     }
                 }
         ) {
-            AmbientBackground(Modifier.fillMaxSize()) {
+            AmbientBackground(
+                Modifier.fillMaxSize(),
+                // Blur & fade the branded pattern once you're inside a system browsing games.
+                patternSubdued = state.topTab == TopTab.GAMES && state.gameViewActive
+            ) {
             Column(Modifier.fillMaxSize()) {
 
                 // ── Header + mode tabs ─────────────────────────────────
@@ -385,6 +402,7 @@ fun HomeScreen(
                             columns          = gameGridColumns,
                             mediaForGames    = state.mediaForGames,
                             focusedGameIndex = gridFocusIndex,
+                            onPageSizeChange = { gridPageSize = it },
                             modifier         = Modifier.fillMaxSize()
                         )
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.ui.screen.settings
 
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -46,6 +47,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -89,6 +92,7 @@ import com.gamelaunch.frontend.ui.theme.LayoutMode
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 import com.gamelaunch.frontend.ui.theme.ThemedScreen
 import com.gamelaunch.frontend.util.StorageUtils
+import kotlin.math.roundToInt
 
 private val gradientBrush = Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple))
 
@@ -140,6 +144,13 @@ fun SettingsScreen(
             // Persist the folder and auto-import any existing media it contains.
             viewModel.chooseMediaStorageFolder(path)
         }
+    }
+
+    // Android photo picker (no storage permission needed) for the custom branded background.
+    val backgroundImagePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        uri?.let { viewModel.importBackgroundImage(it) }
     }
 
     // L1 / R1 cycle between tabs (with wraparound), mirroring the home screen.
@@ -258,6 +269,16 @@ fun SettingsScreen(
                             DisplaySection(state, viewModel)
                             Spacer(Modifier.height(4.dp))
                             SystemSortSection(state, viewModel)
+                            Spacer(Modifier.height(4.dp))
+                            BackgroundBrandingSection(
+                                state,
+                                viewModel,
+                                onPickImage = {
+                                    backgroundImagePicker.launch(
+                                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                    )
+                                }
+                            )
                         }
                         SettingsTab.MEDIA -> {
                             MediaStorageSection(
@@ -435,6 +456,128 @@ private fun SystemSortSection(state: SettingsUiState, viewModel: SettingsViewMod
                 }
             }
         }
+    }
+}
+
+// ── Section: Background ───────────────────────────────────────────────────
+
+@Composable
+private fun BackgroundBrandingSection(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel,
+    onPickImage: () -> Unit
+) {
+    SettingsSectionHeader("Background")
+    SettingsCard {
+        val hasImage = state.backgroundImagePath.isNotBlank()
+        Text(
+            "Brand your background with an image, converted to a single-colour silhouette drawn over " +
+                "the backdrop and recoloured to match light and dark mode. With no image, the eOr " +
+                "silhouette is used.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        CardSwitchRow(
+            label           = "Enable custom background",
+            checked         = state.backgroundImageEnabled,
+            onCheckedChange = viewModel::setBackgroundImageEnabled
+        )
+        if (state.backgroundImageEnabled) {
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "Layout",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                BackgroundModeChip(
+                    label    = "Fill",
+                    selected = state.backgroundImageMode == "FILL",
+                    onClick  = { viewModel.setBackgroundImageMode("FILL") },
+                    modifier = Modifier.weight(1f)
+                )
+                BackgroundModeChip(
+                    label    = "Tile",
+                    selected = state.backgroundImageMode == "TILE",
+                    onClick  = { viewModel.setBackgroundImageMode("TILE") },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    "Opacity",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    "${(state.backgroundImageOpacity * 100).roundToInt()}%",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Slider(
+                value = state.backgroundImageOpacity,
+                onValueChange = viewModel::setBackgroundImageOpacity,
+                valueRange = 0.05f..1f,
+                colors = SliderDefaults.colors(
+                    thumbColor        = ElectricBlue,
+                    activeTrackColor  = ElectricBlue,
+                    inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                )
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        GradientFillButton(
+            text     = if (hasImage) "Replace image" else "Upload image",
+            onClick  = onPickImage,
+            modifier = Modifier.fillMaxWidth(),
+            loading  = state.convertingBackground
+        )
+        if (hasImage) {
+            Spacer(Modifier.height(8.dp))
+            GradientOutlineButton(
+                text     = "Remove image (use eOr silhouette)",
+                onClick  = viewModel::clearBackgroundImage,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+/** Pill selector used for the Fill / Tile background layout choice. */
+@Composable
+private fun BackgroundModeChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .height(42.dp)
+            .clip(RoundedCornerShape(21.dp))
+            .then(
+                if (selected) Modifier.background(gradientBrush)
+                else Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = if (selected) Color.White else MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -8,7 +8,9 @@ import com.gamelaunch.frontend.domain.repository.EmulatorRepository
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
 import com.gamelaunch.frontend.domain.repository.ScraperRepository
 import com.gamelaunch.frontend.domain.platform.SystemSort
+import android.net.Uri
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.domain.usecase.ConvertBackgroundImageUseCase
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.ImportEsdeMediaUseCase
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
@@ -56,6 +58,11 @@ data class SettingsUiState(
     val showRecentlyPlayed: Boolean = true,
     val showRetroAchievements: Boolean = true,
     val darkMode: Boolean = false,
+    val backgroundImageEnabled: Boolean = false,
+    val backgroundImagePath: String = "",
+    val backgroundImageMode: String = "FILL",
+    val backgroundImageOpacity: Float = 0.15f,
+    val convertingBackground: Boolean = false,
     val systemSort: List<SystemSort> = emptyList()
 )
 
@@ -67,6 +74,7 @@ class SettingsViewModel @Inject constructor(
     private val syncLaunchBoxUseCase: SyncLaunchBoxUseCase,
     private val importEsdeMediaUseCase: ImportEsdeMediaUseCase,
     private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
+    private val convertBackgroundImageUseCase: ConvertBackgroundImageUseCase,
     private val raRepository: RetroAchievementsRepository,
     private val launchBoxDao: LaunchBoxDao
 ) : ViewModel() {
@@ -154,6 +162,26 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.backgroundImageEnabled.collect { enabled ->
+                _uiState.update { it.copy(backgroundImageEnabled = enabled) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.backgroundImagePath.collect { path ->
+                _uiState.update { it.copy(backgroundImagePath = path) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.backgroundImageMode.collect { mode ->
+                _uiState.update { it.copy(backgroundImageMode = mode) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.backgroundImageOpacity.collect { opacity ->
+                _uiState.update { it.copy(backgroundImageOpacity = opacity) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.raUsername.collect { u ->
                 _uiState.update { it.copy(raUsername = u) }
             }
@@ -180,6 +208,39 @@ class SettingsViewModel @Inject constructor(
 
     fun setDarkMode(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setDarkMode(enabled) }
+    }
+
+    /**
+     * Convert the picked image to a single-colour branding mask, persist its path, and turn the
+     * custom background on. A spinner flag is surfaced while the (off-main-thread) conversion runs.
+     */
+    fun importBackgroundImage(uri: Uri) {
+        if (_uiState.value.convertingBackground) return
+        _uiState.update { it.copy(convertingBackground = true) }
+        viewModelScope.launch {
+            val path = convertBackgroundImageUseCase(uri)
+            if (path != null) {
+                settingsRepository.setBackgroundImagePath(path)
+                settingsRepository.setBackgroundImageEnabled(true)
+            }
+            _uiState.update { it.copy(convertingBackground = false) }
+        }
+    }
+
+    fun setBackgroundImageEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setBackgroundImageEnabled(enabled) }
+    }
+
+    fun setBackgroundImageMode(mode: String) {
+        viewModelScope.launch { settingsRepository.setBackgroundImageMode(mode) }
+    }
+
+    fun setBackgroundImageOpacity(opacity: Float) {
+        viewModelScope.launch { settingsRepository.setBackgroundImageOpacity(opacity) }
+    }
+
+    fun clearBackgroundImage() {
+        viewModelScope.launch { settingsRepository.clearBackgroundImage() }
     }
 
     /** Toggle a system-sort key. Selected keys are an ordered list of up to two (primary first). */

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/AppTheme.kt
@@ -94,9 +94,13 @@ private val GameTypography = Typography(
 @Composable
 fun AppTheme(
     darkMode: Boolean = false,
+    branding: BackgroundBranding = BackgroundBranding(),
     content: @Composable () -> Unit
 ) {
-    CompositionLocalProvider(LocalDarkMode provides darkMode) {
+    CompositionLocalProvider(
+        LocalDarkMode provides darkMode,
+        LocalBackgroundBranding provides branding
+    ) {
         MaterialTheme(
             colorScheme = GameColorScheme,
             typography  = GameTypography,

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.ui.theme
 
 import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -9,18 +10,43 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 
 /** Provided at the root by AppTheme; read anywhere in the tree to choose light vs. dark colours. */
 val LocalDarkMode = compositionLocalOf { false }
+
+/** How a user's branded background image is laid across the ambient background. */
+enum class BackgroundImageMode { FILL, TILE }
+
+/**
+ * The user's optional branded background. [mask] is the pre-processed single-colour silhouette
+ * (white RGB + alpha); it's recoloured with a theme tint at draw time so it matches light/dark mode.
+ */
+data class BackgroundBranding(
+    val enabled: Boolean = false,
+    val mask: ImageBitmap? = null,
+    val mode: BackgroundImageMode = BackgroundImageMode.FILL,
+    val opacity: Float = 0.15f
+)
+
+/** Provided at the root by AppTheme; consumed by [AmbientBackground] to overlay the branded image. */
+val LocalBackgroundBranding = compositionLocalOf { BackgroundBranding() }
 
 // ── Light, playful liquid-glass + 3DS palette ───────────────────────────────
 val LightBg   = Color(0xFFEDEFF4)   // very light cool grey base
@@ -45,14 +71,31 @@ fun tileColor(index: Int): Color = TilePalette[index % TilePalette.size]
 val BounceEasing = CubicBezierEasing(0.34f, 1.8f, 0.45f, 1f)
 const val BounceDurationMs = 420
 
-/** Ambient background — light pastels in light mode, dark navy glows in dark mode. */
+// Branded-silhouette layout constants.
+private const val FILL_FRACTION = 0.72f   // Fill scales to *contain* at this fraction (a centred mark)
+private val TILE_SIZE = 78.dp             // drawn size of each motif in Tile mode
+private val TILE_GAP = 16.dp              // transparent spacing between motifs in Tile mode
+private const val SUBDUE_ALPHA = 0.5f     // extra fade applied on game grid / detail screens
+private val SUBDUE_BLUR = 18.dp           // blur applied on game grid / detail screens
+
+/**
+ * Ambient background — light pastels in light mode, dark navy glows in dark mode. When the user has
+ * enabled a branded background, the silhouette is layered on top (behind content). Set
+ * [patternSubdued] on busier screens (the game grid, game detail) to blur and further fade that
+ * pattern so it doesn't compete with the foreground.
+ */
 @Composable
 fun AmbientBackground(
     modifier: Modifier = Modifier,
+    patternSubdued: Boolean = false,
     content: @Composable BoxScope.() -> Unit
 ) {
     val dark = LocalDarkMode.current
     val bg = if (dark) NavyBg else LightBg
+    val branding = LocalBackgroundBranding.current
+    // Recolour the silhouette so it reads as subtle branding in either mode.
+    val brandTint = if (dark) IceWhite else TileText
+    val mask = branding.mask
     Box(
         modifier
             .fillMaxSize()
@@ -75,9 +118,87 @@ fun AmbientBackground(
                     glow(Color(0xFF59E0B8).copy(alpha = 0.16f), 0.55f, 1.05f, 1.05f)
                     glow(Color(0xFFFF9CC0).copy(alpha = 0.14f), 0.18f, 0.95f, 0.75f)
                 }
-            },
-        content = content
-    )
+            }
+    ) {
+        // Branded overlay — drawn on top of the base colour + glows, behind content. It lives in its
+        // own Canvas so it can be blurred (Modifier.blur) on subdued screens, and uses a radial mask
+        // to fade toward the edges (strongest in the centre) without touching the glows.
+        if (branding.enabled && mask != null && mask.width > 0) {
+            val subdue = if (patternSubdued) SUBDUE_ALPHA else 1f
+            val fillAlpha = (branding.opacity * subdue).coerceIn(0f, 1f)
+            val tileAlpha = (branding.opacity * 0.7f * subdue).coerceIn(0f, 1f)
+            Canvas(
+                Modifier
+                    .matchParentSize()
+                    .then(if (patternSubdued) Modifier.blur(SUBDUE_BLUR) else Modifier)
+            ) {
+                val tint = ColorFilter.tint(brandTint)
+                drawContext.canvas.saveLayer(Rect(Offset.Zero, size), Paint())
+                when (branding.mode) {
+                    BackgroundImageMode.FILL -> {
+                        // Contain-fit at FILL_FRACTION, centred — a mark, not a full bleed. Wide
+                        // photos stay near full-width; square/tall art (the donkey) stays compact.
+                        val fit = minOf(size.width / mask.width, size.height / mask.height) * FILL_FRACTION
+                        val dstW = (mask.width * fit).toInt()
+                        val dstH = (mask.height * fit).toInt()
+                        drawImage(
+                            image = mask,
+                            srcOffset = IntOffset.Zero,
+                            srcSize = IntSize(mask.width, mask.height),
+                            dstOffset = IntOffset(((size.width - dstW) / 2f).toInt(), ((size.height - dstH) / 2f).toInt()),
+                            dstSize = IntSize(dstW, dstH),
+                            alpha = fillAlpha,
+                            colorFilter = tint
+                        )
+                    }
+                    BackgroundImageMode.TILE -> {
+                        // Repeat at a fixed motif size, stepping by size + gap so the motifs are
+                        // spaced apart rather than edge-to-edge. Reads as a pattern regardless of
+                        // the source image's dimensions.
+                        val drawW = TILE_SIZE.toPx()
+                        val drawH = drawW * (mask.height.toFloat() / mask.width)
+                        if (drawH >= 1f) {
+                            val gap = TILE_GAP.toPx()
+                            val strideX = drawW + gap
+                            val strideY = drawH + gap
+                            val ds = IntSize(drawW.toInt(), drawH.toInt())
+                            var y = gap / 2f
+                            while (y < size.height) {
+                                var x = gap / 2f
+                                while (x < size.width) {
+                                    drawImage(
+                                        image = mask,
+                                        srcOffset = IntOffset.Zero,
+                                        srcSize = IntSize(mask.width, mask.height),
+                                        dstOffset = IntOffset(x.toInt(), y.toInt()),
+                                        dstSize = ds,
+                                        alpha = tileAlpha,
+                                        colorFilter = tint
+                                    )
+                                    x += strideX
+                                }
+                                y += strideY
+                            }
+                        }
+                    }
+                }
+                // Radial fade: full strength through a solid central core, then a steep falloff so
+                // the screen edges are almost fully transparent. DstIn multiplies the layer's alpha.
+                drawRect(
+                    brush = Brush.radialGradient(
+                        0.0f to Color.Black,
+                        0.28f to Color.Black,
+                        1.0f to Color.Transparent,
+                        center = Offset(size.width / 2f, size.height / 2f),
+                        radius = size.width * 0.52f
+                    ),
+                    blendMode = BlendMode.DstIn
+                )
+                drawContext.canvas.restore()
+            }
+        }
+        content()
+    }
 }
 
 /**

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -29,6 +30,7 @@ fun GridHomeContent(
     columns: Int,
     mediaForGames: Map<Long, GameMedia> = emptyMap(),
     focusedGameIndex: Int = -1,
+    onPageSizeChange: (Int) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     if (games.isEmpty()) {
@@ -39,6 +41,16 @@ fun GridHomeContent(
     }
 
     val gridState = rememberLazyGridState()
+
+    // Report a "page" (whole rows currently on screen × columns) up to the caller so L2/R2 can jump
+    // the selection by a screenful at a time.
+    LaunchedEffect(gridState, columns) {
+        snapshotFlow { gridState.layoutInfo.visibleItemsInfo.size }
+            .collect { visible ->
+                val rows = (visible / columns).coerceAtLeast(1)
+                onPageSizeChange(rows * columns)
+            }
+    }
 
     // Scroll so the controller-focused card is always visible. Anchor the focused card to the
     // second visible row (one row of context above it) instead of pinning it to the top row —
@@ -62,7 +74,9 @@ fun GridHomeContent(
     LazyVerticalGrid(
         columns               = GridCells.Fixed(columns),
         state                 = gridState,
-        contentPadding        = PaddingValues(8.dp),
+        // Extra top padding so a focused top-row card (which scales 1.16× and bobs upward) clears
+        // the header instead of being clipped under it.
+        contentPadding        = PaddingValues(start = 8.dp, end = 8.dp, top = 30.dp, bottom = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement   = Arrangement.spacedBy(8.dp),
         modifier              = modifier

--- a/app/src/main/res/drawable/ic_donkey_silhouette.xml
+++ b/app/src/main/res/drawable/ic_donkey_silhouette.xml
@@ -10,12 +10,12 @@
     android:viewportWidth="48"
     android:viewportHeight="48">
 
-    <!-- Left ear -->
+    <!-- Left ear (rounded tip) -->
     <path android:fillColor="#000000"
-          android:pathData="M10,20 L6,2 L14,2 L18,22 Z"/>
-    <!-- Right ear -->
+          android:pathData="M10,20 L6.5,4 Q10,0.5 13.5,4 L18,22 Z"/>
+    <!-- Right ear (rounded tip) -->
     <path android:fillColor="#000000"
-          android:pathData="M38,20 L34,2 L42,2 L30,22 Z"/>
+          android:pathData="M38,20 L34.5,4 Q38,0.5 41.5,4 L30,22 Z"/>
     <!-- Head -->
     <path android:fillColor="#000000"
           android:pathData="M6,32 A18,16 0 1 0 42,32 A18,16 0 1 0 6,32 Z"/>


### PR DESCRIPTION
## eOr 1.5.0

- **Custom branded background** (Settings → Background): upload an image converted to a single-colour silhouette that matches light/dark mode, or use the eOr donkey silhouette by default. Fill or Tile layout, opacity control. Off by default; blurred & faded on the game grid and game detail screens.
- **Update notifications**: on launch the app checks GitHub Releases and, if a newer version exists, shows a system notification + an in-app banner.
- **Controls**: L2/R2 page through the game grid a screenful at a time.
- **Fix**: focused top-row card no longer clipped under the header.
- Rounded the donkey logo's ears; bumped version to 1.5.0 (versionCode 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)