### PR TITLE
Scan zipped ROMs + hide systems + remove from library

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -55,6 +56,11 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val RA_TOKEN = stringPreferencesKey("ra_token")
         val RA_POINTS = intPreferencesKey("ra_points")
         val RA_SOFTCORE_POINTS = intPreferencesKey("ra_softcore_points")
+        // Platform ids the user has chosen to hide from the home screen (e.g. "pc", "android").
+        val HIDDEN_PLATFORMS = stringSetPreferencesKey("hidden_platforms")
+        // rom_path identifiers the user removed from the library; scans skip these so they don't
+        // come back. Android games use the synthetic path "package:<pkg>".
+        val EXCLUDED_PATHS = stringSetPreferencesKey("excluded_paths")
     }
 
     val romRootPath: Flow<String> = context.dataStore.data.map { it[Keys.ROM_ROOT_PATH] ?: "" }
@@ -98,6 +104,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
     val raPoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_POINTS] ?: 0 }
     val raSoftcorePoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_SOFTCORE_POINTS] ?: 0 }
+    val hiddenPlatforms: Flow<Set<String>> = context.dataStore.data.map { it[Keys.HIDDEN_PLATFORMS] ?: emptySet() }
+    val excludedPaths: Flow<Set<String>> = context.dataStore.data.map { it[Keys.EXCLUDED_PATHS] ?: emptySet() }
 
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
@@ -149,5 +157,14 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         it.remove(Keys.RA_TOKEN)
         it.remove(Keys.RA_POINTS)
         it.remove(Keys.RA_SOFTCORE_POINTS)
