### PR TITLE
Fix RetroAchievements 0/0 progress + game-view header spacing (v1.6.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 19
-        versionName = "1.6.0"
+        versionCode = 20
+        versionName = "1.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/network/dto/RaDto.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/network/dto/RaDto.kt
@@ -39,12 +39,14 @@ data class RaRecentGameDto(
     @SerializedName("ConsoleName")               val consoleName: String? = null,
     @SerializedName("Title")                     val title: String? = null,
     @SerializedName("ImageIcon")                 val imageIcon: String? = null,
-    @SerializedName("NumAchievements")           val numAchievements: Int? = null,
-    @SerializedName("NumAwardedToUser")          val numAwardedToUser: Int? = null,
-    @SerializedName("NumAwardedToUserHardcore")  val numAwardedHardcore: Int? = null,
+    // API_GetUserRecentlyPlayedGames returns NumPossibleAchievements / NumAchieved / PossibleScore —
+    // not the NumAchievements / NumAwardedToUser / MaxPossible names used by other RA endpoints.
+    @SerializedName("NumPossibleAchievements")   val numAchievements: Int? = null,
+    @SerializedName("NumAchieved")               val numAwardedToUser: Int? = null,
+    @SerializedName("NumAchievedHardcore")       val numAwardedHardcore: Int? = null,
     @SerializedName("ScoreAchieved")             val scoreAchieved: Int? = null,
     @SerializedName("ScoreAchievedHardcore")     val scoreAchievedHardcore: Int? = null,
-    @SerializedName("MaxPossible")               val maxPossible: Int? = null,
+    @SerializedName("PossibleScore")             val maxPossible: Int? = null,
     @SerializedName("LastPlayed")                val lastPlayed: String? = null,
     @SerializedName("HighestAwardKind")          val highestAwardKind: String? = null
 )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -316,7 +316,12 @@ fun HomeScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .statusBarsPadding()
-                            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 6.dp),
+                            .padding(
+                                start = 16.dp, end = 16.dp, top = 16.dp,
+                                // Inside a system there's no tab bar under the header, so give the
+                                // settings button / breadcrumb more breathing room above the grid.
+                                bottom = if (state.topTab == TopTab.GAMES && state.gameViewActive) 16.dp else 6.dp
+                            ),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
@@ -333,7 +338,7 @@ fun HomeScreen(
                             state.selectedPlatform?.let { pid ->
                                 Text(
                                     "  ·  " + platformDisplayName(pid),
-                                    fontSize = 16.sp,
+                                    fontSize = 18.sp,
                                     fontWeight = FontWeight.SemiBold,
                                     color = textPrimary.copy(alpha = 0.85f),
                                     maxLines = 1
@@ -343,7 +348,7 @@ fun HomeScreen(
                             if (hoveredGame != null) {
                                 Text(
                                     "  →  " + hoveredGame.title,
-                                    fontSize = 15.sp,
+                                    fontSize = 17.sp,
                                     fontWeight = FontWeight.Medium,
                                     color = BrandBlue,
                                     maxLines = 1,


### PR DESCRIPTION
Patch release **1.6.1**.

- **RetroAchievements progress bars showed 0/0 for every game.** Root cause: `RaRecentGameDto` used `NumAchievements` / `NumAwardedToUser` / `MaxPossible`, but `API_GetUserRecentlyPlayedGames` returns `NumPossibleAchievements` / `NumAchieved` / `PossibleScore` — so Gson matched nothing. Fixed the `@SerializedName`s; counts, points and bars now populate (verified: GTA:LCS → 1/53, 4/852 pts).
- **Game-selection header:** more space below the settings button (bottom padding 6→16dp inside a system, where there's no tab bar).
- **Breadcrumb text** enlarged (console 16→18sp, game 15→17sp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)