### PR TITLE
Fix zip ROM md5: hash full inner window, not one inflate chunk

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 26
-        versionName = "1.8.2"
+        versionCode = 27
+        versionName = "1.8.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -108,28 +108,41 @@ class ScanRomsUseCase @Inject constructor(
                 while (entry != null) {
                     if (!entry.isDirectory) {
                         foundFile = true
-                        val buffer = ByteArray(512 * 1024)
-                        val read = zip.read(buffer)
-                        if (read > 0) md.update(buffer, 0, read)
+                        updateWithPartial(md, zip)
                         break
                     }
                     entry = zip.nextEntry
                 }
                 if (!foundFile) {
-                    file.inputStream().use { stream ->
-                        val buffer = ByteArray(512 * 1024)
-                        val read = stream.read(buffer)
-                        if (read > 0) md.update(buffer, 0, read)
-                    }
+                    file.inputStream().use { stream -> updateWithPartial(md, stream) }
                 }
             }
         } else {
-            file.inputStream().use { stream ->
-                val buffer = ByteArray(512 * 1024)
-                val read = stream.read(buffer)
-                if (read > 0) md.update(buffer, 0, read)
-            }
+            file.inputStream().use { stream -> updateWithPartial(md, stream) }
         }
         md.digest().joinToString("") { "%02x".format(it) }
     }.getOrNull()
+
+    /**
+     * Feeds up to [PARTIAL_HASH_BYTES] of [stream] into [md]. A single
+     * [java.io.InputStream.read] is not guaranteed to fill the buffer — this is
+     * especially true for decompressing streams like [ZipInputStream], where one
+     * read typically returns only a small inflate chunk. Looping until the window
+     * is filled (or EOF) makes the hashed byte count deterministic and consistent
+     * between raw and zipped ROMs.
+     */
+    private fun updateWithPartial(md: MessageDigest, stream: java.io.InputStream) {
+        val buffer = ByteArray(PARTIAL_HASH_BYTES)
+        var off = 0
+        while (off < buffer.size) {
+            val n = stream.read(buffer, off, buffer.size - off)
+            if (n < 0) break
+            off += n
+        }
+        if (off > 0) md.update(buffer, 0, off)
+    }
+
+    private companion object {
+        const val PARTIAL_HASH_BYTES = 512 * 1024 // 512 KB — first-window hash, keeps memory bounded
+    }
 }

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -124,4 +124,37 @@ class ScanRomsUseCaseTest {
 
         assertEquals(expectedMd5, gameCaptor.firstValue.md5)
     }
+
+    /**
+     * A single ZipInputStream.read() returns only the first inflate chunk, not the
+     * whole entry. For an inner ROM that is larger than one chunk but still under the
+     * 512 KB partial-hash window, the hash must cover the ENTIRE inner file so it
+     * equals the ROM's full-file md5 (what ScreenScraper matches on). Uses pseudo-random,
+     * poorly-compressible data so the inner stream spans several inflate reads.
+     */
+    @Test fun `hashes full inner rom when it spans multiple inflate chunks`() = runTest {
+        val innerRom = ByteArray(200 * 1024).also { java.util.Random(42).nextBytes(it) }
+
+        val snesDir = tmpFolder.newFolder("SNES")
+        val zipFile = File(snesDir, "big.zip")
+        ZipOutputStream(zipFile.outputStream()).use { zos ->
+            zos.putNextEntry(ZipEntry("inner.sfc"))
+            zos.write(innerRom)
+            zos.closeEntry()
+        }
+
+        whenever(gameRepository.insertGame(any())).thenReturn(1L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        useCase(tmpFolder.root.absolutePath).toList()
+
+        val gameCaptor = argumentCaptor<Game>()
+        verify(gameRepository).insertGame(gameCaptor.capture())
+
+        val expectedMd5 = MessageDigest.getInstance("MD5")
+            .digest(innerRom)
+            .joinToString("") { "%02x".format(it) }
+
+        assertEquals(expectedMd5, gameCaptor.firstValue.md5)
+    }
 }


### PR DESCRIPTION
## Problem

Follow-up to #44. `computeMd5Partial` hashes the first 512 KB of a ROM so that ROMs **at or under** that size produce their true full-file md5 — the value ScreenScraper (`jeuInfos.php`, `@Query("md5")`) matches on exactly. Many retro ROMs (NES, Game Boy, Game Gear, Master System) are ≤ 512 KB and rely on this for accurate hash-based scraping.

The zip path added in #44 fed the `ZipInputStream` through a **single** `read(buffer)`:

```kotlin
val read = zip.read(buffer)
if (read > 0) md.update(buffer, 0, read)
```

One `read()` on a decompressing stream returns only the first inflate chunk (a few KB), **not** the whole entry. So a small zipped ROM that should hash-match instead produced a fragment hash that matches nothing in ScreenScraper's DB — silently degrading it to filename-only (`romnom`) scraping. The raw-file path doesn't hit this because `FileInputStream.read` returns a small local file in one shot.

The test added in #44 used a 7-byte payload, which fits in a single read and therefore can't distinguish the two behaviours.

## Fix

Read in a loop up to the 512 KB window, via a shared `updateWithPartial` helper used by both the raw and zip paths, so the hashed byte count is deterministic and consistent between a raw ROM and the same ROM zipped. The 512 KB cap (the intentional OOM guard) is unchanged.

## Test

Adds a regression test with a **200 KB pseudo-random** inner ROM that spans several inflate reads:
- **Fails** against the old single-read (verified locally: `ComparisonFailure`).
- **Passes** with the loop.

Existing `ScanRomsUseCaseTest` cases still pass.

## Release

Bumps `versionName` to **1.8.3** (`versionCode` 27) for the patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)