### PR TITLE
Add support for .zip ROM(s) and fixed UI bugs

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.io.File
 import java.security.MessageDigest
+import java.util.zip.ZipInputStream
 import javax.inject.Inject
 
 data class ScanProgress(
@@ -100,10 +101,34 @@ class ScanRomsUseCase @Inject constructor(
 
     private fun computeMd5Partial(file: File): String? = runCatching {
         val md = MessageDigest.getInstance("MD5")
-        file.inputStream().use { stream ->
-            val buffer = ByteArray(512 * 1024) // 512 KB — reduced from 8 MB to avoid OOM
-            val read = stream.read(buffer)
-            if (read > 0) md.update(buffer, 0, read)
+        if (file.extension.equals("zip", ignoreCase = true)) {
+            ZipInputStream(file.inputStream().buffered()).use { zip ->
+                var entry = zip.nextEntry
+                var foundFile = false
+                while (entry != null) {
+                    if (!entry.isDirectory) {
+                        foundFile = true
+                        val buffer = ByteArray(512 * 1024)
+                        val read = zip.read(buffer)
+                        if (read > 0) md.update(buffer, 0, read)
+                        break
+                    }
+                    entry = zip.nextEntry
+                }
+                if (!foundFile) {
+                    file.inputStream().use { stream ->
+                        val buffer = ByteArray(512 * 1024)
+                        val read = stream.read(buffer)
+                        if (read > 0) md.update(buffer, 0, read)
+                    }
+                }
+            }
+        } else {
+            file.inputStream().use { stream ->
+                val buffer = ByteArray(512 * 1024)
+                val read = stream.read(buffer)
+                if (read > 0) md.update(buffer, 0, read)
+            }
         }
         md.digest().joinToString("") { "%02x".format(it) }
     }.getOrNull()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -85,6 +85,8 @@ import com.gamelaunch.frontend.ui.theme.TileSub
 import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassChip
 import com.gamelaunch.frontend.ui.theme.grid.GridHomeContent
+import com.gamelaunch.frontend.ui.theme.carousel.CarouselHomeContent
+import com.gamelaunch.frontend.ui.theme.LayoutMode
 import com.gamelaunch.frontend.ui.screen.retroachievements.RetroAchievementsScreen
 
 @Composable
@@ -184,12 +186,32 @@ fun HomeScreen(
                 else -> false
             }
         } else {
-            when (key) {
-                Key.DirectionLeft  -> { gridFocusIndex = (gridFocusIndex - 1).coerceAtLeast(0); true }
-                Key.DirectionRight -> { gridFocusIndex = (gridFocusIndex + 1).coerceAtMost(state.games.size - 1); true }
-                Key.DirectionUp    -> { (gridFocusIndex - gameGridColumns).let { if (it >= 0) gridFocusIndex = it }; true }
-                Key.DirectionDown  -> { (gridFocusIndex + gameGridColumns).let { if (it < state.games.size) gridFocusIndex = it }; true }
-                else -> false
+            if (state.layoutMode == LayoutMode.CAROUSEL) {
+                when (key) {
+                    Key.DirectionLeft  -> {
+                        val nextIdx = (state.selectedGameIndex - 1).coerceAtLeast(0)
+                        if (nextIdx != state.selectedGameIndex) {
+                            viewModel.onGameSelected(nextIdx)
+                            true
+                        } else false
+                    }
+                    Key.DirectionRight -> {
+                        val nextIdx = (state.selectedGameIndex + 1).coerceAtMost(state.games.size - 1)
+                        if (nextIdx != state.selectedGameIndex) {
+                            viewModel.onGameSelected(nextIdx)
+                            true
+                        } else false
+                    }
+                    else -> false
+                }
+            } else {
+                when (key) {
+                    Key.DirectionLeft  -> { gridFocusIndex = (gridFocusIndex - 1).coerceAtLeast(0); true }
+                    Key.DirectionRight -> { gridFocusIndex = (gridFocusIndex + 1).coerceAtMost(state.games.size - 1); true }
+                    Key.DirectionUp    -> { (gridFocusIndex - gameGridColumns).let { if (it >= 0) gridFocusIndex = it }; true }
+                    Key.DirectionDown  -> { (gridFocusIndex + gameGridColumns).let { if (it < state.games.size) gridFocusIndex = it }; true }
+                    else -> false
+                }
             }
         }
         TopTab.RECENTLY_PLAYED -> {
@@ -322,7 +344,8 @@ fun HomeScreen(
                         } else {
                             when (key) {
                                 GamepadA, Key.DirectionCenter, Key.Enter -> {
-                                    state.games.getOrNull(gridFocusIndex)?.let { onGameClick(it.id) }; true
+                                    val idx = if (state.layoutMode == LayoutMode.CAROUSEL) state.selectedGameIndex else gridFocusIndex
+                                    state.games.getOrNull(idx)?.let { onGameClick(it.id) }; true
                                 }
                                 GamepadL1 -> { cyclePlatform(-1); true }
                                 GamepadR1 -> { cyclePlatform(+1); true }
@@ -404,7 +427,8 @@ fun HomeScreen(
                                     maxLines = 1
                                 )
                             }
-                            val hoveredGame = state.games.getOrNull(gridFocusIndex)
+                            val idx = if (state.layoutMode == LayoutMode.CAROUSEL) state.selectedGameIndex else gridFocusIndex
+                            val hoveredGame = state.games.getOrNull(idx)
                             if (hoveredGame != null) {
                                 Text(
                                     "  →  " + hoveredGame.title,
@@ -461,15 +485,32 @@ fun HomeScreen(
                                 modifier        = Modifier.fillMaxSize()
                             )
 
-                        state.topTab == TopTab.GAMES -> GridHomeContent(
-                            games            = state.games,
-                            onGameClick      = onGameClick,
-                            columns          = gameGridColumns,
-                            mediaForGames    = state.mediaForGames,
-                            focusedGameIndex = gridFocusIndex,
-                            onPageSizeChange = { gridPageSize = it },
-                            modifier         = Modifier.fillMaxSize()
-                        )
+                        state.topTab == TopTab.GAMES -> {
+                            if (state.layoutMode == LayoutMode.CAROUSEL) {
+                                CarouselHomeContent(
+                                    games             = state.games,
+                                    selectedGameMedia = state.selectedGameMedia,
+                                    mediaForGames     = state.mediaForGames,
+                                    selectedIndex     = state.selectedGameIndex,
+                                    shouldPlayVideo   = state.shouldPlayVideo,
+                                    videoMuted        = state.videoMuted,
+                                    onGameSelected    = viewModel::onGameSelected,
+                                    onGameClick       = onGameClick,
+                                    onMuteToggle      = viewModel::toggleMute,
+                                    modifier          = Modifier.fillMaxSize()
+                                )
+                            } else {
+                                GridHomeContent(
+                                    games            = state.games,
+                                    onGameClick      = onGameClick,
+                                    columns          = gameGridColumns,
+                                    mediaForGames    = state.mediaForGames,
+                                    focusedGameIndex = gridFocusIndex,
+                                    onPageSizeChange = { gridPageSize = it },
+                                    modifier         = Modifier.fillMaxSize()
+                                )
+                            }
+                        }
 
                         state.topTab == TopTab.RECENTLY_PLAYED ->
                             if (state.recentlyPlayed.isEmpty()) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -395,6 +395,30 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
         )
         Spacer(Modifier.height(10.dp))
         Text(
+            "Library Layout",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            BackgroundModeChip(
+                label    = "Carousel",
+                selected = state.layoutMode == LayoutMode.CAROUSEL,
+                onClick  = { viewModel.setLayoutMode(LayoutMode.CAROUSEL) },
+                modifier = Modifier.weight(1f)
+            )
+            BackgroundModeChip(
+                label    = "Grid",
+                selected = state.layoutMode == LayoutMode.GRID,
+                onClick  = { viewModel.setLayoutMode(LayoutMode.GRID) },
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        Text(
             "Appearance",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurface
@@ -1509,7 +1533,9 @@ private fun CardSwitchRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 6.dp),
+            .clip(RoundedCornerShape(8.dp))
+            .clickable { onCheckedChange(!checked) }
+            .padding(horizontal = 4.dp, vertical = 6.dp),
         verticalAlignment   = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.gamelaunch.frontend
 
+import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.platform.PlatformDetector
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
@@ -16,7 +17,12 @@ import org.junit.rules.TemporaryFolder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.argumentCaptor
 import java.io.File
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class ScanRomsUseCaseTest {
 
@@ -92,5 +98,30 @@ class ScanRomsUseCaseTest {
         val results = useCase(tmpFolder.root.absolutePath).toList()
         val final = results.last()
         assertEquals(1, final.total) // only .sfc counted
+    }
+
+    @Test fun `computes md5 on uncompressed contents of zip files`() = runTest {
+        val snesDir = tmpFolder.newFolder("SNES")
+        val zipFile = File(snesDir, "game.zip")
+
+        ZipOutputStream(zipFile.outputStream()).use { zos ->
+            zos.putNextEntry(ZipEntry("inner.sfc"))
+            zos.write("ROMDATA".toByteArray())
+            zos.closeEntry()
+        }
+
+        whenever(gameRepository.insertGame(any())).thenReturn(1L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        useCase(tmpFolder.root.absolutePath).toList()
+
+        val gameCaptor = argumentCaptor<Game>()
+        verify(gameRepository).insertGame(gameCaptor.capture())
+
+        val expectedMd5 = MessageDigest.getInstance("MD5")
+            .digest("ROMDATA".toByteArray())
+            .joinToString("") { "%02x".format(it) }
+
+        assertEquals(expectedMd5, gameCaptor.firstValue.md5)
     }
 }


### PR DESCRIPTION
This submission adds full support for scanning and hashing .zip based ROMs (by hashing the first file inside the zip) and resolves several gaps and bugs in the Jetpack Compose frontend, including the unimplemented Carousel layout mode, Settings layout picker, and clickable settings rows.