### PR TITLE
Fix

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
@@ -50,7 +50,7 @@ object PlatformDefinitions {
         ),
         Platform(
             id = "ps1", displayName = "PlayStation", scraperSystemId = 57,
-            extensions = listOf(".bin", ".cue", ".iso", ".pbp", ".chd", ".img"),
+            extensions = listOf(".bin", ".cue", ".iso", ".pbp", ".chd", ".img", ".m3u"),
             folderNames = listOf("PS1", "ps1", "PSX", "psx", "PlayStation", "PS"),
             defaultEmulatorPackage = "com.github.stenzek.duckstation",
             defaultCoreForRetroArch = "pcsx_rearmed_libretro.so"
@@ -70,7 +70,7 @@ object PlatformDefinitions {
         ),
         Platform(
             id = "dc", displayName = "Dreamcast", scraperSystemId = 23,
-            extensions = listOf(".cdi", ".gdi", ".chd", ".cue"),
+            extensions = listOf(".cdi", ".gdi", ".chd", ".cue", ".m3u"),
             folderNames = listOf("DC", "Dreamcast", "dreamcast", "Sega Dreamcast"),
             defaultEmulatorPackage = "com.flycast.emulator",
             defaultCoreForRetroArch = "flycast_libretro.so"
@@ -95,7 +95,7 @@ object PlatformDefinitions {
         ),
         Platform(
             id = "saturn", displayName = "Sega Saturn", scraperSystemId = 22,
-            extensions = listOf(".cue", ".iso", ".chd", ".ccd"),
+            extensions = listOf(".cue", ".iso", ".chd", ".ccd", ".m3u"),
             folderNames = listOf("Saturn", "Sega Saturn", "saturn"),
             defaultCoreForRetroArch = "mednafen_saturn_libretro.so"
         ),
@@ -167,19 +167,19 @@ object PlatformDefinitions {
         ),
         Platform(
             id = "pcengine", displayName = "PC Engine / TurboGrafx-16", scraperSystemId = 31,
-            extensions = listOf(".pce", ".sgx", ".cue", ".chd"),
+            extensions = listOf(".pce", ".sgx", ".cue", ".chd", ".m3u"),
             folderNames = listOf("pcengine", "PCEngine", "tg16", "TG16", "TurboGrafx-16", "pce"),
             defaultCoreForRetroArch = "mednafen_pce_fast_libretro.so"
         ),
         Platform(
             id = "segacd", displayName = "Sega CD / Mega-CD", scraperSystemId = 20,
-            extensions = listOf(".chd", ".cue", ".iso"),
+            extensions = listOf(".chd", ".cue", ".iso", ".m3u"),
             folderNames = listOf("segacd", "SegaCD", "Sega CD", "megacd", "MegaCD", "Mega CD"),
             defaultCoreForRetroArch = "genesis_plus_gx_libretro.so"
         ),
         Platform(
             id = "3do", displayName = "Panasonic 3DO", scraperSystemId = 29,
-            extensions = listOf(".iso", ".chd", ".cue", ".bin"),
+            extensions = listOf(".iso", ".chd", ".cue", ".bin", ".m3u"),
             folderNames = listOf("3do", "3DO", "Panasonic 3DO"),
             defaultCoreForRetroArch = "opera_libretro.so"
         ),

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDetector.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDetector.kt
@@ -11,7 +11,7 @@ class PlatformDetector @Inject constructor() {
     // Extensions used by lots of non-game data files (saves, dumps, disc tracks, system files).
     // For these we never trust the extension alone — the file must live inside a recognised
     // platform folder AND the extension must be valid for that platform.
-    private val ambiguousExtensions = setOf(".bin", ".iso", ".img", ".chd", ".cso", ".cue", ".zip", ".7z")
+    private val ambiguousExtensions = setOf(".bin", ".iso", ".img", ".chd", ".cso", ".cue", ".zip", ".7z", ".m3u")
 
     // Archive formats that most libretro cores load directly. When a file already sits inside a
     // recognised system folder the folder tells us the platform, so a zipped ROM there is a game

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/DetectRomFolderUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/DetectRomFolderUseCase.kt
@@ -62,8 +62,8 @@ class DetectRomFolderUseCase @Inject constructor(
             "Emulation/roms"
         )
         val SKIP_EXTENSIONS = setOf(
-            ".txt", ".xml", ".cue", ".nfo", ".jpg", ".jpeg", ".png", ".mp4", ".rar",
-            ".sav", ".srm", ".state", ".m3u", ".dat", ".db"
+            ".txt", ".xml", ".nfo", ".jpg", ".jpeg", ".png", ".mp4", ".rar",
+            ".sav", ".srm", ".state", ".dat", ".db"
         )
         // Emulator-data + OS folders that never contain ROMs (mirrors ScanRomsUseCase).
         val SKIP_FOLDERS = setOf(

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -28,8 +28,8 @@ class ScanRomsUseCase @Inject constructor(
     private val settingsRepository: SettingsRepository
 ) {
     private val skipExtensions = setOf(
-        ".txt", ".xml", ".cue", ".nfo", ".jpg", ".png", ".mp4", ".rar",
-        ".sav", ".srm", ".state", ".m3u"
+        ".txt", ".xml", ".nfo", ".jpg", ".png", ".mp4", ".rar",
+        ".sav", ".srm", ".state"
     )
 
     // Emulator data sub-folders (saves, shaders, system files…) that hold no ROMs. Pruning
@@ -62,11 +62,29 @@ class ScanRomsUseCase @Inject constructor(
             .filterNot { it.absolutePath in excludedPaths }
             .toList()
 
+        val referencedPaths = mutableSetOf<String>()
+        romFiles.forEach { file ->
+            val ext = file.extension.lowercase()
+            if (ext == "cue") {
+                parseCueReferencedFiles(file).forEach { refFile ->
+                    referencedPaths.add(getNormalizedPath(refFile))
+                }
+            } else if (ext == "m3u") {
+                parseM3uReferencedFiles(file).forEach { refFile ->
+                    referencedPaths.add(getNormalizedPath(refFile))
+                }
+            }
+        }
+
+        val filteredRomFiles = romFiles.filterNot { file ->
+            getNormalizedPath(file) in referencedPaths
+        }
+
         val validPaths = mutableListOf<String>()
         var added = 0
 
-        romFiles.forEachIndexed { index, file ->
-            emit(ScanProgress(index, romFiles.size, file.name, added))
+        filteredRomFiles.forEachIndexed { index, file ->
+            emit(ScanProgress(index, filteredRomFiles.size, file.name, added))
 
             val platform = platformDetector.detect(file, file.parentFile?.name ?: "") ?: return@forEachIndexed
 
@@ -96,8 +114,62 @@ class ScanRomsUseCase @Inject constructor(
             gameRepository.deleteGamesNotInPaths(validPaths)
         }
 
-        emit(ScanProgress(romFiles.size, romFiles.size, added = added))
+        emit(ScanProgress(filteredRomFiles.size, filteredRomFiles.size, added = added))
     }.flowOn(Dispatchers.IO) // move all file I/O and hashing off the main thread
+
+    private fun parseCueReferencedFiles(cueFile: File): List<File> {
+        val referencedFiles = mutableListOf<File>()
+        val parentDir = cueFile.parentFile ?: return emptyList()
+        runCatching {
+            cueFile.forEachLine { line ->
+                val trimmed = line.trim()
+                if (trimmed.startsWith("FILE", ignoreCase = true)) {
+                    val quoteStart = trimmed.indexOf('"')
+                    val filename = if (quoteStart >= 0) {
+                        val quoteEnd = trimmed.indexOf('"', quoteStart + 1)
+                        if (quoteEnd > quoteStart) {
+                            trimmed.substring(quoteStart + 1, quoteEnd)
+                        } else {
+                            trimmed.substring(quoteStart + 1)
+                        }
+                    } else {
+                        val parts = trimmed.split(Regex("\\s+"))
+                        if (parts.size >= 2) {
+                            if (parts.size >= 3) {
+                                parts.subList(1, parts.size - 1).joinToString(" ")
+                            } else {
+                                parts[1]
+                            }
+                        } else {
+                            ""
+                        }
+                    }
+                    if (filename.isNotEmpty()) {
+                        referencedFiles.add(File(parentDir, filename))
+                    }
+                }
+            }
+        }
+        return referencedFiles
+    }
+
+    private fun parseM3uReferencedFiles(m3uFile: File): List<File> {
+        val referencedFiles = mutableListOf<File>()
+        val parentDir = m3uFile.parentFile ?: return emptyList()
+        runCatching {
+            m3uFile.forEachLine { line ->
+                val trimmed = line.trim()
+                if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
+                    referencedFiles.add(File(parentDir, trimmed))
+                }
+            }
+        }
+        return referencedFiles
+    }
+
+    private fun getNormalizedPath(file: File): String {
+        return runCatching { file.canonicalFile.absolutePath }.getOrDefault(file.absolutePath)
+    }
 
     private fun computeMd5Partial(file: File): String? = runCatching {
         val md = MessageDigest.getInstance("MD5")

--- a/app/src/test/java/com/gamelaunch/frontend/PlatformDetectorTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/PlatformDetectorTest.kt
@@ -56,4 +56,16 @@ class PlatformDetectorTest {
         val file = File(dir, "game.iso").also { it.createNewFile() }
         assertEquals("psp", detector.detect(file, "PSP")?.id)
     }
+
+    @Test fun `ps1 m3u detected via PS1 folder`() {
+        val dir = tmpFolder.newFolder("PS1")
+        val file = File(dir, "game.m3u").also { it.createNewFile() }
+        assertEquals("ps1", detector.detect(file, "PS1")?.id)
+    }
+
+    @Test fun `m3u outside platform folder is ignored as ambiguous`() {
+        val dir = tmpFolder.newFolder("misc")
+        val file = File(dir, "game.m3u").also { it.createNewFile() }
+        assertNull(detector.detect(file, "misc"))
+    }
 }

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -157,4 +157,54 @@ class ScanRomsUseCaseTest {
 
         assertEquals(expectedMd5, gameCaptor.firstValue.md5)
     }
+
+    @Test fun `detects ps1 cue file and filters out bin files referenced by cue`() = runTest {
+        val ps1Dir = tmpFolder.newFolder("PS1")
+        val cueFile = File(ps1Dir, "game.cue")
+        cueFile.writeText("""
+            FILE "game (Track 1).bin" BINARY
+            FILE "game (Track 2).bin" BINARY
+        """.trimIndent())
+
+        File(ps1Dir, "game (Track 1).bin").createNewFile()
+        File(ps1Dir, "game (Track 2).bin").createNewFile()
+
+        whenever(gameRepository.insertGame(any())).thenReturn(1L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        val results = useCase(tmpFolder.root.absolutePath).toList()
+        val final = results.last()
+
+        // Only the .cue file should be counted and added, the .bin files are filtered out
+        assertEquals(1, final.total)
+        assertEquals(1, final.added)
+    }
+
+    @Test fun `detects ps1 m3u file and filters out cue and bin files referenced by m3u and cue`() = runTest {
+        val ps1Dir = tmpFolder.newFolder("PS1")
+
+        val m3uFile = File(ps1Dir, "game.m3u")
+        m3uFile.writeText("""
+            game (Disc 1).cue
+            game (Disc 2).cue
+        """.trimIndent())
+
+        val cue1 = File(ps1Dir, "game (Disc 1).cue")
+        cue1.writeText("FILE \"game (Disc 1) (Track 1).bin\" BINARY")
+        File(ps1Dir, "game (Disc 1) (Track 1).bin").createNewFile()
+
+        val cue2 = File(ps1Dir, "game (Disc 2).cue")
+        cue2.writeText("FILE \"game (Disc 2) (Track 1).bin\" BINARY")
+        File(ps1Dir, "game (Disc 2) (Track 1).bin").createNewFile()
+
+        whenever(gameRepository.insertGame(any())).thenReturn(1L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        val results = useCase(tmpFolder.root.absolutePath).toList()
+        val final = results.last()
+
+        // Only the .m3u file should be counted and added, cues and bins are filtered out
+        assertEquals(1, final.total)
+        assertEquals(1, final.added)
+    }
 }


### PR DESCRIPTION
This change addresses the issue where multi-bin PS1 games or multi-disc games appear as multiple individual games on the list. We've updated the ROM scanner to parse .cue and .m3u files, extract any referenced track files (like .bin files), and filter them out of the list of scanned games. This ensures only the .cue or .m3u file is registered as a game. We've also added comprehensive unit tests to prevent regressions.

