### PR TITLE
Bump version to 1.8.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 27
-        versionName = "1.8.3"
+        versionCode = 28
+        versionName = "1.8.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Version bump for the **v1.8.4** release, cutting the multi-disc / multi-bin scan de-duplication contributed by @aarvsn in #46.

- `versionName` → **1.8.4**, `versionCode` → **28**.

No code changes beyond the version bump. #46's logic was reviewed (scan/filter, platform defs, and launch path), built, and the full unit suite passes.