### PR TITLE
Shape box-art containers to each system's box proportions

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
@@ -161,24 +161,32 @@ fun platformIcon(platformId: String): Int? =
  * Default (0.72) is the standard tall home-console box / DVD keep-case used by most consoles.
  */
 fun boxArtAspectRatio(platformId: String): Float = when (platformId) {
-    // Near-square cardboard handheld boxes
+    // ── Landscape (wider than tall): the big-cardboard Nintendo boxes ──
+    // SNES and N64 retail boxes are horizontal rectangles.
+    "snes" -> 1.32f
+    "n64" -> 1.38f
+
+    // ── Near-square handheld cartridge boxes ──
     "gb", "gbc", "gba" -> 0.92f
     "gg", "ngp", "lynx", "ws", "wsc" -> 0.95f
     // DS / 3DS plastic game cases — slightly taller than square
     "nds", "3ds" -> 0.88f
-    // UMD / Vita cartridge cases — tall and narrow
+
+    // ── Tall & narrow cartridge/disc cases ──
+    // UMD / Vita cases
     "psp", "psvita" -> 0.69f
-    // Jewel-case & CD-era systems — a touch wider than a DVD keep-case
+
+    // ── Jewel-case & CD-era systems — a touch wider than a DVD keep-case ──
     "ps1", "dc", "saturn", "segacd", "pcengine", "3do" -> 0.79f
-    // Neo Geo AES — large near-square boxes
-    "neogeo" -> 1.0f
-    // Arcade has no retail box; ScreenScraper art is roughly square (flyers / snaps)
-    "mame", "fbneo" -> 0.95f
-    // Android app icons are square; Steam vertical capsule art is 600×900
-    "android" -> 1.0f
-    "steam" -> 0.667f
-    // Standard tall home-console box / DVD keep-case: NES, SNES, N64, Genesis, SMS,
-    // GameCube, Wii, Wii U, PS2, Switch, Atari 2600, 32X, …
+
+    // ── Square-ish ──
+    "neogeo" -> 1.0f                 // Neo Geo AES — large near-square boxes
+    "mame", "fbneo" -> 0.95f         // arcade has no retail box; art ~ square (flyers / snaps)
+    "android" -> 1.0f                // Android app icons are square
+    "steam" -> 0.667f               // Steam vertical capsule art is 600×900
+
+    // ── Standard tall home-console box / DVD keep-case (default) ──
+    // NES, Genesis/Mega Drive, SMS, 32X, GameCube, Wii, Wii U, PS2, Switch, Atari 2600, …
     else -> 0.72f
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
@@ -151,6 +151,37 @@ private val platformIconAlias: Map<String, String> = mapOf(
 fun platformIcon(platformId: String): Int? =
     iconByKey[platformIconAlias[platformId] ?: platformId]
 
+/**
+ * Aspect ratio (width ÷ height) of a system's physical box art, so cover containers can take the
+ * real shape of the box instead of a one-size-fits-all rectangle — GameCube discs come in tall DVD
+ * cases, Game Boy carts came in near-square cardboard boxes, PSP UMDs in tall narrow cases, etc.
+ * Sizing containers to this ratio (with the art filling them) keeps covers from being cropped.
+ *
+ * Values approximate the retail packaging each system's ScreenScraper "box-2D" art is shot from.
+ * Default (0.72) is the standard tall home-console box / DVD keep-case used by most consoles.
+ */
+fun boxArtAspectRatio(platformId: String): Float = when (platformId) {
+    // Near-square cardboard handheld boxes
+    "gb", "gbc", "gba" -> 0.92f
+    "gg", "ngp", "lynx", "ws", "wsc" -> 0.95f
+    // DS / 3DS plastic game cases — slightly taller than square
+    "nds", "3ds" -> 0.88f
+    // UMD / Vita cartridge cases — tall and narrow
+    "psp", "psvita" -> 0.69f
+    // Jewel-case & CD-era systems — a touch wider than a DVD keep-case
+    "ps1", "dc", "saturn", "segacd", "pcengine", "3do" -> 0.79f
+    // Neo Geo AES — large near-square boxes
+    "neogeo" -> 1.0f
+    // Arcade has no retail box; ScreenScraper art is roughly square (flyers / snaps)
+    "mame", "fbneo" -> 0.95f
+    // Android app icons are square; Steam vertical capsule art is 600×900
+    "android" -> 1.0f
+    "steam" -> 0.667f
+    // Standard tall home-console box / DVD keep-case: NES, SNES, N64, Genesis, SMS,
+    // GameCube, Wii, Wii U, PS2, Switch, Atari 2600, 32X, …
+    else -> 0.72f
+}
+
 /** A controller silhouette that fits each console family — a bit of whimsy. */
 @DrawableRes
 fun platformPadIcon(platformId: String): Int = when (platformId) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -62,7 +62,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.R
+import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.component.platformDisplayName
+import kotlin.math.roundToInt
 import com.gamelaunch.frontend.ui.input.GamepadA
 import com.gamelaunch.frontend.ui.input.GamepadB
 import com.gamelaunch.frontend.ui.input.GamepadL1
@@ -112,7 +114,15 @@ fun HomeScreen(
     // Match LazyVerticalGrid's column maths exactly so D-pad navigation lands on the right cell.
     fun gridColumns(minCellDp: Int, paddingDp: Int, spacingDp: Int) =
         maxOf(1, (screenWidthDp - 2 * paddingDp + spacingDp) / (minCellDp + spacingDp))
-    val gameGridColumns = gridColumns(minCellDp = 110, paddingDp = 8, spacingDp = 8)
+    // Cover tiles take the selected system's box shape, so scale the min cell *width* by that
+    // aspect to keep tile height roughly constant across systems — otherwise landscape boxes
+    // (SNES, N64) end up as short, tiny strips at the portrait column count. ~150dp tall target
+    // (matches the old 110dp / 0.72 portrait tile).
+    val gameCellMinDp = (150f * boxArtAspectRatio(state.selectedPlatform ?: ""))
+        .roundToInt().coerceIn(96, 240)
+    val gameGridColumns = gridColumns(minCellDp = gameCellMinDp, paddingDp = 8, spacingDp = 8)
+    // Recently-played mixes systems, so keep the portrait default there.
+    val recentGridColumns = gridColumns(minCellDp = 110, paddingDp = 8, spacingDp = 8)
     val appColumns      = gridColumns(minCellDp = 96, paddingDp = 16, spacingDp = 12)
 
     // Keep focus in bounds when lists change
@@ -441,11 +451,12 @@ fun HomeScreen(
                                 )
                             } else {
                                 GridHomeContent(
-                                    games            = state.recentlyPlayed,
-                                    onGameClick      = onGameClick,
-                                    columns          = gameGridColumns,
-                                    mediaForGames    = state.mediaForGames,
-                                    focusedGameIndex = recentFocusIndex,
+                                    games              = state.recentlyPlayed,
+                                    onGameClick        = onGameClick,
+                                    columns            = recentGridColumns,
+                                    mediaForGames      = state.mediaForGames,
+                                    focusedGameIndex   = recentFocusIndex,
+                                    uniformAspectRatio = 0.72f,
                                     modifier         = Modifier.fillMaxSize()
                                 )
                             }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -135,8 +135,14 @@ private fun SystemCarousel(
                 val covers = previewArt.take(5)
                 val n = covers.size
                 // Shape the fan cards like the focused system's real box art (GameCube tall,
-                // Game Boy near-square, …) so covers aren't cropped.
+                // Game Boy near-square, SNES/N64 landscape, …) so covers aren't cropped.
                 val coverAspect = boxArtAspectRatio(focused ?: "")
+                // Landscape boxes would otherwise grow very wide at full band height; cap the
+                // card width to a fraction of the screen and shrink the height to match.
+                val maxCoverW = maxW * 0.40f
+                val coverH =
+                    if (coverHeight * coverAspect > maxCoverW) maxCoverW / coverAspect
+                    else coverHeight
                 // one progress per cover-set; cards rise + fan as it goes 0 -> 1
                 val progress = remember { Animatable(1f) }
                 LaunchedEffect(previewArt) {
@@ -175,7 +181,7 @@ private fun SystemCarousel(
                             remoteUrl = art,
                             contentDescription = null,
                             modifier = Modifier
-                                .height(coverHeight)
+                                .height(coverH)
                                 .aspectRatio(coverAspect)
                                 .shadow(14.dp, RoundedCornerShape(10.dp))
                                 .clip(RoundedCornerShape(10.dp))

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.component.platformIcon
 import com.gamelaunch.frontend.ui.component.platformPadIcon
@@ -133,6 +134,9 @@ private fun SystemCarousel(
             ) {
                 val covers = previewArt.take(5)
                 val n = covers.size
+                // Shape the fan cards like the focused system's real box art (GameCube tall,
+                // Game Boy near-square, …) so covers aren't cropped.
+                val coverAspect = boxArtAspectRatio(focused ?: "")
                 // one progress per cover-set; cards rise + fan as it goes 0 -> 1
                 val progress = remember { Animatable(1f) }
                 LaunchedEffect(previewArt) {
@@ -172,7 +176,7 @@ private fun SystemCarousel(
                             contentDescription = null,
                             modifier = Modifier
                                 .height(coverHeight)
-                                .aspectRatio(0.72f)
+                                .aspectRatio(coverAspect)
                                 .shadow(14.dp, RoundedCornerShape(10.dp))
                                 .clip(RoundedCornerShape(10.dp))
                         )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselGameCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 
@@ -34,13 +35,17 @@ fun CarouselGameCard(
     )
     val shape = RoundedCornerShape(12.dp)
 
+    // Fixed width, height derived from the system's real box shape so covers aren't cropped.
+    val cardWidth = 118.dp
+    val cardHeight = cardWidth / boxArtAspectRatio(game.platformId)
+
     AsyncGameArtwork(
         localPath          = media?.boxArtLocalPath,
         remoteUrl          = media?.boxArtRemoteUrl,
         contentDescription = game.title,
         modifier = Modifier
-            .width(118.dp)
-            .height(160.dp)
+            .width(cardWidth)
+            .height(cardHeight)
             .scale(scale)
             .then(
                 if (isSelected)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.theme.BounceDurationMs
 import com.gamelaunch.frontend.ui.theme.BounceEasing
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
@@ -110,7 +111,7 @@ fun GridGameCard(
             )
             .clip(shape)
             .fillMaxWidth()
-            .aspectRatio(0.75f)
+            .aspectRatio(boxArtAspectRatio(game.platformId))
             .then(if (isFocused) Modifier.border(2.dp, ElectricBlue, shape) else Modifier)
             .clickable(onClick = onClick)
     ) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -52,6 +52,9 @@ fun GridGameCard(
     media: GameMedia? = null,
     isFocused: Boolean = false,
     animateOnEntry: Boolean = true,
+    // Container shape. Defaults to the system's real box proportions; callers showing a mixed-system
+    // list (e.g. Recently played) pass a fixed value to keep every tile the same rectangle.
+    aspectRatio: Float = boxArtAspectRatio(game.platformId),
     onClick: () -> Unit
 ) {
     val shape = RoundedCornerShape(12.dp)
@@ -111,7 +114,7 @@ fun GridGameCard(
             )
             .clip(shape)
             .fillMaxWidth()
-            .aspectRatio(boxArtAspectRatio(game.platformId))
+            .aspectRatio(aspectRatio)
             .then(if (isFocused) Modifier.border(2.dp, ElectricBlue, shape) else Modifier)
             .clickable(onClick = onClick)
     ) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
+import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import kotlinx.coroutines.delay
 
 @Composable
@@ -31,6 +32,9 @@ fun GridHomeContent(
     mediaForGames: Map<Long, GameMedia> = emptyMap(),
     focusedGameIndex: Int = -1,
     onPageSizeChange: (Int) -> Unit = {},
+    // When set, every tile uses this fixed aspect ratio instead of its system's box shape — used by
+    // mixed-system lists (Recently played) so the grid stays a uniform rectangle.
+    uniformAspectRatio: Float? = null,
     modifier: Modifier = Modifier
 ) {
     if (games.isEmpty()) {
@@ -88,6 +92,7 @@ fun GridHomeContent(
                 media          = mediaForGames[game.id],
                 isFocused      = index == focusedGameIndex,
                 animateOnEntry = entranceWindowOpen,
+                aspectRatio    = uniformAspectRatio ?: boxArtAspectRatio(game.platformId),
                 onClick        = { onGameClick(game.id) }
             )
         }


### PR DESCRIPTION
## What
Box-art containers used a single fixed rectangle everywhere (grid `0.75`, system-selection fan `0.72`, carousel card `118×160`). Systems whose boxes aren't that shape got cropped — square Game Boy carts had their sides chopped, tall GameCube/PSP cases got squeezed.

## Change
- New `boxArtAspectRatio(platformId)` in `PlatformVisuals.kt` — width÷height per system family:
  - near-square handheld carts (GB/GBC/GBA ~0.92, GG/NGP/WS ~0.95)
  - DS/3DS cases ~0.88, UMD/Vita ~0.69
  - jewel/CD systems (PS1, DC, Saturn, Sega CD, PCE, 3DO) ~0.79
  - Neo Geo ~1.0, arcade/MAME/FBNeo ~0.95, Android app icons 1.0, Steam capsule 0.667
  - default 0.72 (standard tall home-console box / DVD keep-case)
- Drive the **grid card** (per `game.platformId`), the **system-selection fan** (focused system), and the **carousel card** from it.

## Verified on device (Retroid)
- Fan: Atari renders tall/portrait, Game Boy near-square.
- Grid: Sega Master System tall boxes show full art in a clean grid; Game Boy grid shows the full near-square box incl. the vertical "GAME BOY" spine; Android grid is square.
- No cropping in any of the three surfaces.

_No version bump — batch into the next release when ready._

🤖 Generated with [Claude Code](https://claude.com/claude-code)