### PR TITLE
Fix launcher frozen/unresponsive after returning from a game (v1.6.3)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 21
-        versionName = "1.6.2"
+        versionCode = 22
+        versionName = "1.6.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -312,7 +312,13 @@ class MainActivity : ComponentActivity() {
     // Re-hide bars if Android temporarily shows them (e.g. swipe-from-edge)
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) hideSystemBars()
+        if (hasFocus) {
+            hideSystemBars()
+        } else {
+            // Reset joystick tracking when we lose focus (e.g. launching a game) so a stale
+            // non-neutral axis value can't leave a synthesized DPAD direction "held" on return.
+            lastAxisX = 0f; lastAxisY = 0f; lastHatX = 0f; lastHatY = 0f
+        }
     }
 
     private fun hideSystemBars() {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -44,6 +44,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
@@ -210,13 +213,29 @@ fun HomeScreen(
     }
 
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { try { focusRequester.requestFocus() } catch (_: Exception) {} }
+    var isFocused by remember { mutableStateOf(false) }
+
+    // Grab (and re-grab) controller focus on every resume — e.g. after returning from a game.
+    // Without this the focusable Box can stay unfocused after a heavy emulator session, so the
+    // launcher renders but ignores the gamepad and looks frozen. Retry briefly because window focus
+    // can lag ON_RESUME, and clear any stuck hold-to-scroll state.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        stopRepeat()
+        scope.launch {
+            var tries = 0
+            while (!isFocused && tries++ < 15) {
+                runCatching { focusRequester.requestFocus() }
+                delay(80)
+            }
+        }
+    }
 
     Scaffold(containerColor = bgColor) { _ ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .focusRequester(focusRequester)
+                .onFocusChanged { isFocused = it.hasFocus }
                 .focusable()
                 .onKeyEvent { event ->
                     val key = event.key


### PR DESCRIPTION
Patch **1.6.3**.

**Bug:** after playing a game (notably long PS2 sessions) and quitting back to eOr, the launcher could become unresponsive to the controller — rendered but not navigable.

**Cause:** the launcher requested gamepad focus only once (`LaunchedEffect(Unit)`) and never restored it on resume. Returning from a heavy game (memory-trimmed, janky transition) left the focusable Box unfocused, so key events went nowhere.

**Fix:**
- Re-request focus on every `ON_RESUME` (retrying until it sticks, since window focus can lag resume) and clear any stuck hold-to-scroll state; track focus via `onFocusChanged`.
- Reset joystick axis tracking on focus loss so a stale non-neutral stick value can't leave a synthesized DPAD direction held on return.

Verified: after backgrounding eOr behind another app and returning, the D-pad navigates again (previously this warm-resume path left it unfocused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)