+    }
+
+    suspend fun setPlatformHidden(platformId: String, hidden: Boolean) = context.dataStore.edit {
+        val current = it[Keys.HIDDEN_PLATFORMS] ?: emptySet()
+        it[Keys.HIDDEN_PLATFORMS] = if (hidden) current + platformId else current - platformId
+    }
+
+    suspend fun addExcludedPath(romPath: String) = context.dataStore.edit {
+        it[Keys.EXCLUDED_PATHS] = (it[Keys.EXCLUDED_PATHS] ?: emptySet()) + romPath
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
@@ -101,6 +101,8 @@ class GameRepositoryImpl @Inject constructor(
     override suspend fun deleteAllAndroidGames(): Int =
         gameDao.deleteAllAndroidGames()
 
+    override suspend fun deleteGame(id: Long) = gameDao.deleteById(id)
+
     override suspend fun getTotalCount(): Int = gameDao.getTotalCount()
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -69,6 +69,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override val raToken: Flow<String> = dataStore.raToken
     override val raPoints: Flow<Int> = dataStore.raPoints
     override val raSoftcorePoints: Flow<Int> = dataStore.raSoftcorePoints
+    override val hiddenPlatforms: Flow<Set<String>> = dataStore.hiddenPlatforms
+    override val excludedPaths: Flow<Set<String>> = dataStore.excludedPaths
 
     override suspend fun setRomRootPath(path: String) { dataStore.setRomRootPath(path) }
     override suspend fun setMediaFolderPath(path: String) { dataStore.setMediaFolderPath(path) }
@@ -117,4 +119,6 @@ class SettingsRepositoryImpl @Inject constructor(
         dataStore.setRaSession(username, token, points, softcorePoints)
     }
     override suspend fun clearRaCredentials() { dataStore.clearRaCredentials() }
+    override suspend fun setPlatformHidden(platformId: String, hidden: Boolean) { dataStore.setPlatformHidden(platformId, hidden) }
+    override suspend fun addExcludedPath(romPath: String) { dataStore.addExcludedPath(romPath) }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDetector.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDetector.kt
@@ -13,6 +13,12 @@ class PlatformDetector @Inject constructor() {
     // platform folder AND the extension must be valid for that platform.
     private val ambiguousExtensions = setOf(".bin", ".iso", ".img", ".chd", ".cso", ".cue", ".zip", ".7z")
 
+    // Archive formats that most libretro cores load directly. When a file already sits inside a
+    // recognised system folder the folder tells us the platform, so a zipped ROM there is a game
+    // even though the raw extension list for that platform (e.g. SNES → .sfc) doesn't list it.
+    // Most collections store cartridge ROMs zipped, so without this the bulk of a library is skipped.
+    private val archiveExtensions = setOf(".zip", ".7z")
+
     fun detect(file: File, parentFolderName: String): Platform? {
         val ext = ".${file.extension.lowercase()}"
 
@@ -27,7 +33,10 @@ class PlatformDetector @Inject constructor() {
         if (folderMatch != null) {
             // A stray data file inside a system folder (e.g. a .bin save under psp/) has an
             // extension the platform doesn't use — reject it so it never shows up as a "game".
-            val validForPlatform = folderMatch.extensions.any { it.equals(ext, ignoreCase = true) }
+            // Archives (.zip/.7z) are always accepted here since the folder already identifies
+            // the platform and cores load zipped ROMs directly.
+            val validForPlatform = ext in archiveExtensions ||
+                folderMatch.extensions.any { it.equals(ext, ignoreCase = true) }
             return if (validForPlatform) folderMatch else null
         }
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
@@ -32,5 +32,7 @@ interface GameRepository {
     suspend fun deleteAllNonAndroidGames(): Int
     suspend fun deleteAndroidGamesNotIn(validPaths: List<String>): Int
     suspend fun deleteAllAndroidGames(): Int
+    /** Remove a single game row by id (used by the manual "remove from library" action). */
+    suspend fun deleteGame(id: Long)
     suspend fun getTotalCount(): Int
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -33,6 +33,8 @@ interface SettingsRepository {
     val raToken: Flow<String>
     val raPoints: Flow<Int>
     val raSoftcorePoints: Flow<Int>
+    val hiddenPlatforms: Flow<Set<String>>
+    val excludedPaths: Flow<Set<String>>
 
     suspend fun setRomRootPath(path: String)
     suspend fun setMediaFolderPath(path: String)
@@ -67,4 +69,6 @@ interface SettingsRepository {
     suspend fun setRaApiKey(apiKey: String)
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)
     suspend fun clearRaCredentials()
+    suspend fun setPlatformHidden(platformId: String, hidden: Boolean)
+    suspend fun addExcludedPath(romPath: String)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
@@ -6,9 +6,11 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
@@ -16,6 +18,7 @@ import javax.inject.Inject
 class ScanAndroidGamesUseCase @Inject constructor(
     @ApplicationContext private val context: Context,
     private val gameRepository: GameRepository,
+    private val settingsRepository: SettingsRepository,
     private val packageManagerHelper: com.gamelaunch.frontend.launcher.PackageManagerHelper
 ) {
     // Package prefixes that belong to the OS or this launcher — skip them.
@@ -26,6 +29,9 @@ class ScanAndroidGamesUseCase @Inject constructor(
 
     operator fun invoke(): Flow<ScanProgress> = flow {
         val pm = context.packageManager
+
+        // Apps the user manually removed from the library (stored as "package:<pkg>").
+        val excludedPaths = settingsRepository.excludedPaths.first()
 
         // Apps that declare the GAME launcher category (older / explicit signal).
         val gameIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.GAME")
@@ -41,6 +47,8 @@ class ScanAndroidGamesUseCase @Inject constructor(
             .map { it.activityInfo.packageName }
 
         val packages = (categoryGamePkgs + launchablePkgs).distinct().filter { pkg ->
+            // Respect manual removals so a rescan doesn't bring a hidden app back.
+            if ("package:$pkg" in excludedPaths) return@filter false
             if (systemPrefixes.any { pkg == it || pkg.startsWith("$it.") }) return@filter false
             // Emulators/launchers are categorised as games too — keep them out of the library.
             if (pkg in packageManagerHelper.emulatorPackages) return@filter false

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -3,9 +3,11 @@ package com.gamelaunch.frontend.domain.usecase
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.platform.PlatformDetector
 import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.util.StorageUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.io.File
@@ -21,7 +23,8 @@ data class ScanProgress(
 
 class ScanRomsUseCase @Inject constructor(
     private val gameRepository: GameRepository,
-    private val platformDetector: PlatformDetector
+    private val platformDetector: PlatformDetector,
+    private val settingsRepository: SettingsRepository
 ) {
     private val skipExtensions = setOf(
         ".txt", ".xml", ".cue", ".nfo", ".jpg", ".png", ".mp4", ".rar",
@@ -47,11 +50,15 @@ class ScanRomsUseCase @Inject constructor(
             return@flow
         }
 
+        // Paths the user has manually removed from the library — never re-add them.
+        val excludedPaths = settingsRepository.excludedPaths.first()
+
         val romFiles = rootDir.walkTopDown()
             // Don't descend into hidden folders or known emulator-data folders.
             .onEnter { !it.name.startsWith(".") && it.name.lowercase() !in skipFolders }
             // Skip hidden files (e.g. macOS "._Foo.chd" AppleDouble files and .DS_Store)
             .filter { it.isFile && !it.name.startsWith(".") && ".${it.extension.lowercase()}" !in skipExtensions }
+            .filterNot { it.absolutePath in excludedPaths }
             .toList()
 
         val validPaths = mutableListOf<String>()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.PlayArrow
@@ -40,7 +41,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -80,9 +83,15 @@ fun GameDetailScreen(
 ) {
     val state          by viewModel.uiState.collectAsState()
     val focusRequester  = remember { FocusRequester() }
+    var showRemoveConfirm by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         try { focusRequester.requestFocus() } catch (_: Exception) { }
+    }
+
+    // Once the game has been removed, leave the detail screen — it no longer exists.
+    LaunchedEffect(state.removed) {
+        if (state.removed) onBack()
     }
 
     ThemedScreen {
@@ -224,6 +233,11 @@ fun GameDetailScreen(
                             tint = if (state.isFavorite) favoritePink else null,
                             onClick = viewModel::toggleFavorite
                         )
+                        RoundIconButton(
+                            icon = Icons.Default.DeleteOutline,
+                            contentDescription = "Remove from library",
+                            onClick = { showRemoveConfirm = true }
+                        )
                     }
                     Spacer(Modifier.height(12.dp))
 
@@ -290,6 +304,28 @@ fun GameDetailScreen(
                 text  = { Text(error) },
                 confirmButton = {
                     TextButton(onClick = viewModel::dismissError) { Text("OK") }
+                }
+            )
+        }
+
+        if (showRemoveConfirm) {
+            AlertDialog(
+                onDismissRequest = { showRemoveConfirm = false },
+                title = { Text("Remove from library?") },
+                text  = {
+                    Text(
+                        "\"${game.title}\" will be removed from your library and won't come back " +
+                        "on the next scan. This doesn't delete any files on your device."
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showRemoveConfirm = false
+                        viewModel.removeFromLibrary()
+                    }) { Text("Remove") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showRemoveConfirm = false }) { Text("Cancel") }
                 }
             )
         }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailViewModel.kt
@@ -25,7 +25,8 @@ data class GameDetailUiState(
     val videoMuted: Boolean = true,
     val isFavorite: Boolean = false,
     val launchError: String? = null,
-    val isLoading: Boolean = true
+    val isLoading: Boolean = true,
+    val removed: Boolean = false
 )
 
 @HiltViewModel
@@ -84,6 +85,19 @@ class GameDetailViewModel @Inject constructor(
             val newValue = !game.isFavorite
             gameRepository.setFavorite(game.id, newValue)
             _uiState.update { it.copy(isFavorite = newValue) }
+        }
+    }
+
+    /**
+     * Remove this game from the library and remember its path so a rescan won't re-add it.
+     * Works for both ROM games and Android-category games (whose path is "package:<pkg>").
+     */
+    fun removeFromLibrary() {
+        val game = _uiState.value.game ?: return
+        viewModelScope.launch {
+            settingsRepository.addExcludedPath(game.romPath)
+            gameRepository.deleteGame(game.id)
+            _uiState.update { it.copy(removed = true) }
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -104,25 +104,34 @@ class HomeViewModel @Inject constructor(
             combine(
                 gameRepository.getDistinctPlatformIds(),
                 gameRepository.getPlatformCounts(),
-                settingsRepository.systemSort
-            ) { ids, counts, sorts -> Triple(ids, counts, sorts) }
-                .collect { (ids, counts, sorts) ->
-                    val sorted = ids.sortedBySystems(
-                        sorts = sorts,
-                        displayName = { PlatformDefinitions.byId[it]?.displayName ?: it },
-                        gameCount = { counts[it] ?: 0 }
-                    )
+                settingsRepository.systemSort,
+                settingsRepository.hiddenPlatforms
+            ) { ids, counts, sorts, hidden ->
+                // Systems the user has hidden never appear on the home screen.
+                val visibleIds = ids.filter { it !in hidden }
+                val sorted = visibleIds.sortedBySystems(
+                    sorts = sorts,
+                    displayName = { PlatformDefinitions.byId[it]?.displayName ?: it },
+                    gameCount = { counts[it] ?: 0 }
+                )
+                Triple(sorted, counts, sorted.toSet())
+            }
+                .collect { (sorted, counts, idSet) ->
                     _uiState.update { state ->
+                        // If the currently-selected system was just hidden (or removed), fall back
+                        // to the first visible one so the grid never points at a gone platform.
+                        val selected = state.selectedPlatform
+                            ?.takeIf { it in idSet }
+                            ?: sorted.firstOrNull()
                         state.copy(
                             platforms = sorted,
                             platformCounts = counts,
-                            selectedPlatform = state.selectedPlatform ?: sorted.firstOrNull(),
+                            selectedPlatform = selected,
                             isLoading = false
                         )
                     }
-                    // Only (re)load the games list when the set of platforms actually changes,
-                    // not on every count tick during a scrape.
-                    val idSet = ids.toSet()
+                    // Only (re)load the games list when the set of visible platforms actually
+                    // changes, not on every count tick during a scrape.
                     if (idSet != lastPlatformIdSet) {
                         lastPlatformIdSet = idSet
                         loadGamesForPlatform(_uiState.value.selectedPlatform)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -277,6 +277,8 @@ fun SettingsScreen(
                             Spacer(Modifier.height(4.dp))
                             SystemSortSection(state, viewModel)
                             Spacer(Modifier.height(4.dp))
+                            HideSystemsSection(state, viewModel)
+                            Spacer(Modifier.height(4.dp))
                             BackgroundBrandingSection(
                                 state,
                                 viewModel,
@@ -463,6 +465,32 @@ private fun SystemSortSection(state: SettingsUiState, viewModel: SettingsViewMod
                     }
                 }
             }
+        }
+    }
+}
+
+// ── Section: Hide Systems ─────────────────────────────────────────────────
+
+@Composable
+private fun HideSystemsSection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    if (state.libraryPlatforms.isEmpty()) return
+    SettingsSectionHeader("Hide Systems")
+    SettingsCard {
+        Text(
+            "Turn a system off to hide its whole category from the home screen. Its games stay in the library and can be shown again anytime.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        state.libraryPlatforms.forEachIndexed { index, platformId ->
+            if (index > 0) CardDivider()
+            val displayName = com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+                .byId[platformId]?.displayName ?: platformId
+            CardSwitchRow(
+                label           = displayName,
+                checked         = platformId !in state.hiddenPlatforms,
+                onCheckedChange = { shown -> viewModel.setPlatformHidden(platformId, !shown) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.data.db.dao.LaunchBoxDao
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
 import com.gamelaunch.frontend.domain.repository.ScraperRepository
 import com.gamelaunch.frontend.domain.platform.SystemSort
@@ -63,7 +65,11 @@ data class SettingsUiState(
     val backgroundImageMode: String = "FILL",
     val backgroundImageOpacity: Float = 0.15f,
     val convertingBackground: Boolean = false,
-    val systemSort: List<SystemSort> = emptyList()
+    val systemSort: List<SystemSort> = emptyList(),
+    // Systems currently in the library (platform ids) and which of them the user has hidden,
+    // for the "Hide Systems" settings section.
+    val libraryPlatforms: List<String> = emptyList(),
+    val hiddenPlatforms: Set<String> = emptySet()
 )
 
 @HiltViewModel
@@ -76,6 +82,7 @@ class SettingsViewModel @Inject constructor(
     private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
     private val convertBackgroundImageUseCase: ConvertBackgroundImageUseCase,
     private val raRepository: RetroAchievementsRepository,
+    private val gameRepository: GameRepository,
     private val launchBoxDao: LaunchBoxDao
 ) : ViewModel() {
 
@@ -162,6 +169,18 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            // The platforms present in the library, ordered by display name, for the hide list.
+            gameRepository.getDistinctPlatformIds().collect { ids ->
+                val ordered = ids.sortedBy { PlatformDefinitions.byId[it]?.displayName ?: it }
+                _uiState.update { it.copy(libraryPlatforms = ordered) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.hiddenPlatforms.collect { hidden ->
+                _uiState.update { it.copy(hiddenPlatforms = hidden) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.backgroundImageEnabled.collect { enabled ->
                 _uiState.update { it.copy(backgroundImageEnabled = enabled) }
             }
@@ -208,6 +227,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setDarkMode(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setDarkMode(enabled) }
+    }
+
+    fun setPlatformHidden(platformId: String, hidden: Boolean) {
+        viewModelScope.launch { settingsRepository.setPlatformHidden(platformId, hidden) }
     }
 
     /**

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -2,7 +2,9 @@ package com.gamelaunch.frontend
 
 import com.gamelaunch.frontend.domain.platform.PlatformDetector
 import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.domain.usecase.ScanRomsUseCase
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -21,11 +23,13 @@ class ScanRomsUseCaseTest {
     @get:Rule val tmpFolder = TemporaryFolder()
 
     private val gameRepository: GameRepository = mock()
+    private val settingsRepository: SettingsRepository = mock()
     private val platformDetector = PlatformDetector()
     private lateinit var useCase: ScanRomsUseCase
 
     @Before fun setup() {
-        useCase = ScanRomsUseCase(gameRepository, platformDetector)
+        whenever(settingsRepository.excludedPaths).thenReturn(flowOf(emptySet()))
+        useCase = ScanRomsUseCase(gameRepository, platformDetector, settingsRepository)
     }
 
     @Test fun `emits error progress for missing root folder`() = runTest {
@@ -46,6 +50,34 @@ class ScanRomsUseCaseTest {
         val final = results.last()
         assertEquals(2, final.added)
         assertEquals(2, final.total)
+    }
+
+    @Test fun `detects zipped roms inside a system folder`() = runTest {
+        val snesDir = tmpFolder.newFolder("SNES")
+        File(snesDir, "Super Mario World.zip").createNewFile()
+        File(snesDir, "Chrono Trigger.7z").createNewFile()
+
+        whenever(gameRepository.insertGame(any())).thenReturn(1L, 2L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        val results = useCase(tmpFolder.root.absolutePath).toList()
+        val final = results.last()
+        assertEquals(2, final.added)
+        assertEquals(2, final.total)
+    }
+
+    @Test fun `skips paths the user excluded`() = runTest {
+        val nesDir = tmpFolder.newFolder("NES")
+        val keep = File(nesDir, "keep.nes").also { it.createNewFile() }
+        val removed = File(nesDir, "removed.nes").also { it.createNewFile() }
+        whenever(settingsRepository.excludedPaths).thenReturn(flowOf(setOf(removed.absolutePath)))
+
+        whenever(gameRepository.insertGame(any())).thenReturn(1L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        val results = useCase(tmpFolder.root.absolutePath).toList()
+        val final = results.last()
+        assertEquals(1, final.total) // only keep.nes counted; excluded file skipped
     }
 
     @Test fun `skips txt and xml files`() = runTest {


### PR DESCRIPTION
## Summary

Addresses user feedback: scans were missing most games, and there was no way to curate the library (hide a category, remove a stray entry).

### 1. Zip/7z ROM support 🗜️
`PlatformDetector` only accepted a file inside a system folder if its extension was in that platform's list (e.g. SNES → `.sfc`). Since most collections store cartridge ROMs **zipped**, `SNES/Mario.zip` was silently dropped — the cause of the "90% of my games missing" report. Archives (`.zip`/`.7z`) are now accepted whenever the file sits inside a recognised system folder (the folder identifies the platform; libretro cores load zipped ROMs directly). Bare archives with no system folder are still ignored.

### 2. Hide system categories 🙈
New `hiddenPlatforms` setting + a **Settings → General → "Hide Systems"** toggle list (covers PC/Steam, Android, and every scanned system). `HomeViewModel` filters hidden categories off the home screen and reselects a visible system if the active one gets hidden. Games remain in the DB and reappear when re-enabled.

### 3. Remove games / apps from library 🗑️
New `excludedPaths` setting + a **"Remove from library"** action (with a confirm dialog) on the game detail screen — works for ROM games and miscategorised Android-category games alike. Removal deletes the row **and** records the path so a rescan won't re-add it; both scanners skip excluded paths/packages. Files on disk are never touched.

Manual-add was intentionally out of scope — zip support removes most of the need.

## Testing
- `./gradlew testDebugUnitTest` → **13 tests, 0 failures**. New tests cover zipped-ROM detection and excluded-path skipping.
- Full app compiles. **Not** yet exercised on a device/emulator — the new UI (settings toggles, home filtering, remove dialog) is verified by compilation + scanner-level unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
