### PR TITLE
Fix Back dead-ending on game detail + match detail box-art shape

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -53,6 +53,7 @@ import com.gamelaunch.frontend.ui.component.LoadingScreen
 import com.gamelaunch.frontend.ui.component.UpdateBanner
 import com.gamelaunch.frontend.ui.navigation.AppNavGraph
 import com.gamelaunch.frontend.ui.navigation.Screen
+import com.gamelaunch.frontend.ui.navigation.backOrHome
 import com.gamelaunch.frontend.ui.theme.AppTheme
 import com.gamelaunch.frontend.ui.theme.BackgroundBranding
 import com.gamelaunch.frontend.ui.theme.BackgroundImageMode
@@ -166,11 +167,13 @@ class MainActivity : ComponentActivity() {
                             startDestination = startDestination
                         )
                         // System Back (the Retroid's B maps to it): pop the nav stack so the
-                        // detail/settings screens return to where they came from. At the launcher
-                        // root nothing pops, so we consume it and stay instead of exiting.
+                        // detail/settings screens return to where they came from. If the stack has
+                        // nothing to pop — e.g. eOr was resumed on a sub-screen via a launcher
+                        // intent (singleTask) — fall back to Home so Back never dead-ends. At the
+                        // Home root nothing pops and we stay, instead of exiting.
                         // Focused screens (e.g. the home game grid) handle Back in their own
                         // onKeyEvent first, so this only runs when nothing else consumed it.
-                        BackHandler { navController.popBackStack() }
+                        BackHandler { navController.backOrHome() }
                     }
                 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -13,6 +14,22 @@ import com.gamelaunch.frontend.ui.screen.scan.ScanScreen
 import com.gamelaunch.frontend.ui.screen.scrape.ScrapeProgressScreen
 import com.gamelaunch.frontend.ui.screen.settings.EmulatorConfigScreen
 import com.gamelaunch.frontend.ui.screen.settings.SettingsScreen
+
+/**
+ * Go back one screen, or fall back to Home when there's nothing to pop.
+ *
+ * MainActivity is a `singleTask` launcher activity, so when eOr is resumed on a sub-screen (e.g. the
+ * game detail page) via a launcher intent — after launching a game, or pressing Home and reopening —
+ * the nav back stack can come back with that screen as the only entry. Then a plain `popBackStack()`
+ * is a no-op and every back affordance (touch arrow, gamepad B, and system Back, which the Retroid's
+ * B maps to) dead-ends, trapping the user. Routing to Home in that case guarantees an escape.
+ */
+fun NavController.backOrHome() {
+    if (popBackStack()) return
+    if (currentDestination?.route != Screen.Home.route) {
+        navigate(Screen.Home.route) { popUpTo(0) { inclusive = true } }
+    }
+}
 
 @Composable
 fun AppNavGraph(
@@ -57,7 +74,7 @@ fun AppNavGraph(
             arguments = listOf(navArgument(Screen.GameDetail.ARG_GAME_ID) { type = NavType.LongType })
         ) {
             GameDetailScreen(
-                onBack = { navController.popBackStack() }
+                onBack = { navController.backOrHome() }
             )
         }
 
@@ -78,13 +95,13 @@ fun AppNavGraph(
 
         composable(Screen.EmulatorConfig.route) {
             EmulatorConfigScreen(
-                onBack = { navController.popBackStack() }
+                onBack = { navController.backOrHome() }
             )
         }
 
         composable(Screen.ScrapeProgress.route) {
             ScrapeProgressScreen(
-                onBack = { navController.popBackStack() }
+                onBack = { navController.backOrHome() }
             )
         }
     }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.component.VideoPlayer
 import com.gamelaunch.frontend.ui.theme.AmbientBackground
@@ -134,7 +135,9 @@ fun GameDetailScreen(
                         contentDescription = game.title,
                         modifier = Modifier
                             .height(178.dp)
-                            .aspectRatio(0.72f)
+                            // Match the grid's per-system box shape so the cover isn't cropped
+                            // differently here than in the library.
+                            .aspectRatio(boxArtAspectRatio(game.platformId))
                             .shadow(14.dp, RoundedCornerShape(12.dp))
                             .clip(RoundedCornerShape(12.dp))
                     )


### PR DESCRIPTION
Two small game-detail-page fixes.

## 1. Back dead-ending on the detail page
**Symptom:** stuck on the game detail page — on-screen back arrow, gamepad **B**, and touch/system **Back** all do nothing.

**Root cause:** `MainActivity` is a `singleTask` launcher activity. When eOr is resumed on a sub-screen (the detail page) via a launcher intent — after launching a game, or pressing **Home** and reopening — the nav back stack comes back with that screen as its **only** entry, so `popBackStack()` is a no-op. Every back path funnels through it, so they all dead-end together.

**Fix:** `NavController.backOrHome()` — pop when possible, else route to Home (unless already there). Wired into the detail / emulator-config / scrape `onBack` and the global system-Back handler. Normal back is unchanged (pop succeeds and returns early).

## 2. Detail-page box art shape
The detail cover was hardcoded to `aspectRatio(0.72f)`, so a GBC/PS1/etc. game showed a tall rectangle on the detail page while the grid showed its real box shape. Now uses `boxArtAspectRatio(game.platformId)` so it matches the library.

## Verified on device (Retroid)
- Reproduced the Back trap (open detail → Home → reopen → Back was dead); after fix, Back lands on Home. Normal detail → Back still returns to the grid.
- Game Boy detail cover now renders square (matching the grid) with full art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)