### PR TITLE
Check for updates on foreground, not just cold start

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -81,6 +81,10 @@ class MainActivity : ComponentActivity() {
 
     // Set when a newer GitHub release is found; drives the in-app update banner.
     private val updateState = mutableStateOf<AppUpdate?>(null)
+    // Monotonic timestamp of the last update check. Foreground checks are throttled so returning to
+    // the app re-checks GitHub without hammering its API (unauthenticated: 60 req/hr) during
+    // frequent game-launch/return cycles. 0 = never checked, so the first check always runs.
+    private var lastUpdateCheckMs = 0L
 
     // The branded splash stays up until cold-start data is loaded and the first screen's box art
     // is warmed in Coil's cache, so Home appears populated instead of grey-then-crossfading in.
@@ -112,7 +116,9 @@ class MainActivity : ComponentActivity() {
 
         requestStoragePermissions()
         requestAllFilesAccessIfNeeded()
-        checkForUpdate()
+        // Update check runs from onStart() so it fires on every return to the foreground, not just
+        // cold start — otherwise an update that lands while the app is open is only noticed after a
+        // force-close and reopen.
         startSaveSyncIfEnabled()
 
         setContent {
@@ -272,7 +278,17 @@ class MainActivity : ComponentActivity() {
      * On launch, ask GitHub whether a newer release exists. If so, surface an in-app banner and —
      * once per new version — a system notification so users hear about it even outside the app.
      */
+    override fun onStart() {
+        super.onStart()
+        // Re-check for updates whenever the app comes to the foreground (cold start included), so a
+        // release published while the app is open/backgrounded surfaces without a force-close.
+        checkForUpdate()
+    }
+
     private fun checkForUpdate() {
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastUpdateCheckMs < UPDATE_CHECK_INTERVAL_MS) return
+        lastUpdateCheckMs = now
         lifecycleScope.launch {
             val update = checkForUpdateUseCase() ?: return@launch
             updateState.value = update
@@ -416,5 +432,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    companion object {
+        // Minimum gap between foreground update checks. Long enough to spare GitHub's API during
+        // rapid game-launch/return cycles, short enough to notice a new release soon after returning.
+        private const val UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000L
     }
 }


### PR DESCRIPTION
## Summary

Fixes a user-reported bug: the in-app update banner / notification never appeared while the app was already open — you had to force-close and reopen to see it.

**Root cause:** `checkForUpdate()` was only called from `MainActivity.onCreate()`, which runs on a cold start. Returning to an already-open app skips `onCreate`, so no re-check happened; force-closing destroys the Activity, so reopening re-runs `onCreate` — the exact workaround the user found.

**Fix:** Move the check to `onStart()`, which fires on cold start *and* every return to the foreground. Added a 15-minute throttle so returning to the app re-checks without hammering GitHub's unauthenticated API (60 req/hr) during frequent game-launch/return cycles. The first check per process always runs; the existing per-version notification dedup is unchanged.

## Testing
- Compiles clean (`compileDebugKotlin`).
- **Not** exercised on-device — this is Activity-lifecycle timing, best confirmed by backgrounding the app, publishing a release, returning, and seeing the banner. No unit test (no pure-logic seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
