### PR TITLE
Fix cold-start loading screen (Retroid) + blur background off Games tab (v1.6.2)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 20
-        versionName = "1.6.1"
+        versionCode = 21
+        versionName = "1.6.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.GameLauncher.Splash"
+            android:theme="@style/Theme.GameLauncher"
             android:launchMode="singleTask"
             android:stateNotNeeded="true"
             android:windowSoftInputMode="adjustResize"

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -49,6 +49,7 @@ import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.domain.usecase.AppUpdate
 import com.gamelaunch.frontend.domain.usecase.CheckForUpdateUseCase
+import com.gamelaunch.frontend.ui.component.LoadingScreen
 import com.gamelaunch.frontend.ui.component.UpdateBanner
 import com.gamelaunch.frontend.ui.navigation.AppNavGraph
 import com.gamelaunch.frontend.ui.navigation.Screen
@@ -82,7 +83,8 @@ class MainActivity : ComponentActivity() {
 
     // The branded splash stays up until cold-start data is loaded and the first screen's box art
     // is warmed in Coil's cache, so Home appears populated instead of grey-then-crossfading in.
-    @Volatile private var splashReady = false
+    // Compose-observable so the in-app loading screen can react, not just the system splash.
+    private val splashReady = mutableStateOf(false)
 
     // Track last axis values so we only fire once per threshold crossing
     private var lastAxisX   = 0f
@@ -95,14 +97,12 @@ class MainActivity : ComponentActivity() {
     ) { /* storage permissions handled — ROM folder picker and all-files access are the fallback */ }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        // installSplashScreen() reads the theme and must run before super.onCreate(); the keep
-        // condition and warm-up run after, once Hilt has injected the repositories.
-        val splash = installSplashScreen()
         super.onCreate(savedInstanceState)
 
-        // Hold the splash until the first screen is warm (bounded so it can never hang), then let
-        // Android cross-fade it away.
-        splash.setKeepOnScreenCondition { !splashReady }
+        // No SplashScreen API: on API 31+ it forces the system splash (which doesn't render on some
+        // devices, e.g. the Retroid) and suppresses the window's starting background. Instead the
+        // activity theme's windowBackground (@drawable/splash_bg — logo on navy) covers the
+        // cold-start gap on every device, and the in-app LoadingScreen covers artwork warm-up.
         warmFirstScreen()
 
         // Edge-to-edge + full immersive: hide status bar and nav bar
@@ -150,12 +150,15 @@ class MainActivity : ComponentActivity() {
                 // because the DataStore emit arrives after the first Compose frame.
                 val isFirstLaunch by settingsRepository.isFirstLaunch.collectAsState(initial = null)
 
-                when (val firstLaunch = isFirstLaunch) {
-                    null -> {
-                        // DataStore hasn't emitted yet — show blank background for ~1 frame
-                        Box(Modifier.fillMaxSize().background(NavyBg))
+                // Show the in-app loading screen until artwork is warmed (splashReady) and the launch
+                // destination is known. Guarantees a visible loading state even when the OS skips the
+                // system splash (e.g. eOr launched as the home app on cold boot).
+                when {
+                    !splashReady.value || isFirstLaunch == null -> {
+                        LoadingScreen()
                     }
                     else -> {
+                        val firstLaunch = isFirstLaunch == true
                         val startDestination =
                             if (firstLaunch) Screen.Onboarding.route else Screen.Home.route
                         AppNavGraph(
@@ -202,7 +205,7 @@ class MainActivity : ComponentActivity() {
                     prewarmFirstScreenArt()
                 }
             }
-            splashReady = true
+            splashReady.value = true
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/LoadingScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/LoadingScreen.kt
@@ -1,0 +1,52 @@
+package com.gamelaunch.frontend.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.gamelaunch.frontend.R
+import com.gamelaunch.frontend.ui.theme.BrandBlue
+import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.IceWhite
+import com.gamelaunch.frontend.ui.theme.NavyBg
+
+/**
+ * In-app loading screen shown while the app warms its first screen's artwork. Rendered by the app
+ * itself (not just the system splash) so the loading state is guaranteed to appear even when the OS
+ * skips the per-app splash — e.g. when eOr is the device's home launcher and starts on cold boot.
+ */
+@Composable
+fun LoadingScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize().background(NavyBg),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(R.drawable.ic_donkey_silhouette),
+                contentDescription = null,
+                tint = BrandBlue,
+                modifier = Modifier.size(48.dp).padding(end = 8.dp)
+            )
+            Text("e", fontSize = 40.sp, fontWeight = FontWeight.ExtraBold, color = BrandBlue, letterSpacing = 3.sp)
+            Text("Or", fontSize = 40.sp, fontWeight = FontWeight.ExtraBold, color = IceWhite, letterSpacing = 3.sp)
+        }
+        Spacer(Modifier.height(28.dp))
+        CircularProgressIndicator(color = ElectricBlue, strokeWidth = 3.dp, modifier = Modifier.size(28.dp))
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -305,8 +305,9 @@ fun HomeScreen(
         ) {
             AmbientBackground(
                 Modifier.fillMaxSize(),
-                // Blur & fade the branded pattern once you're inside a system browsing games.
-                patternSubdued = state.topTab == TopTab.GAMES && state.gameViewActive
+                // Keep the background crisp only on the main Games tab (console selection); blur &
+                // fade it on every other view — game selection, Recent, Apps, RetroAchievements.
+                patternSubdued = !(state.topTab == TopTab.GAMES && !state.gameViewActive)
             ) {
             Column(Modifier.fillMaxSize()) {
 

--- a/app/src/main/res/drawable/splash_bg.xml
+++ b/app/src/main/res/drawable/splash_bg.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Window background used during cold start. The OS paints this the instant eOr's window is created —
+  before the first Compose frame — so a branded loading visual (donkey on brand navy) covers the
+  launch gap even on devices where the Android 12+ SplashScreen API doesn't render (e.g. the Retroid
+  showing the home launcher instead of the splash).
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#06091A" />
+        </shape>
+    </item>
+    <item
+        android:width="200dp"
+        android:height="200dp"
+        android:drawable="@drawable/ic_launcher_foreground"
+        android:gravity="center" />
+</layer-list>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.GameLauncher" parent="android:Theme.Material.NoActionBar">
-        <item name="android:windowBackground">#06091A</item>
+        <!-- Logo-on-navy so the launch gap shows branding, not the previous app / launcher. -->
+        <item name="android:windowBackground">@drawable/splash_bg</item>
         <item name="android:statusBarColor">#00000000</item>
         <item name="android:navigationBarColor">#00000000</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
@@ -14,5 +15,8 @@
         <item name="windowSplashScreenBackground">#06091A</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
         <item name="postSplashScreenTheme">@style/Theme.GameLauncher</item>
+        <!-- Fallback the OS paints if the SplashScreen API doesn't render (e.g. on the Retroid) so a
+             branded background still covers the cold-start gap instead of the home launcher. -->
+        <item name="android:windowBackground">@drawable/splash_bg</item>
     </style>
 </resources>


### PR DESCRIPTION
Patch **1.6.2**.

- **Loading screen never displayed on cold start on some devices (e.g. Retroid).** The Android 12+ SplashScreen API doesn't render there, and `Theme.SplashScreen` suppressed the window's starting background — so the home launcher stayed visible for seconds with no artwork warm-up. Fix: plain launch theme with a logo-on-navy `windowBackground` (reliable starting window everywhere), drop `installSplashScreen()`, and add an in-app `LoadingScreen` (logo + spinner) covering warm-up.
- **Blur the branded background on every view except the main Games tab** (game selection, Recent, Apps, RetroAchievements).

Verified on Retroid Pocket 4 Pro (Android 13): loading screen now shows on cold start; Games tab background is crisp while other tabs are blurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)