### PR TITLE
Set box-art aspect ratios from measured cover art

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/PlatformVisuals.kt
@@ -152,41 +152,36 @@ fun platformIcon(platformId: String): Int? =
     iconByKey[platformIconAlias[platformId] ?: platformId]
 
 /**
- * Aspect ratio (width ÷ height) of a system's physical box art, so cover containers can take the
- * real shape of the box instead of a one-size-fits-all rectangle — GameCube discs come in tall DVD
- * cases, Game Boy carts came in near-square cardboard boxes, PSP UMDs in tall narrow cases, etc.
- * Sizing containers to this ratio (with the art filling them) keeps covers from being cropped.
+ * Aspect ratio (width ÷ height) of a system's cover art, so cover containers can take the real
+ * shape of the art instead of a one-size-fits-all rectangle — this keeps covers from being cropped.
  *
- * Values approximate the retail packaging each system's ScreenScraper "box-2D" art is shot from.
- * Default (0.72) is the standard tall home-console box / DVD keep-case used by most consoles.
+ * These values are measured, not guessed: they're the median aspect ratio of the actual scraped
+ * "covers" images across a sample of each system's library (ScreenScraper/ES-DE media). That
+ * matters because the scraped art doesn't always follow physical packaging — e.g. DS/3DS covers
+ * come through landscape, Saturn and 3DO tall, Neo Geo portrait — so measuring beats assuming.
+ * The ~0.71–0.73 portrait cluster (NES, GameCube, PS2, Genesis, SMS, 32X, Wii, Wii U, Atari,
+ * Game Gear, MAME, Neo Geo, Sega CD, Vita, Steam, …) all fall under the 0.72 default.
  */
 fun boxArtAspectRatio(platformId: String): Float = when (platformId) {
-    // ── Landscape (wider than tall): the big-cardboard Nintendo boxes ──
-    // SNES and N64 retail boxes are horizontal rectangles.
-    "snes" -> 1.32f
-    "n64" -> 1.38f
+    // Landscape (wider than tall)
+    "snes", "n64" -> 1.37f          // big cardboard boxes — horizontal
+    "ps1" -> 1.16f                  // jewel-case front, a hair wider than square
+    "3ds" -> 1.14f
+    "nds" -> 1.11f
 
-    // ── Near-square handheld cartridge boxes ──
-    "gb", "gbc", "gba" -> 0.92f
-    "gg", "ngp", "lynx", "ws", "wsc" -> 0.95f
-    // DS / 3DS plastic game cases — slightly taller than square
-    "nds", "3ds" -> 0.88f
+    // Square
+    "dc", "pcengine", "gb", "gbc", "gba", "neocd", "android" -> 1.0f
 
-    // ── Tall & narrow cartridge/disc cases ──
-    // UMD / Vita cases
-    "psp", "psvita" -> 0.69f
+    // Slightly portrait
+    "ngp" -> 0.86f
 
-    // ── Jewel-case & CD-era systems — a touch wider than a DVD keep-case ──
-    "ps1", "dc", "saturn", "segacd", "pcengine", "3do" -> 0.79f
+    // Tall / narrow
+    "saturn" -> 0.65f
+    "switch" -> 0.62f               // narrow cartridge case
+    "psp" -> 0.59f                  // UMD case — tall
+    "3do" -> 0.53f                  // longbox
 
-    // ── Square-ish ──
-    "neogeo" -> 1.0f                 // Neo Geo AES — large near-square boxes
-    "mame", "fbneo" -> 0.95f         // arcade has no retail box; art ~ square (flyers / snaps)
-    "android" -> 1.0f                // Android app icons are square
-    "steam" -> 0.667f               // Steam vertical capsule art is 600×900
-
-    // ── Standard tall home-console box / DVD keep-case (default) ──
-    // NES, Genesis/Mega Drive, SMS, 32X, GameCube, Wii, Wii U, PS2, Switch, Atari 2600, …
+    // Standard portrait box / DVD keep-case (~0.71–0.73 measured cluster)
     else -> 0.72f
 }
 


### PR DESCRIPTION
## What
Follow-up to the box-art shaping work. The earlier ratios were guessed from physical packaging, but the scraped ES-DE/ScreenScraper covers don't always match physical box orientation — so this replaces them with **measured** values: median width÷height over ~12 real cover images per system, pulled from the device.

## Key corrections
| System | Was | Now (measured) |
|---|---|---|
| **PS1** | 0.79 (tall) | **1.16** (near-square jewel case) |
| **Dreamcast / PCEngine / GB / GBC / GBA** | 0.79 / 0.92 | **1.0** (square) |
| **Nintendo DS** | 0.88 | **1.11** (landscape) |
| **Nintendo 3DS** | 0.88 | **1.14** (landscape) |
| **Saturn** | 0.79 | **0.65** (tall) |
| **3DO** | 0.79 | **0.53** (longbox) |
| **Switch** | 0.72 | **0.62** (narrow) |
| **PSP** | 0.69 | **0.59** (UMD) |
| **NGP** | 0.95 | **0.86** |
| Neo Geo / Sega CD / Game Gear / MAME / Vita / Steam | various | **0.72** cluster |

SNES/N64 stay landscape (measured 1.37). Everything in the ~0.71–0.73 measured cluster falls under the 0.72 default.

## Verified on device (Retroid)
Fan + grid checked for PS1 (near-square, full jewel-case art incl. spine — uncropped), GBA (square), 3DS (landscape), SNES/N64 (landscape), Switch (tall). PS1 grid tiles are larger and uncropped.

_Note: PS1's scraped art measures 1.16 (a hair wider than a perfect square); Dreamcast is exactly 1.0. Matched each to its real art so nothing crops._

🤖 Generated with [Claude Code](https://claude.com/claude-code)