### PR TITLE
Game grid: Select-button quick menu (grid size + sort)

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -48,6 +48,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val SYNC_WIFI_ONLY = booleanPreferencesKey("sync_wifi_only")
         val SYNC_CHARGING_ONLY = booleanPreferencesKey("sync_charging_only")
         val SYSTEM_SORT = stringPreferencesKey("system_sort")
+        val GAME_SORT = stringPreferencesKey("game_sort")
+        val GAME_GRID_COLUMNS = intPreferencesKey("game_grid_columns")
         val RA_USERNAME = stringPreferencesKey("ra_username")
         val RA_API_KEY = stringPreferencesKey("ra_api_key")
         val RA_TOKEN = stringPreferencesKey("ra_token")
@@ -87,6 +89,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val systemSort: Flow<List<String>> = context.dataStore.data.map {
         it[Keys.SYSTEM_SORT]?.split(",")?.filter { s -> s.isNotBlank() } ?: emptyList()
     }
+    // Game-grid view options (set from the Select-button quick menu on the game grid).
+    val gameSort: Flow<String> = context.dataStore.data.map { it[Keys.GAME_SORT] ?: "ALPHABETICAL" }
+    // 0 = auto-fit columns to screen; > 0 = user-chosen fixed column count.
+    val gameGridColumns: Flow<Int> = context.dataStore.data.map { it[Keys.GAME_GRID_COLUMNS] ?: 0 }
     val raUsername: Flow<String> = context.dataStore.data.map { it[Keys.RA_USERNAME] ?: "" }
     val raApiKey: Flow<String> = context.dataStore.data.map { it[Keys.RA_API_KEY] ?: "" }
     val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
@@ -126,6 +132,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         it.remove(Keys.BG_IMAGE_PATH)
     }
     suspend fun setSystemSort(keys: List<String>) = context.dataStore.edit { it[Keys.SYSTEM_SORT] = keys.joinToString(",") }
+    suspend fun setGameSort(sort: String) = context.dataStore.edit { it[Keys.GAME_SORT] = sort }
+    suspend fun setGameGridColumns(columns: Int) = context.dataStore.edit { it[Keys.GAME_GRID_COLUMNS] = columns }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
         it[Keys.RA_API_KEY] = apiKey
     }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.gamelaunch.frontend.data.repository
 
 import com.gamelaunch.frontend.data.preferences.AppDataStore
+import com.gamelaunch.frontend.domain.model.GameSort
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.ui.theme.LayoutMode
@@ -61,6 +62,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override val syncChargingOnly: Flow<Boolean> = dataStore.syncChargingOnly
     override val systemSort: Flow<List<SystemSort>> =
         dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
+    override val gameSort: Flow<GameSort> = dataStore.gameSort.map { GameSort.fromName(it) }
+    override val gameGridColumns: Flow<Int> = dataStore.gameGridColumns
     override val raUsername: Flow<String> = dataStore.raUsername
     override val raApiKey: Flow<String> = dataStore.raApiKey
     override val raToken: Flow<String> = dataStore.raToken
@@ -107,6 +110,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setSyncChargingOnly(v: Boolean) { dataStore.setSyncChargingOnly(v) }
     override suspend fun clearBackgroundImage() { dataStore.clearBackgroundImage() }
     override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
