### PR TITLE
Fix fetchSyncthing failing on clean builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -155,6 +155,9 @@ val fetchSyncthing = tasks.register("fetchSyncthing") {
         if (out.exists() && out.length() > 1_000_000L) return@doLast
         out.parentFile.mkdirs()
         val apk = File(tmpDir, "syncthing-android.apk")
+        // temporaryDir is captured at configuration time; a preceding `clean` in the same
+        // invocation deletes it, so recreate it before writing the downloaded APK.
+        apk.parentFile.mkdirs()
         println("Fetching Syncthing $version daemon…")
         URL(url).openStream().use { input -> apk.outputStream().use { output -> input.copyTo(output) } }
         ZipFile(apk).use { zip ->


### PR DESCRIPTION
## Problem

The `fetchSyncthing` Gradle task captures `temporaryDir` at configuration time. When `clean` runs in the same invocation as a build (`./gradlew clean assembleDebug`), it deletes `build/` — including that temp dir — **after** it was created at configuration. The task's download write then fails:

```
Execution failed for task ':app:fetchSyncthing'.
> java.io.FileNotFoundException: .../build/tmp/fetchSyncthing/syncthing-android.apk (No such file or directory)
```

This bites anyone doing a clean release build from scratch.

## Fix

One line: `apk.parentFile.mkdirs()` before writing the downloaded APK, mirroring the existing `out.parentFile.mkdirs()` for the output `.so`.

## Verification

`./gradlew clean :app:assembleDebug` — which reproduced the failure — now completes successfully in a single invocation (`fetchSyncthing` downloads the daemon, build succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)