+    override suspend fun setGameSort(sort: GameSort) { dataStore.setGameSort(sort.name) }
+    override suspend fun setGameGridColumns(columns: Int) { dataStore.setGameGridColumns(columns) }
     override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }
     override suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) {
         dataStore.setRaSession(username, token, points, softcorePoints)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/model/GameSort.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/model/GameSort.kt
@@ -1,0 +1,28 @@
+package com.gamelaunch.frontend.domain.model
+
+/** Ordering for the games shown inside a system. Persisted by name. */
+enum class GameSort(val label: String) {
+    FAVORITES("Favorites"),
+    RECENTLY_PLAYED("Recently played"),
+    RECENTLY_ADDED("Recently added"),
+    ALPHABETICAL("Alphabetical");
+
+    companion object {
+        val DEFAULT = ALPHABETICAL
+        fun fromName(name: String): GameSort = entries.firstOrNull { it.name == name } ?: DEFAULT
+    }
+}
+
+/** Apply a [GameSort] to a list of games. Ties fall back to title so the order is stable. */
+fun List<Game>.sortedBy(sort: GameSort): List<Game> = when (sort) {
+    GameSort.ALPHABETICAL    -> sortedBy { it.title.lowercase() }
+    GameSort.RECENTLY_PLAYED -> sortedWith(
+        compareByDescending<Game> { it.lastPlayedMs ?: Long.MIN_VALUE }.thenBy { it.title.lowercase() }
+    )
+    GameSort.RECENTLY_ADDED  -> sortedWith(
+        compareByDescending<Game> { it.dateAdded }.thenBy { it.title.lowercase() }
+    )
+    GameSort.FAVORITES       -> sortedWith(
+        compareByDescending<Game> { it.isFavorite }.thenBy { it.title.lowercase() }
+    )
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -1,5 +1,6 @@
 package com.gamelaunch.frontend.domain.repository
 
+import com.gamelaunch.frontend.domain.model.GameSort
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.platform.SystemSort
 import com.gamelaunch.frontend.ui.theme.LayoutMode
@@ -25,6 +26,8 @@ interface SettingsRepository {
     val syncWifiOnly: Flow<Boolean>
     val syncChargingOnly: Flow<Boolean>
     val systemSort: Flow<List<SystemSort>>
+    val gameSort: Flow<GameSort>
+    val gameGridColumns: Flow<Int>
     val raUsername: Flow<String>
     val raApiKey: Flow<String>
     val raToken: Flow<String>
@@ -59,6 +62,8 @@ interface SettingsRepository {
     suspend fun setSyncChargingOnly(v: Boolean)
     suspend fun clearBackgroundImage()
     suspend fun setSystemSort(keys: List<SystemSort>)
+    suspend fun setGameSort(sort: GameSort)
+    suspend fun setGameGridColumns(columns: Int)
     suspend fun setRaApiKey(apiKey: String)
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)
     suspend fun clearRaCredentials()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/GameViewOptions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/GameViewOptions.kt
@@ -1,0 +1,171 @@
+package com.gamelaunch.frontend.ui.screen.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.gamelaunch.frontend.domain.model.GameSort
+import com.gamelaunch.frontend.ui.theme.BrandBlue
+import com.gamelaunch.frontend.ui.theme.ElectricBlue
+import com.gamelaunch.frontend.ui.theme.IceWhite
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
+import com.gamelaunch.frontend.ui.theme.SteelGray
+import com.gamelaunch.frontend.ui.theme.TileSub
+import com.gamelaunch.frontend.ui.theme.TileText
+import com.gamelaunch.frontend.ui.theme.glassTile
+import kotlin.math.roundToInt
+
+/** Rows in the quick menu: index 0 is the grid-size slider, then one row per [GameSort]. */
+val gameSortOptions: List<GameSort> = GameSort.entries.toList()
+const val GAME_OPTIONS_ROWS: Int = 1 + 4   // size + four sort choices
+
+/**
+ * A small controller-first quick menu shown over the game grid (opened with Select). Row focus and
+ * the actual key handling live in HomeScreen; this is presentational and also touch-friendly.
+ *
+ * @param columns      current effective column count
+ * @param minColumns   fewest columns allowed (largest tiles)
+ * @param maxColumns   most columns allowed (smallest tiles)
+ * @param focusIndex   0 = size slider, 1..4 = sort rows
+ */
+@Composable
+fun GameViewOptions(
+    sort: GameSort,
+    columns: Int,
+    minColumns: Int,
+    maxColumns: Int,
+    focusIndex: Int,
+    onSetColumns: (Int) -> Unit,
+    onPickSort: (GameSort) -> Unit,
+    onClose: () -> Unit
+) {
+    val darkMode = LocalDarkMode.current
+    val textPrimary = if (darkMode) IceWhite else TileText
+    val textSecondary = if (darkMode) SteelGray else TileSub
+
+    // Rendered inside HomeScreen's root Box so its focusable keeps receiving controller keys.
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .zIndex(10f)
+            .background(Color.Black.copy(alpha = 0.45f))
+            .clickable(onClick = onClose),
+        contentAlignment = Alignment.Center
+    ) {
+            // The panel itself swallows clicks so tapping inside doesn't dismiss.
+            Column(
+                modifier = Modifier
+                    .width(460.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .glassTile(RoundedCornerShape(24.dp), color = BrandBlue)
+                    .clickable(enabled = false) {}
+                    .padding(20.dp)
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.GridView, contentDescription = null, tint = BrandBlue, modifier = Modifier.size(20.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("View options", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = textPrimary)
+                }
+                Spacer(Modifier.height(16.dp))
+
+                // ── Grid size ──────────────────────────────────────────────
+                OptionRow(focused = focusIndex == 0) {
+                    Column(Modifier.fillMaxWidth()) {
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                            Text("Grid size", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, color = textPrimary)
+                            Text("$columns per row", style = MaterialTheme.typography.labelMedium, color = textSecondary)
+                        }
+                        // Bigger tiles (fewer columns) to the right, so the slider reads small → large.
+                        val span = (maxColumns - minColumns).coerceAtLeast(1)
+                        Slider(
+                            value = (maxColumns - columns).toFloat(),
+                            onValueChange = { v -> onSetColumns(maxColumns - v.roundToInt()) },
+                            valueRange = 0f..span.toFloat(),
+                            steps = (span - 1).coerceAtLeast(0),
+                            colors = SliderDefaults.colors(
+                                thumbColor = ElectricBlue,
+                                activeTrackColor = ElectricBlue,
+                            )
+                        )
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                            Text("Smaller", style = MaterialTheme.typography.labelSmall, color = textSecondary)
+                            Text("Larger", style = MaterialTheme.typography.labelSmall, color = textSecondary)
+                        }
+                    }
+                }
+                Spacer(Modifier.height(10.dp))
+
+                Text("Sort by", style = MaterialTheme.typography.labelLarge, color = BrandBlue, modifier = Modifier.padding(start = 4.dp, bottom = 4.dp))
+                gameSortOptions.forEachIndexed { i, option ->
+                    OptionRow(focused = focusIndex == i + 1, onClick = { onPickSort(option) }) {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                option.label,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = textPrimary,
+                                fontWeight = if (option == sort) FontWeight.SemiBold else FontWeight.Normal,
+                                modifier = Modifier.weight(1f)
+                            )
+                            if (option == sort) {
+                                Icon(Icons.Default.Check, contentDescription = "Selected", tint = ElectricBlue, modifier = Modifier.size(20.dp))
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(4.dp))
+                }
+
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "↑↓ Move   ←→ Size   Ⓐ Select   Ⓑ Close",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = textSecondary,
+                    modifier = Modifier.fillMaxWidth().padding(top = 2.dp)
+                )
+            }
+        }
+    }
+
+@Composable
+private fun OptionRow(
+    focused: Boolean,
+    onClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    val shape = RoundedCornerShape(14.dp)
+    val base = Modifier
+        .fillMaxWidth()
+        .clip(shape)
+        .then(
+            if (focused) Modifier.background(ElectricBlue.copy(alpha = 0.18f))
+            else Modifier
+        )
+        .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+        .padding(horizontal = 12.dp, vertical = 10.dp)
+    Box(base) { content() }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -71,6 +71,7 @@ import com.gamelaunch.frontend.ui.input.GamepadL1
 import com.gamelaunch.frontend.ui.input.GamepadL2
 import com.gamelaunch.frontend.ui.input.GamepadR1
 import com.gamelaunch.frontend.ui.input.GamepadR2
+import com.gamelaunch.frontend.ui.input.GamepadSelect
 import com.gamelaunch.frontend.ui.input.GamepadStart
 import com.gamelaunch.frontend.ui.theme.AmbientBackground
 import com.gamelaunch.frontend.ui.theme.BrandBlue
@@ -109,6 +110,9 @@ fun HomeScreen(
     var recentFocusIndex by rememberSaveable { mutableIntStateOf(0) }
     // A screenful of games (whole visible rows × columns), reported by the grid, for L2/R2 paging.
     var gridPageSize     by remember { mutableIntStateOf(0) }
+    // Select-button quick menu on the game grid (grid size + sort).
+    var showGameOptions   by remember { mutableStateOf(false) }
+    var optionsFocusIndex by remember { mutableIntStateOf(0) }
 
     val screenWidthDp = LocalConfiguration.current.screenWidthDp
     // Match LazyVerticalGrid's column maths exactly so D-pad navigation lands on the right cell.
@@ -120,7 +124,14 @@ fun HomeScreen(
     // (matches the old 110dp / 0.72 portrait tile).
     val gameCellMinDp = (150f * boxArtAspectRatio(state.selectedPlatform ?: ""))
         .roundToInt().coerceIn(96, 240)
-    val gameGridColumns = gridColumns(minCellDp = gameCellMinDp, paddingDp = 8, spacingDp = 8)
+    val autoGameCols = gridColumns(minCellDp = gameCellMinDp, paddingDp = 8, spacingDp = 8)
+    // Bounds for the Select-menu grid-size slider. Every integer column count fills the row exactly
+    // (GridCells.Fixed), so each slider step "resizes perfectly".
+    val minGameCols = 3
+    val maxGameCols = gridColumns(minCellDp = 92, paddingDp = 8, spacingDp = 8).coerceIn(minGameCols + 1, 12)
+    // User-chosen column count (from the Select menu) overrides the auto-fit; 0 = auto.
+    val gameGridColumns = (state.gameGridColumns.takeIf { it > 0 } ?: autoGameCols)
+        .coerceIn(minGameCols, maxGameCols)
     // Recently-played mixes systems, so keep the portrait default there.
     val recentGridColumns = gridColumns(minCellDp = 110, paddingDp = 8, spacingDp = 8)
     val appColumns      = gridColumns(minCellDp = 96, paddingDp = 16, spacingDp = 12)
@@ -259,6 +270,24 @@ fun HomeScreen(
                     }
                     if (event.type != KeyEventType.KeyDown) return@onKeyEvent false
 
+                    // ── Game-grid quick menu (opened with Select): it captures all input ──
+                    if (showGameOptions) {
+                        when (key) {
+                            Key.DirectionUp   -> optionsFocusIndex = (optionsFocusIndex - 1 + GAME_OPTIONS_ROWS) % GAME_OPTIONS_ROWS
+                            Key.DirectionDown -> optionsFocusIndex = (optionsFocusIndex + 1) % GAME_OPTIONS_ROWS
+                            // Size row: left = smaller (more columns), right = larger (fewer columns).
+                            Key.DirectionLeft  -> if (optionsFocusIndex == 0)
+                                viewModel.setGameGridColumns((gameGridColumns + 1).coerceAtMost(maxGameCols))
+                            Key.DirectionRight -> if (optionsFocusIndex == 0)
+                                viewModel.setGameGridColumns((gameGridColumns - 1).coerceAtLeast(minGameCols))
+                            GamepadA, Key.DirectionCenter, Key.Enter ->
+                                if (optionsFocusIndex >= 1) viewModel.setGameSort(gameSortOptions[optionsFocusIndex - 1])
+                            GamepadB, Key.Back, GamepadSelect -> showGameOptions = false
+                            else -> {}
+                        }
+                        return@onKeyEvent true
+                    }
+
                     // Directional input: ignore the OS's own auto-repeat while we already drive a
                     // hold; on first press move once and start our own steady repeat.
                     if (isDirection) {
@@ -307,6 +336,7 @@ fun HomeScreen(
                                     gridFocusIndex = (gridFocusIndex + page).coerceAtMost(state.games.size - 1); true
                                 }
                                 GamepadB, Key.Back -> { viewModel.exitToSystems(); true }
+                                GamepadSelect -> { optionsFocusIndex = 0; showGameOptions = true; true }
                                 else -> false
                             }
                         }
@@ -479,6 +509,19 @@ fun HomeScreen(
                     }
                 }
             }
+            }
+
+            if (showGameOptions) {
+                GameViewOptions(
+                    sort         = state.gameSort,
+                    columns      = gameGridColumns,
+                    minColumns   = minGameCols,
+                    maxColumns   = maxGameCols,
+                    focusIndex   = optionsFocusIndex,
+                    onSetColumns = viewModel::setGameGridColumns,
+                    onPickSort   = viewModel::setGameSort,
+                    onClose      = { showGameOptions = false }
+                )
             }
         }
     }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -7,6 +7,8 @@ import coil.imageLoader
 import coil.request.ImageRequest
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
+import com.gamelaunch.frontend.domain.model.GameSort
+import com.gamelaunch.frontend.domain.model.sortedBy
 import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
 import com.gamelaunch.frontend.domain.platform.sortedBySystems
 import com.gamelaunch.frontend.domain.repository.GameRepository
@@ -41,6 +43,8 @@ data class HomeUiState(
     val showRetroAchievements: Boolean = true,
     val recentlyPlayed: List<Game> = emptyList(),
     val games: List<Game> = emptyList(),
+    val gameSort: GameSort = GameSort.DEFAULT,
+    val gameGridColumns: Int = 0,             // 0 = auto-fit; > 0 = user-chosen column count
     val selectedGameIndex: Int = 0,
     val selectedGameMedia: GameMedia? = null,
     val mediaForGames: Map<Long, GameMedia> = emptyMap(),
@@ -67,8 +71,22 @@ class HomeViewModel @Inject constructor(
     init {
         observePlatforms()
         observeSettings()
+        observeGameViewPrefs()
         observeAllMedia()
         observeRecentlyPlayed()
+    }
+
+    /** The Select-menu options (game sort + fixed column count) for the game grid. */
+    private fun observeGameViewPrefs() {
+        viewModelScope.launch {
+            combine(
+                settingsRepository.gameSort,
+                settingsRepository.gameGridColumns
+            ) { sort, cols -> sort to cols }
+                .collect { (sort, cols) ->
+                    _uiState.update { it.copy(gameSort = sort, gameGridColumns = cols) }
+                }
+        }
     }
 
     private fun observeRecentlyPlayed() {
@@ -241,18 +259,32 @@ class HomeViewModel @Inject constructor(
         gamesJob?.cancel()
         if (platformId == null) return
         gamesJob = viewModelScope.launch {
-            gameRepository.getGamesByPlatform(platformId).collect { games ->
-                val firstMedia = _uiState.value.mediaForGames[games.firstOrNull()?.id]
-                _uiState.update { state ->
-                    state.copy(
-                        games             = games,
-                        selectedGameIndex = 0,
-                        shouldPlayVideo   = false,
-                        selectedGameMedia = firstMedia
-                    )
+            // Re-sort whenever the games change or the chosen sort order changes.
+            combine(
+                gameRepository.getGamesByPlatform(platformId),
+                settingsRepository.gameSort
+            ) { games, sort -> games.sortedBy(sort) }
+                .collect { games ->
+                    val firstMedia = _uiState.value.mediaForGames[games.firstOrNull()?.id]
+                    _uiState.update { state ->
+                        state.copy(
+                            games             = games,
+                            selectedGameIndex = 0,
+                            shouldPlayVideo   = false,
+                            selectedGameMedia = firstMedia
+                        )
+                    }
                 }
-            }
         }
+    }
+
+    /** Game-grid Select-menu actions. */
+    fun setGameSort(sort: GameSort) {
+        viewModelScope.launch { settingsRepository.setGameSort(sort) }
+    }
+
+    fun setGameGridColumns(columns: Int) {
+        viewModelScope.launch { settingsRepository.setGameGridColumns(columns) }
     }
 
     fun selectPlatform(platformId: String) {


### PR DESCRIPTION
Pressing **Select** on the game selection screen opens a controller-first **View options** overlay.

## Features
- **Grid size slider** — adjusts tile size, snapping only to whole column counts. Because the grid uses `GridCells.Fixed(n)`, every integer column count fills the row exactly, so each step "resizes perfectly". Live-resizes the grid; persisted as an explicit column count that overrides the auto-fit.
- **Sort by** — Favorites, Recently played, Recently added, Alphabetical. Applied to the per-system games list (ties fall back to title) and persisted.

## Implementation
- New `GameSort` model + `sortedBy` extension.
- New `GameViewOptions` overlay — rendered **in-layout** (not a `Dialog`) so `HomeScreen`'s focusable keeps receiving controller input.
- Two DataStore prefs (`game_sort`, `game_grid_columns`) with repository flows/setters.
- `HomeViewModel` sorts the per-system list reactively (`combine(games, gameSort)`).
- `HomeScreen` computes effective columns (override → auto), opens the menu on Select, and routes menu keys: **↑↓** move, **←→** size, **Ⓐ** select, **Ⓑ/Select** close. Also touch-friendly.

## Verified on device (Retroid)
Menu opens on Select; grid-size slider live-resizes and snaps to whole columns (e.g. 7 → 5, tiles grow); sort selection shows a checkmark and reorders; B closes; both prefs persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)