### PR TITLE
Add Friends: on-device P2P social (share code, add nearby, no server)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,9 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockitoKotlin)
     testImplementation(libs.mockwebserver)
+    // Real org.json on the unit-test classpath (Android's bundled one is a non-functional stub),
+    // so profile.json (de)serialization can be tested on the JVM.
+    testImplementation("org.json:json:20240303")
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(platform(libs.compose.bom))

--- a/app/schemas/com.gamelaunch.frontend.data.db.AppDatabase/3.json
+++ b/app/schemas/com.gamelaunch.frontend.data.db.AppDatabase/3.json
@@ -1,0 +1,547 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "6db2c3eb858755f4960256c569f9687c",
+    "entities": [
+      {
+        "tableName": "games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `rom_path` TEXT NOT NULL, `rom_filename` TEXT NOT NULL, `platform_id` TEXT NOT NULL, `md5` TEXT, `crc` TEXT, `scraper_game_id` INTEGER, `description` TEXT, `genre` TEXT, `release_year` INTEGER, `rating` REAL, `is_favorite` INTEGER NOT NULL, `last_played_ms` INTEGER, `play_count` INTEGER NOT NULL, `date_added` INTEGER NOT NULL, `is_scraped` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "romPath",
+            "columnName": "rom_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "romFilename",
+            "columnName": "rom_filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformId",
+            "columnName": "platform_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "md5",
+            "columnName": "md5",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "crc",
+            "columnName": "crc",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scraperGameId",
+            "columnName": "scraper_game_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "releaseYear",
+            "columnName": "release_year",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedMs",
+            "columnName": "last_played_ms",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isScraped",
+            "columnName": "is_scraped",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_games_rom_path",
+            "unique": true,
+            "columnNames": [
+              "rom_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_games_rom_path` ON `${TABLE_NAME}` (`rom_path`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "game_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `game_id` INTEGER NOT NULL, `box_art_local` TEXT, `box_art_remote` TEXT, `screenshot_local` TEXT, `screenshot_remote` TEXT, `wheel_logo_local` TEXT, `wheel_logo_remote` TEXT, `video_local` TEXT, `video_remote` TEXT, `background_local` TEXT, `scraper_timestamp_ms` INTEGER, FOREIGN KEY(`game_id`) REFERENCES `games`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "game_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "boxArtLocalPath",
+            "columnName": "box_art_local",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "boxArtRemoteUrl",
+            "columnName": "box_art_remote",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "screenshotLocalPath",
+            "columnName": "screenshot_local",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "screenshotRemoteUrl",
+            "columnName": "screenshot_remote",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wheelLogoLocalPath",
+            "columnName": "wheel_logo_local",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "wheelLogoRemoteUrl",
+            "columnName": "wheel_logo_remote",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoLocalPath",
+            "columnName": "video_local",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoRemoteUrl",
+            "columnName": "video_remote",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "backgroundLocalPath",
+            "columnName": "background_local",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "scraperTimestampMs",
+            "columnName": "scraper_timestamp_ms",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_game_media_game_id",
+            "unique": true,
+            "columnNames": [
+              "game_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_game_media_game_id` ON `${TABLE_NAME}` (`game_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "games",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "game_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "emulator_mappings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `platform_id` TEXT NOT NULL, `package_name` TEXT NOT NULL, `launch_action` TEXT NOT NULL, `intent_extras_json` TEXT NOT NULL, `is_retroarch` INTEGER NOT NULL, `retroarch_core` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platformId",
+            "columnName": "platform_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchAction",
+            "columnName": "launch_action",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intentExtrasJson",
+            "columnName": "intent_extras_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRetroArch",
+            "columnName": "is_retroarch",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retroArchCore",
+            "columnName": "retroarch_core",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_emulator_mappings_platform_id",
+            "unique": true,
+            "columnNames": [
+              "platform_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_emulator_mappings_platform_id` ON `${TABLE_NAME}` (`platform_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "lb_games",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `platform` TEXT NOT NULL, `release_year` INTEGER, `overview` TEXT, `developer` TEXT, `publisher` TEXT, `rating` REAL, `video_url` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseYear",
+            "columnName": "release_year",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "developer",
+            "columnName": "developer",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoUrl",
+            "columnName": "video_url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lb_games_platform",
+            "unique": false,
+            "columnNames": [
+              "platform"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lb_games_platform` ON `${TABLE_NAME}` (`platform`)"
+          },
+          {
+            "name": "index_lb_games_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lb_games_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "lb_images",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `game_id` INTEGER NOT NULL, `file_name` TEXT NOT NULL, `type` TEXT NOT NULL, `region` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gameId",
+            "columnName": "game_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "file_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "region",
+            "columnName": "region",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lb_images_game_id",
+            "unique": false,
+            "columnNames": [
+              "game_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lb_images_game_id` ON `${TABLE_NAME}` (`game_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "friends",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`device_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, `status` TEXT NOT NULL, `last_played_title` TEXT, `last_played_platform` TEXT, `last_played_md5` TEXT, `last_played_at` INTEGER, `ra_username` TEXT, `ra_points` INTEGER, `ra_softcore_points` INTEGER, `added_at` INTEGER NOT NULL, `profile_updated_at` INTEGER, `last_synced_at` INTEGER, PRIMARY KEY(`device_id`))",
+        "fields": [
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedTitle",
+            "columnName": "last_played_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlayedPlatform",
+            "columnName": "last_played_platform",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlayedMd5",
+            "columnName": "last_played_md5",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "raUsername",
+            "columnName": "ra_username",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "raPoints",
+            "columnName": "ra_points",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "raSoftcorePoints",
+            "columnName": "ra_softcore_points",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileUpdatedAt",
+            "columnName": "profile_updated_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "device_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6db2c3eb858755f4960256c569f9687c')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
     <!-- Save Sync runs the embedded Syncthing daemon as a data-sync foreground service -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Friends "add nearby": UDP LAN discovery on the same Wi-Fi. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <queries>
         <!-- RetroArch — aarch64 build ships on Retroid Pocket; standard is the Play Store build -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,6 +90,13 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Friends: eor://friend/<deviceId>?n=<name> deep link (adding always needs confirmation). -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="eor" android:host="friend" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -78,6 +78,9 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var mediaRepository: MediaRepository
     @Inject lateinit var checkForUpdateUseCase: CheckForUpdateUseCase
     @Inject lateinit var syncthingController: com.gamelaunch.frontend.data.sync.SyncthingController
+    @Inject lateinit var syncEngineManager: com.gamelaunch.frontend.data.sync.SyncEngineManager
+    @Inject lateinit var friendRepository: com.gamelaunch.frontend.domain.repository.FriendRepository
+    @Inject lateinit var pendingFriendLink: com.gamelaunch.frontend.domain.friends.PendingFriendLink
 
     // Set when a newer GitHub release is found; drives the in-app update banner.
     private val updateState = mutableStateOf<AppUpdate?>(null)
@@ -120,6 +123,7 @@ class MainActivity : ComponentActivity() {
         // cold start — otherwise an update that lands while the app is open is only noticed after a
         // force-close and reopen.
         startSaveSyncIfEnabled()
+        handleFriendDeepLink(intent)
 
         setContent {
             val darkMode by settingsRepository.darkMode.collectAsState(initial = false)
@@ -268,10 +272,27 @@ class MainActivity : ComponentActivity() {
     /** If the user left Save Sync on, bring the Syncthing daemon back up when eOr launches. */
     private fun startSaveSyncIfEnabled() {
         lifecycleScope.launch {
-            if (settingsRepository.saveSyncEnabled.first() && syncthingController.isSupported()) {
-                com.gamelaunch.frontend.data.sync.SyncthingService.start(this@MainActivity)
+            // Starts the daemon if Save Sync OR Friends is enabled; then bring friends up to date.
+            syncEngineManager.refresh()
+            if (settingsRepository.friendsEnabled.first() && syncthingController.isSupported()) {
+                runCatching { friendRepository.publishMyProfile() }
+                runCatching { friendRepository.refreshFriends() }
             }
         }
+    }
+
+    /** Parse an incoming eor://friend/... deep link and stage it for a user-confirmed add. */
+    private fun handleFriendDeepLink(intent: Intent?) {
+        val data = intent?.data ?: return
+        if (intent.action != Intent.ACTION_VIEW) return
+        if (!data.scheme.equals(com.gamelaunch.frontend.domain.friends.FriendCode.SCHEME, ignoreCase = true)) return
+        com.gamelaunch.frontend.domain.friends.FriendCode.parse(data.toString())?.let { pendingFriendLink.offer(it) }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleFriendDeepLink(intent)
     }
 
     /**

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/AppDatabase.kt
@@ -4,10 +4,12 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.gamelaunch.frontend.data.db.dao.EmulatorMappingDao
+import com.gamelaunch.frontend.data.db.dao.FriendDao
 import com.gamelaunch.frontend.data.db.dao.GameDao
 import com.gamelaunch.frontend.data.db.dao.GameMediaDao
 import com.gamelaunch.frontend.data.db.dao.LaunchBoxDao
 import com.gamelaunch.frontend.data.db.entity.EmulatorMappingEntity
+import com.gamelaunch.frontend.data.db.entity.FriendEntity
 import com.gamelaunch.frontend.data.db.entity.GameEntity
 import com.gamelaunch.frontend.data.db.entity.GameMediaEntity
 import com.gamelaunch.frontend.data.db.entity.LaunchBoxGameEntity
@@ -19,9 +21,10 @@ import com.gamelaunch.frontend.data.db.entity.LaunchBoxImageEntity
         GameMediaEntity::class,
         EmulatorMappingEntity::class,
         LaunchBoxGameEntity::class,
-        LaunchBoxImageEntity::class
+        LaunchBoxImageEntity::class,
+        FriendEntity::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -30,6 +33,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun gameMediaDao(): GameMediaDao
     abstract fun emulatorMappingDao(): EmulatorMappingDao
     abstract fun launchBoxDao(): LaunchBoxDao
+    abstract fun friendDao(): FriendDao
 
     companion object {
         const val DATABASE_NAME = "gamelauncher.db"

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/dao/FriendDao.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/dao/FriendDao.kt
@@ -1,0 +1,33 @@
+package com.gamelaunch.frontend.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.gamelaunch.frontend.data.db.entity.FriendEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FriendDao {
+
+    @Query("SELECT * FROM friends ORDER BY display_name ASC")
+    fun observeAll(): Flow<List<FriendEntity>>
+
+    @Query("SELECT * FROM friends WHERE status = :status ORDER BY display_name ASC")
+    fun observeByStatus(status: String): Flow<List<FriendEntity>>
+
+    @Query("SELECT * FROM friends WHERE device_id = :deviceId")
+    suspend fun getByDeviceId(deviceId: String): FriendEntity?
+
+    @Query("SELECT * FROM friends")
+    suspend fun getAll(): List<FriendEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(friend: FriendEntity)
+
+    @Query("DELETE FROM friends WHERE device_id = :deviceId")
+    suspend fun delete(deviceId: String)
+
+    @Query("DELETE FROM friends")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/entity/FriendEntity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/entity/FriendEntity.kt
@@ -1,0 +1,27 @@
+package com.gamelaunch.frontend.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A friend (or pending friend request) identified by their Syncthing device id. All fields other
+ * than identity/status are a cached copy of the last profile.json we received over P2P sync — they
+ * may be stale if the friend is offline. `status` is one of PENDING_OUT / PENDING_IN / ACTIVE.
+ */
+@Entity(tableName = "friends")
+data class FriendEntity(
+    @PrimaryKey @ColumnInfo(name = "device_id") val deviceId: String,
+    @ColumnInfo(name = "display_name") val displayName: String,
+    @ColumnInfo(name = "status") val status: String,
+    @ColumnInfo(name = "last_played_title") val lastPlayedTitle: String? = null,
+    @ColumnInfo(name = "last_played_platform") val lastPlayedPlatform: String? = null,
+    @ColumnInfo(name = "last_played_md5") val lastPlayedMd5: String? = null,
+    @ColumnInfo(name = "last_played_at") val lastPlayedAt: Long? = null,
+    @ColumnInfo(name = "ra_username") val raUsername: String? = null,
+    @ColumnInfo(name = "ra_points") val raPoints: Int? = null,
+    @ColumnInfo(name = "ra_softcore_points") val raSoftcorePoints: Int? = null,
+    @ColumnInfo(name = "added_at") val addedAt: Long,
+    @ColumnInfo(name = "profile_updated_at") val profileUpdatedAt: Long? = null,
+    @ColumnInfo(name = "last_synced_at") val lastSyncedAt: Long? = null
+)

--- a/app/src/main/java/com/gamelaunch/frontend/data/friends/FriendProfileStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/friends/FriendProfileStore.kt
@@ -1,0 +1,47 @@
+package com.gamelaunch.frontend.data.friends
+
+import android.content.Context
+import com.gamelaunch.frontend.domain.friends.FriendProfile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Owns the on-disk layout of the Friends P2P folders under filesDir/eor-friends:
+ *   out/profile.json         — my send-only profile (synced TO friends)
+ *   in/<friendDeviceId>/profile.json — each friend's receive-only profile (synced FROM them)
+ * These directories are what SyncthingController registers as sendonly/receiveonly folders.
+ */
+@Singleton
+class FriendProfileStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val root: File get() = File(context.filesDir, "eor-friends").apply { mkdirs() }
+
+    val outDir: File get() = File(root, "out").apply { mkdirs() }
+    private val outFile: File get() = File(outDir, PROFILE_FILE)
+
+    fun inDir(friendDeviceId: String): File =
+        File(File(root, "in"), friendDeviceId.trim().uppercase()).apply { mkdirs() }
+
+    suspend fun writeMyProfile(profile: FriendProfile) = withContext(Dispatchers.IO) {
+        outFile.writeText(profile.encode())
+    }
+
+    /** Empty my outbound profile so nothing is shared while the feature is off. */
+    suspend fun clearMyProfile() = withContext(Dispatchers.IO) {
+        if (outFile.exists()) outFile.delete()
+    }
+
+    suspend fun readFriendProfile(friendDeviceId: String): FriendProfile? = withContext(Dispatchers.IO) {
+        val f = File(inDir(friendDeviceId), PROFILE_FILE)
+        if (!f.exists()) null else runCatching { FriendProfile.decode(f.readText()) }.getOrNull()
+    }
+
+    companion object {
+        const val PROFILE_FILE = "profile.json"
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/friends/NearbyBeacon.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/friends/NearbyBeacon.kt
@@ -1,0 +1,159 @@
+package com.gamelaunch.frontend.data.friends
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.util.Log
+import com.gamelaunch.frontend.domain.friends.FriendCode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * LAN discovery for the "add nearby" flow: while active, periodically broadcasts our own friend code
+ * over UDP and listens for other eOr devices on the same Wi-Fi, exposing them as a tappable list.
+ * Purely for exchanging the (public) device id in person — carries no private data, and only runs
+ * while the Add-nearby screen has it started. Ongoing friend sync still happens over Syncthing.
+ */
+@Singleton
+class NearbyBeacon @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    data class NearbyPeer(val deviceId: String, val displayName: String, val lastSeenMs: Long)
+
+    private val _peers = MutableStateFlow<List<NearbyPeer>>(emptyList())
+    val peers: StateFlow<List<NearbyPeer>> = _peers
+
+    private val seen = ConcurrentHashMap<String, NearbyPeer>()
+    private var scope: CoroutineScope? = null
+    private var socket: DatagramSocket? = null
+    private var multicastLock: WifiManager.MulticastLock? = null
+
+    @Synchronized
+    fun start(myDeviceId: String, myDisplayName: String) {
+        if (scope != null) return // already running
+        seen.clear(); _peers.value = emptyList()
+        val s = CoroutineScope(SupervisorJob() + Dispatchers.IO).also { scope = it }
+
+        val sock = runCatching {
+            DatagramSocket(null).apply {
+                reuseAddress = true
+                broadcast = true
+                bind(InetSocketAddress(PORT))
+                soTimeout = 1000
+            }
+        }.getOrElse { Log.w(TAG, "beacon socket failed: ${it.message}"); stop(); return }
+        socket = sock
+
+        // A multicast lock lets us receive broadcast/multicast frames on many devices.
+        runCatching {
+            val wifi = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            multicastLock = wifi.createMulticastLock("eor-friends-nearby").apply {
+                setReferenceCounted(false); acquire()
+            }
+        }
+
+        val payload = JSONObject().apply {
+            put("m", MAGIC)
+            put("id", myDeviceId)
+            put("n", myDisplayName)
+        }.toString().toByteArray()
+
+        // Broadcaster
+        s.launch {
+            val targets = broadcastTargets()
+            while (isActive) {
+                for (addr in targets) {
+                    runCatching { sock.send(DatagramPacket(payload, payload.size, addr, PORT)) }
+                }
+                delay(2000)
+            }
+        }
+        // Listener
+        s.launch {
+            val buf = ByteArray(2048)
+            while (isActive) {
+                val packet = DatagramPacket(buf, buf.size)
+                val ok = runCatching { sock.receive(packet); true }.getOrElse { false } // soTimeout → retry
+                if (ok) parse(packet, myDeviceId)
+            }
+        }
+        // Pruner: drop peers not seen in the last few seconds.
+        s.launch {
+            while (isActive) {
+                val cutoff = System.currentTimeMillis() - STALE_MS
+                var changed = false
+                seen.entries.removeIf { if (it.value.lastSeenMs < cutoff) { changed = true; true } else false }
+                if (changed) publish()
+                delay(1500)
+            }
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        scope?.cancel(); scope = null
+        runCatching { socket?.close() }; socket = null
+        runCatching { multicastLock?.release() }; multicastLock = null
+        seen.clear(); _peers.value = emptyList()
+    }
+
+    private fun parse(packet: DatagramPacket, myDeviceId: String) {
+        runCatching {
+            val obj = JSONObject(String(packet.data, packet.offset, packet.length))
+            if (obj.optString("m") != MAGIC) return
+            val id = obj.optString("id").takeIf { FriendCode.isValidDeviceId(it) } ?: return
+            if (id.equals(myDeviceId, ignoreCase = true)) return
+            val name = obj.optString("n").ifBlank { "Nearby player" }
+            seen[id.uppercase()] = NearbyPeer(id.uppercase(), name, System.currentTimeMillis())
+            publish()
+        }
+    }
+
+    private fun publish() {
+        _peers.value = seen.values.sortedBy { it.displayName }
+    }
+
+    /** 255.255.255.255 plus the Wi-Fi subnet-directed broadcast (some APs drop limited broadcast). */
+    private fun broadcastTargets(): List<InetAddress> {
+        val targets = mutableListOf<InetAddress>()
+        runCatching { targets.add(InetAddress.getByName("255.255.255.255")) }
+        runCatching {
+            val wifi = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            @Suppress("DEPRECATION") val dhcp = wifi.dhcpInfo
+            if (dhcp != null && dhcp.ipAddress != 0) {
+                val bc = (dhcp.ipAddress and dhcp.netmask) or dhcp.netmask.inv()
+                val bytes = byteArrayOf(
+                    (bc and 0xff).toByte(),
+                    (bc shr 8 and 0xff).toByte(),
+                    (bc shr 16 and 0xff).toByte(),
+                    (bc shr 24 and 0xff).toByte()
+                )
+                targets.add(InetAddress.getByAddress(bytes))
+            }
+        }
+        return targets.distinct()
+    }
+
+    private companion object {
+        const val TAG = "NearbyBeacon"
+        const val PORT = 47811
+        const val MAGIC = "eor-fr-1"
+        const val STALE_MS = 8000L
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -56,6 +56,11 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val RA_TOKEN = stringPreferencesKey("ra_token")
         val RA_POINTS = intPreferencesKey("ra_points")
         val RA_SOFTCORE_POINTS = intPreferencesKey("ra_softcore_points")
+        // Friends (P2P social) — all local. Display name is generated once on first use if blank.
+        val FRIENDS_ENABLED = booleanPreferencesKey("friends_enabled")
+        val FRIEND_DISPLAY_NAME = stringPreferencesKey("friend_display_name")
+        val FRIEND_SHARE_LAST_PLAYED = booleanPreferencesKey("friend_share_last_played")
+        val FRIEND_SHARE_RA = booleanPreferencesKey("friend_share_ra")
         // Platform ids the user has chosen to hide from the home screen (e.g. "pc", "android").
         val HIDDEN_PLATFORMS = stringSetPreferencesKey("hidden_platforms")
         // rom_path identifiers the user removed from the library; scans skip these so they don't
@@ -104,6 +109,12 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
     val raPoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_POINTS] ?: 0 }
     val raSoftcorePoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_SOFTCORE_POINTS] ?: 0 }
+    // Friends feature is opt-in (off by default): enabling it starts the P2P sync engine.
+    val friendsEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.FRIENDS_ENABLED] ?: false }
+    // Empty until first generated (see FriendRepository); never blank once the feature is used.
+    val friendDisplayName: Flow<String> = context.dataStore.data.map { it[Keys.FRIEND_DISPLAY_NAME] ?: "" }
+    val friendShareLastPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.FRIEND_SHARE_LAST_PLAYED] ?: true }
+    val friendShareRa: Flow<Boolean> = context.dataStore.data.map { it[Keys.FRIEND_SHARE_RA] ?: true }
     val hiddenPlatforms: Flow<Set<String>> = context.dataStore.data.map { it[Keys.HIDDEN_PLATFORMS] ?: emptySet() }
     val excludedPaths: Flow<Set<String>> = context.dataStore.data.map { it[Keys.EXCLUDED_PATHS] ?: emptySet() }
 
@@ -158,6 +169,11 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         it.remove(Keys.RA_POINTS)
         it.remove(Keys.RA_SOFTCORE_POINTS)
     }
+
+    suspend fun setFriendsEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.FRIENDS_ENABLED] = enabled }
+    suspend fun setFriendDisplayName(name: String) = context.dataStore.edit { it[Keys.FRIEND_DISPLAY_NAME] = name }
+    suspend fun setFriendShareLastPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.FRIEND_SHARE_LAST_PLAYED] = enabled }
+    suspend fun setFriendShareRa(enabled: Boolean) = context.dataStore.edit { it[Keys.FRIEND_SHARE_RA] = enabled }
 
     suspend fun setPlatformHidden(platformId: String, hidden: Boolean) = context.dataStore.edit {
         val current = it[Keys.HIDDEN_PLATFORMS] ?: emptySet()

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/FriendRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/FriendRepositoryImpl.kt
@@ -1,0 +1,203 @@
+package com.gamelaunch.frontend.data.repository
+
+import com.gamelaunch.frontend.data.db.dao.FriendDao
+import com.gamelaunch.frontend.data.db.entity.FriendEntity
+import com.gamelaunch.frontend.data.friends.FriendProfileStore
+import com.gamelaunch.frontend.data.sync.SyncEngineManager
+import com.gamelaunch.frontend.data.sync.SyncthingController
+import com.gamelaunch.frontend.domain.friends.Friend
+import com.gamelaunch.frontend.domain.friends.FriendCode
+import com.gamelaunch.frontend.domain.friends.FriendProfile
+import com.gamelaunch.frontend.domain.friends.FriendStatus
+import com.gamelaunch.frontend.domain.friends.LastPlayed
+import com.gamelaunch.frontend.domain.friends.RaInfo
+import com.gamelaunch.frontend.domain.friends.RandomHandle
+import com.gamelaunch.frontend.domain.repository.AddFriendResult
+import com.gamelaunch.frontend.domain.repository.FriendRepository
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FriendRepositoryImpl @Inject constructor(
+    private val friendDao: FriendDao,
+    private val syncthingController: SyncthingController,
+    private val syncEngineManager: SyncEngineManager,
+    private val profileStore: FriendProfileStore,
+    private val settingsRepository: SettingsRepository,
+    private val gameRepository: GameRepository
+) : FriendRepository {
+
+    override fun observeFriends(): Flow<List<Friend>> =
+        friendDao.observeAll().map { rows -> rows.map { it.toDomain() } }
+
+    override fun engineSupported(): Boolean = syncthingController.isSupported()
+
+    override suspend fun myDisplayName(): String {
+        val current = settingsRepository.friendDisplayName.first()
+        if (current.isNotBlank()) return current
+        val generated = RandomHandle.generate()
+        settingsRepository.setFriendDisplayName(generated)
+        return generated
+    }
+
+    override suspend fun setMyDisplayName(name: String) {
+        val trimmed = name.trim().ifBlank { RandomHandle.generate() }
+        settingsRepository.setFriendDisplayName(trimmed)
+        publishMyProfile()
+    }
+
+    override suspend fun myDeviceId(): String? = syncthingController.awaitDeviceId()
+
+    override suspend fun myShareLink(): String? =
+        myDeviceId()?.let { FriendCode.buildLink(it, myDisplayName()) }
+
+    override suspend fun addFriend(codeOrLink: String): AddFriendResult {
+        val parsed = FriendCode.parse(codeOrLink) ?: return AddFriendResult.InvalidCode
+        val myId = myDeviceId() ?: return AddFriendResult.EngineUnavailable
+        if (parsed.deviceId.equals(myId, ignoreCase = true)) return AddFriendResult.Self
+
+        val existing = friendDao.getByDeviceId(parsed.deviceId)
+        if (existing?.status == FriendStatus.ACTIVE.name) return AddFriendResult.AlreadyFriend
+
+        // They may have already requested me (PENDING_IN) — adding them back completes the friendship.
+        val nowActive = existing?.status == FriendStatus.PENDING_IN.name
+        wirePeer(parsed.deviceId)
+        upsert(
+            deviceId = parsed.deviceId,
+            displayName = parsed.displayName ?: existing?.displayName ?: "Pending friend",
+            status = if (nowActive) FriendStatus.ACTIVE else FriendStatus.PENDING_OUT,
+            existing = existing
+        )
+        publishMyProfile()
+        return AddFriendResult.Requested(parsed.displayName)
+    }
+
+    override suspend fun acceptRequest(deviceId: String) {
+        val existing = friendDao.getByDeviceId(deviceId)
+        wirePeer(deviceId)
+        upsert(deviceId, existing?.displayName ?: "Friend", FriendStatus.ACTIVE, existing)
+        publishMyProfile()
+    }
+
+    override suspend fun declineRequest(deviceId: String) {
+        val myId = myDeviceId()
+        if (myId != null) syncthingController.removeFriendPeer(deviceId, myId)
+        friendDao.delete(deviceId)
+    }
+
+    override suspend fun removeFriend(deviceId: String) {
+        val myId = myDeviceId()
+        if (myId != null) syncthingController.removeFriendPeer(deviceId, myId)
+        friendDao.delete(deviceId)
+    }
+
+    override suspend fun publishMyProfile() {
+        if (!settingsRepository.friendsEnabled.first()) {
+            profileStore.clearMyProfile()
+            return
+        }
+        val myId = myDeviceId() ?: return
+        syncthingController.configureProfileFolder(myId, profileStore.outDir.absolutePath)
+
+        val lastPlayed = if (settingsRepository.friendShareLastPlayed.first()) {
+            gameRepository.getRecentlyPlayed(1).first().firstOrNull()?.let { g ->
+                LastPlayed(g.title, g.platformId, g.md5, g.lastPlayedMs ?: System.currentTimeMillis())
+            }
+        } else null
+
+        val raUsername = settingsRepository.raUsername.first()
+        val ra = if (settingsRepository.friendShareRa.first() && raUsername.isNotBlank()) {
+            RaInfo(raUsername, settingsRepository.raPoints.first(), settingsRepository.raSoftcorePoints.first())
+        } else null
+
+        val profile = FriendProfile(myId, myDisplayName(), lastPlayed, ra, System.currentTimeMillis())
+        profileStore.writeMyProfile(profile)
+    }
+
+    override suspend fun refreshFriends() {
+        val now = System.currentTimeMillis()
+        // Incoming requests: devices that tried to connect but we haven't added yet.
+        val existingIds = friendDao.getAll().associateBy { it.deviceId }
+        syncthingController.pendingFriendRequests().forEach { pid ->
+            val existing = existingIds[pid]
+            if (existing == null) {
+                friendDao.upsert(
+                    FriendEntity(pid, "Friend request", FriendStatus.PENDING_IN.name, addedAt = now)
+                )
+            }
+        }
+        // Inbound profiles: if we can read a friend's profile, they've added us back → ACTIVE.
+        friendDao.getAll().forEach { row ->
+            val profile = profileStore.readFriendProfile(row.deviceId) ?: return@forEach
+            friendDao.upsert(
+                row.copy(
+                    displayName = profile.displayName,
+                    status = FriendStatus.ACTIVE.name,
+                    lastPlayedTitle = profile.lastPlayed?.title,
+                    lastPlayedPlatform = profile.lastPlayed?.platform,
+                    lastPlayedMd5 = profile.lastPlayed?.md5,
+                    lastPlayedAt = profile.lastPlayed?.at,
+                    raUsername = profile.ra?.username,
+                    raPoints = profile.ra?.points,
+                    raSoftcorePoints = profile.ra?.softcorePoints,
+                    profileUpdatedAt = profile.updatedAt,
+                    lastSyncedAt = now
+                )
+            )
+        }
+    }
+
+    override suspend fun setEnabled(enabled: Boolean) {
+        settingsRepository.setFriendsEnabled(enabled)
+        if (enabled) {
+            syncEngineManager.ensureRunning()
+            myDisplayName() // generate + persist a handle on first enable
+            publishMyProfile()
+        } else {
+            syncthingController.teardownFriends()
+            profileStore.clearMyProfile()
+            syncEngineManager.refresh() // stop the daemon unless Save Sync still needs it
+        }
+    }
+
+    /** Register the peer + isolated profile folders for a friendship (shared by request/accept). */
+    private suspend fun wirePeer(friendDeviceId: String) {
+        val myId = myDeviceId() ?: return
+        syncthingController.configureProfileFolder(myId, profileStore.outDir.absolutePath)
+        syncthingController.addFriendPeer(
+            friendDeviceId = friendDeviceId,
+            myDeviceId = myId,
+            myProfilePath = profileStore.outDir.absolutePath,
+            inboundPath = profileStore.inDir(friendDeviceId).absolutePath
+        )
+    }
+
+    private suspend fun upsert(
+        deviceId: String,
+        displayName: String,
+        status: FriendStatus,
+        existing: FriendEntity?
+    ) {
+        friendDao.upsert(
+            (existing ?: FriendEntity(deviceId, displayName, status.name, addedAt = System.currentTimeMillis()))
+                .copy(deviceId = deviceId, displayName = displayName, status = status.name)
+        )
+    }
+
+    private fun FriendEntity.toDomain() = Friend(
+        deviceId = deviceId,
+        displayName = displayName,
+        status = runCatching { FriendStatus.valueOf(status) }.getOrDefault(FriendStatus.PENDING_OUT),
+        lastPlayed = lastPlayedTitle?.let {
+            LastPlayed(it, lastPlayedPlatform ?: "", lastPlayedMd5, lastPlayedAt ?: 0L)
+        },
+        ra = raUsername?.let { RaInfo(it, raPoints ?: 0, raSoftcorePoints ?: 0) },
+        profileUpdatedAt = profileUpdatedAt,
+        lastSyncedAt = lastSyncedAt
+    )
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -69,6 +69,10 @@ class SettingsRepositoryImpl @Inject constructor(
     override val raToken: Flow<String> = dataStore.raToken
     override val raPoints: Flow<Int> = dataStore.raPoints
     override val raSoftcorePoints: Flow<Int> = dataStore.raSoftcorePoints
+    override val friendsEnabled: Flow<Boolean> = dataStore.friendsEnabled
+    override val friendDisplayName: Flow<String> = dataStore.friendDisplayName
+    override val friendShareLastPlayed: Flow<Boolean> = dataStore.friendShareLastPlayed
+    override val friendShareRa: Flow<Boolean> = dataStore.friendShareRa
     override val hiddenPlatforms: Flow<Set<String>> = dataStore.hiddenPlatforms
     override val excludedPaths: Flow<Set<String>> = dataStore.excludedPaths
 
@@ -121,4 +125,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun clearRaCredentials() { dataStore.clearRaCredentials() }
     override suspend fun setPlatformHidden(platformId: String, hidden: Boolean) { dataStore.setPlatformHidden(platformId, hidden) }
     override suspend fun addExcludedPath(romPath: String) { dataStore.addExcludedPath(romPath) }
+    override suspend fun setFriendsEnabled(enabled: Boolean) { dataStore.setFriendsEnabled(enabled) }
+    override suspend fun setFriendDisplayName(name: String) { dataStore.setFriendDisplayName(name) }
+    override suspend fun setFriendShareLastPlayed(enabled: Boolean) { dataStore.setFriendShareLastPlayed(enabled) }
+    override suspend fun setFriendShareRa(enabled: Boolean) { dataStore.setFriendShareRa(enabled) }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/sync/SyncEngineManager.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/sync/SyncEngineManager.kt
@@ -1,0 +1,31 @@
+package com.gamelaunch.frontend.data.sync
+
+import android.content.Context
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Single owner of the embedded Syncthing daemon's run state. Both Save Sync and Friends need the same
+ * daemon, so neither may stop it unilaterally — the service should run whenever *either* feature is on.
+ * Callers persist their enabled flag first, then call [refresh]; [ensureRunning] is an idempotent start.
+ */
+@Singleton
+class SyncEngineManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val settingsRepository: SettingsRepository,
+    private val syncthingController: SyncthingController
+) {
+    fun ensureRunning() {
+        if (syncthingController.isSupported()) SyncthingService.start(context)
+    }
+
+    /** Start if any feature needs the daemon, otherwise stop it. Read persisted flags to decide. */
+    suspend fun refresh() {
+        val needed = settingsRepository.saveSyncEnabled.first() || settingsRepository.friendsEnabled.first()
+        if (needed && syncthingController.isSupported()) SyncthingService.start(context)
+        else SyncthingService.stop(context)
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/sync/SyncthingController.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/sync/SyncthingController.kt
@@ -10,6 +10,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import com.gamelaunch.frontend.domain.friends.FriendFolders
 import org.json.JSONObject
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -159,8 +160,155 @@ class SyncthingController @Inject constructor(
         client.newCall(request).execute().use { it.isSuccessful }
     }.getOrElse { Log.d(TAG, "PUT $path failed: ${it.message}"); false }
 
+    private fun deleteReq(path: String, apiKey: String): Boolean = runCatching {
+        val request = Request.Builder()
+            .url("http://$guiAddress$path")
+            .header("X-API-Key", apiKey)
+            .delete()
+            .build()
+        client.newCall(request).execute().use { it.isSuccessful }
+    }.getOrElse { Log.d(TAG, "DELETE $path failed: ${it.message}"); false }
+
+    private fun getBody(path: String, apiKey: String): String? = runCatching {
+        val request = Request.Builder().url("http://$guiAddress$path").header("X-API-Key", apiKey).build()
+        client.newCall(request).execute().use { if (!it.isSuccessful) null else it.body?.string() }
+    }.getOrNull()
+
+    // ─────────────────────────── Friends (P2P social) ───────────────────────────
+    // Fully isolated from Save Sync: friend folders use FRIEND_PREFIX (which does NOT start with
+    // "eor-", so shareEorFoldersWith never touches them), peers are added with introducer:false and
+    // autoAcceptFolders:false, and only the specific friend is put on each folder's device list —
+    // so a friend never receives your save folders and can't discover your other friends.
+
+    /** Deterministic id (same on both devices) for the folder that carries [ownerDeviceId]'s profile. */
+    fun profileFolderId(ownerDeviceId: String): String = FriendFolders.profileFolderId(ownerDeviceId)
+
+    /** Upsert my send-only profile folder (holds profile.json), owned by [myDeviceId]. */
+    suspend fun configureProfileFolder(myDeviceId: String, path: String): Boolean = withContext(Dispatchers.IO) {
+        val key = readApiKey() ?: return@withContext false
+        upsertProfileFolder(profileFolderId(myDeviceId), "eOr profile", path, "sendonly", key)
+    }
+
+    /**
+     * Add [friendDeviceId] as a friend peer and wire up the two isolated profile folders (my outbound
+     * send-only, their inbound receive-only). Mutual: only becomes an active friendship once they do
+     * the same for me. [myDeviceId]/[myProfilePath] locate my outbound folder; [inboundPath] is where
+     * their profile.json lands. Used for both an outgoing request and accepting an incoming one.
+     */
+    suspend fun addFriendPeer(
+        friendDeviceId: String,
+        myDeviceId: String,
+        myProfilePath: String,
+        inboundPath: String
+    ): Boolean = withContext(Dispatchers.IO) {
+        val key = readApiKey() ?: return@withContext false
+        val fid = friendDeviceId.trim().uppercase()
+        if (fid.isBlank()) return@withContext false
+        val device = JSONObject().apply {
+            put("deviceID", fid)
+            put("name", "eOr friend")
+            put("introducer", false)        // never let a friend introduce further devices
+            put("autoAcceptFolders", false) // never auto-accept folders a friend offers
+            put("addresses", org.json.JSONArray(listOf("dynamic")))
+        }
+        if (!putJson("/rest/config/devices/$fid", key, device)) return@withContext false
+        // Share my profile folder with this friend only.
+        val myFolderOk = upsertProfileFolder(
+            profileFolderId(myDeviceId), "eOr profile", myProfilePath, "sendonly", key, shareWith = fid
+        )
+        // Receive their profile into an isolated per-friend folder.
+        val theirFolderOk = upsertProfileFolder(
+            profileFolderId(fid), "eOr friend profile", inboundPath, "receiveonly", key, shareWith = fid
+        )
+        myFolderOk && theirFolderOk
+    }
+
+    private fun upsertProfileFolder(
+        id: String, label: String, path: String, type: String, key: String, shareWith: String? = null
+    ): Boolean {
+        val body = JSONObject().apply {
+            put("id", id)
+            put("label", label)
+            put("path", path)
+            put("type", type)
+            put("fsWatcherEnabled", true)
+            put("rescanIntervalS", 3600)
+            if (shareWith != null) {
+                // Preserve any devices already on the folder, then add this friend.
+                val devices = runCatching {
+                    getBody("/rest/config/folders/$id", key)?.let { JSONObject(it).optJSONArray("devices") }
+                }.getOrNull() ?: org.json.JSONArray()
+                val already = (0 until devices.length()).any { devices.getJSONObject(it).optString("deviceID") == shareWith }
+                if (!already) devices.put(JSONObject().put("deviceID", shareWith))
+                put("devices", devices)
+            }
+        }
+        return putJson("/rest/config/folders/$id", key, body)
+    }
+
+    /** Incoming friend requests: device IDs that tried to connect but aren't configured yet. */
+    suspend fun pendingFriendRequests(): List<String> = withContext(Dispatchers.IO) {
+        val key = readApiKey() ?: return@withContext emptyList()
+        val body = getBody("/rest/cluster/pending/devices", key) ?: return@withContext emptyList()
+        runCatching {
+            val obj = JSONObject(body)
+            obj.keys().asSequence().toList() // keys are the pending device IDs
+        }.getOrDefault(emptyList())
+    }
+
+    /** Remove a friend: drop the peer device and both isolated profile folders. */
+    suspend fun removeFriendPeer(friendDeviceId: String, myDeviceId: String): Boolean = withContext(Dispatchers.IO) {
+        val key = readApiKey() ?: return@withContext false
+        val fid = friendDeviceId.trim().uppercase()
+        deleteReq("/rest/config/folders/${profileFolderId(fid)}", key)
+        // Unshare my profile folder from this friend (rewrite its device list without them).
+        runCatching {
+            getBody("/rest/config/folders/${profileFolderId(myDeviceId)}", key)?.let { txt ->
+                val folder = JSONObject(txt)
+                val devices = folder.optJSONArray("devices") ?: org.json.JSONArray()
+                val kept = org.json.JSONArray()
+                for (i in 0 until devices.length()) {
+                    val d = devices.getJSONObject(i)
+                    if (d.optString("deviceID") != fid) kept.put(d)
+                }
+                folder.put("devices", kept)
+                putJson("/rest/config/folders/${profileFolderId(myDeviceId)}", key, folder)
+            }
+        }
+        deleteReq("/rest/config/devices/$fid", key)
+    }
+
+    /** Opt-out teardown: remove every friend device and every friendsync- folder so no data flows. */
+    suspend fun teardownFriends(): Boolean = withContext(Dispatchers.IO) {
+        val key = readApiKey() ?: return@withContext false
+        // Remove all friendsync- folders.
+        getBody("/rest/config/folders", key)?.let { arrText ->
+            runCatching {
+                val arr = org.json.JSONArray(arrText)
+                for (i in 0 until arr.length()) {
+                    val fid = arr.getJSONObject(i).optString("id")
+                    if (fid.startsWith(FRIEND_PREFIX)) deleteReq("/rest/config/folders/$fid", key)
+                }
+            }
+        }
+        // Remove all friend devices (named "eOr friend").
+        getBody("/rest/config/devices", key)?.let { arrText ->
+            runCatching {
+                val arr = org.json.JSONArray(arrText)
+                for (i in 0 until arr.length()) {
+                    val dev = arr.getJSONObject(i)
+                    if (dev.optString("name") == "eOr friend") deleteReq("/rest/config/devices/${dev.optString("deviceID")}", key)
+                }
+            }
+        }
+        true
+    }
+
     companion object {
         const val EOR_FOLDER_PREFIX = "eor-"
+        // Distinct from EOR_FOLDER_PREFIX and intentionally NOT starting with "eor-" so the Save Sync
+        // broadcast (shareEorFoldersWith) never shares friend folders and vice-versa.
+        val FRIEND_PREFIX = FriendFolders.PREFIX
         private const val TAG = "SyncthingController"
         private const val GUI_PORT = 8384
         private val APIKEY_RE = Regex("<apikey>(.*?)</apikey>")

--- a/app/src/main/java/com/gamelaunch/frontend/di/DatabaseModule.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/di/DatabaseModule.kt
@@ -2,8 +2,11 @@ package com.gamelaunch.frontend.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.gamelaunch.frontend.data.db.AppDatabase
 import com.gamelaunch.frontend.data.db.dao.EmulatorMappingDao
+import com.gamelaunch.frontend.data.db.dao.FriendDao
 import com.gamelaunch.frontend.data.db.dao.GameDao
 import com.gamelaunch.frontend.data.db.dao.GameMediaDao
 import com.gamelaunch.frontend.data.db.dao.LaunchBoxDao
@@ -18,10 +21,33 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
 
+    /**
+     * The `friends` table DDL, copied verbatim from FriendEntity's generated Room schema
+     * (app/schemas/.../3.json, `createSql` with `${'$'}{TABLE_NAME}` resolved). Keeping it identical to
+     * what Room expects is what makes [MIGRATION_2_3] pass Room's schema validation — guarded by a test.
+     */
+    const val FRIENDS_CREATE_SQL =
+        "CREATE TABLE IF NOT EXISTS `friends` (`device_id` TEXT NOT NULL, `display_name` TEXT NOT NULL, " +
+        "`status` TEXT NOT NULL, `last_played_title` TEXT, `last_played_platform` TEXT, " +
+        "`last_played_md5` TEXT, `last_played_at` INTEGER, `ra_username` TEXT, `ra_points` INTEGER, " +
+        "`ra_softcore_points` INTEGER, `added_at` INTEGER NOT NULL, `profile_updated_at` INTEGER, " +
+        "`last_synced_at` INTEGER, PRIMARY KEY(`device_id`))"
+
+    /**
+     * v2 → v3 adds the `friends` table for the P2P Friends feature. Explicit (non-destructive) so
+     * users keep their existing library, which the builder's destructive fallback would otherwise wipe.
+     */
+    val MIGRATION_2_3 = object : Migration(2, 3) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(FRIENDS_CREATE_SQL)
+        }
+    }
+
     @Provides
     @Singleton
     fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase =
         Room.databaseBuilder(context, AppDatabase::class.java, AppDatabase.DATABASE_NAME)
+            .addMigrations(MIGRATION_2_3)
             .fallbackToDestructiveMigration()
             .build()
 
@@ -36,4 +62,7 @@ object DatabaseModule {
 
     @Provides
     fun provideLaunchBoxDao(db: AppDatabase): LaunchBoxDao = db.launchBoxDao()
+
+    @Provides
+    fun provideFriendDao(db: AppDatabase): FriendDao = db.friendDao()
 }

--- a/app/src/main/java/com/gamelaunch/frontend/di/RepositoryModule.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/di/RepositoryModule.kt
@@ -1,12 +1,14 @@
 package com.gamelaunch.frontend.di
 
 import com.gamelaunch.frontend.data.repository.EmulatorRepositoryImpl
+import com.gamelaunch.frontend.data.repository.FriendRepositoryImpl
 import com.gamelaunch.frontend.data.repository.GameRepositoryImpl
 import com.gamelaunch.frontend.data.repository.MediaRepositoryImpl
 import com.gamelaunch.frontend.data.repository.RetroAchievementsRepositoryImpl
 import com.gamelaunch.frontend.data.repository.ScraperRepositoryImpl
 import com.gamelaunch.frontend.data.repository.SettingsRepositoryImpl
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
+import com.gamelaunch.frontend.domain.repository.FriendRepository
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
@@ -39,4 +41,7 @@ abstract class RepositoryModule {
 
     @Binds @Singleton
     abstract fun bindRetroAchievementsRepository(impl: RetroAchievementsRepositoryImpl): RetroAchievementsRepository
+
+    @Binds @Singleton
+    abstract fun bindFriendRepository(impl: FriendRepositoryImpl): FriendRepository
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/friends/Friend.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/friends/Friend.kt
@@ -1,0 +1,24 @@
+package com.gamelaunch.frontend.domain.friends
+
+enum class FriendStatus {
+    /** I added them; waiting for them to add me back. */
+    PENDING_OUT,
+    /** They added me; waiting for me to accept. */
+    PENDING_IN,
+    /** Both sides added each other — profiles sync. */
+    ACTIVE
+}
+
+/**
+ * A friend (or pending request). Profile fields are the last snapshot received over P2P sync and may
+ * be stale; [profileUpdatedAt] is the friend's own timestamp, [lastSyncedAt] is when we last read it.
+ */
+data class Friend(
+    val deviceId: String,
+    val displayName: String,
+    val status: FriendStatus,
+    val lastPlayed: LastPlayed?,
+    val ra: RaInfo?,
+    val profileUpdatedAt: Long?,
+    val lastSyncedAt: Long?
+)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/friends/FriendCode.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/friends/FriendCode.kt
@@ -1,0 +1,90 @@
+package com.gamelaunch.frontend.domain.friends
+
+/**
+ * Encodes/decodes a friend's identity as a shareable `eor://friend/<deviceId>?n=<name>` deep link,
+ * and validates raw Syncthing device ids. Pure string logic (no android.net.Uri) so it is unit-testable
+ * and safe to reuse in the deep-link handler. Adding a friend from a parsed link must always be
+ * user-confirmed — links can come from untrusted sources.
+ */
+object FriendCode {
+    const val SCHEME = "eor"
+    const val HOST = "friend"
+
+    data class Parsed(val deviceId: String, val displayName: String?)
+
+    /** Build a shareable link. Display name is optional context for the recipient's confirm dialog. */
+    fun buildLink(deviceId: String, displayName: String? = null): String {
+        val base = "$SCHEME://$HOST/${deviceId.trim().uppercase()}"
+        return if (displayName.isNullOrBlank()) base else "$base?n=${encodeName(displayName.trim())}"
+    }
+
+    /**
+     * Accepts either a full `eor://friend/<id>?n=<name>` link or a bare device id (e.g. pasted).
+     * Returns null if no valid device id is present.
+     */
+    fun parse(input: String): Parsed? {
+        val trimmed = input.trim()
+        if (trimmed.isEmpty()) return null
+        return if (trimmed.startsWith("$SCHEME://", ignoreCase = true)) parseLink(trimmed)
+        else normalizeDeviceId(trimmed)?.let { Parsed(it, null) }
+    }
+
+    fun isValidDeviceId(candidate: String): Boolean = normalizeDeviceId(candidate) != null
+
+    private fun parseLink(link: String): Parsed? {
+        // eor://friend/<id>[?n=<name>]
+        val afterScheme = link.substringAfter("://")
+        val host = afterScheme.substringBefore('/', "")
+        if (!host.equals(HOST, ignoreCase = true)) return null
+        val pathAndQuery = afterScheme.substringAfter('/', "")
+        val rawId = pathAndQuery.substringBefore('?')
+        val deviceId = normalizeDeviceId(rawId) ?: return null
+        val name = if ('?' in pathAndQuery) {
+            pathAndQuery.substringAfter('?').split('&')
+                .firstOrNull { it.startsWith("n=") }
+                ?.substringAfter("n=")
+                ?.let { decodeName(it) }
+                ?.takeIf { it.isNotBlank() }
+        } else null
+        return Parsed(deviceId, name)
+    }
+
+    /**
+     * A Syncthing device id is base32 (A–Z, 2–7) grouped by dashes with luhn check chars — 56 payload
+     * chars (63 with dashes). We normalize by upper-casing and validate the character set and length
+     * without re-deriving check digits (Syncthing does the strict check when the id is added).
+     */
+    private fun normalizeDeviceId(raw: String): String? {
+        val cleaned = raw.trim().uppercase()
+        if (cleaned.isEmpty()) return null
+        val stripped = cleaned.replace("-", "")
+        if (stripped.length !in 52..56) return null
+        if (!stripped.all { it in 'A'..'Z' || it in '2'..'7' }) return null
+        return cleaned
+    }
+
+    // Minimal, dependency-free percent-encoding for the display-name query value.
+    private fun encodeName(name: String): String = buildString {
+        for (b in name.toByteArray(Charsets.UTF_8)) {
+            val c = b.toInt() and 0xFF
+            if (c.toChar().isLetterOrDigit() || c.toChar() in "-_.~") append(c.toChar())
+            else append('%').append("%02X".format(c))
+        }
+    }
+
+    private fun decodeName(value: String): String {
+        val bytes = ArrayList<Byte>(value.length)
+        var i = 0
+        while (i < value.length) {
+            val ch = value[i]
+            when {
+                ch == '%' && i + 2 < value.length -> {
+                    bytes.add(value.substring(i + 1, i + 3).toInt(16).toByte()); i += 3
+                }
+                ch == '+' -> { bytes.add(' '.code.toByte()); i++ }
+                else -> { bytes.add(ch.code.toByte()); i++ }
+            }
+        }
+        return String(bytes.toByteArray(), Charsets.UTF_8)
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/friends/FriendFolders.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/friends/FriendFolders.kt
@@ -1,0 +1,20 @@
+package com.gamelaunch.frontend.domain.friends
+
+import java.security.MessageDigest
+
+/**
+ * Deterministic Syncthing folder ids for the Friends feature. Both devices in a friendship derive the
+ * same id for a given owner's profile folder purely from that owner's device id, so their send-only and
+ * receive-only folders line up and sync. Pure (no Android deps) to keep it unit-testable.
+ *
+ * [PREFIX] intentionally does NOT start with "eor-", so Save Sync's broadcast folder-sharing never
+ * touches friend folders and vice-versa.
+ */
+object FriendFolders {
+    const val PREFIX = "friendsync-"
+
+    fun profileFolderId(ownerDeviceId: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(ownerDeviceId.trim().uppercase().toByteArray())
+        return PREFIX + digest.joinToString("") { "%02x".format(it) }.take(16)
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/friends/FriendProfile.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/friends/FriendProfile.kt
@@ -1,0 +1,78 @@
+package com.gamelaunch.frontend.domain.friends
+
+import org.json.JSONObject
+
+/** The last game a user launched, as shared with friends. Uses portable identifiers, no local paths. */
+data class LastPlayed(
+    val title: String,
+    val platform: String,
+    val md5: String?,
+    val at: Long
+)
+
+/** A user's public RetroAchievements standing, as shared with friends. */
+data class RaInfo(
+    val username: String,
+    val points: Int,
+    val softcorePoints: Int
+)
+
+/**
+ * The small public snapshot each device writes to its send-only profile folder as `profile.json`
+ * and syncs to friends. Contains only user-authored / already-public data — never credentials,
+ * tokens, save files, or filesystem paths.
+ */
+data class FriendProfile(
+    val deviceId: String,
+    val displayName: String,
+    val lastPlayed: LastPlayed?,
+    val ra: RaInfo?,
+    val updatedAt: Long
+) {
+    fun encode(): String = JSONObject().apply {
+        put("v", VERSION)
+        put("deviceId", deviceId)
+        put("displayName", displayName)
+        lastPlayed?.let { lp ->
+            put("lastPlayed", JSONObject().apply {
+                put("title", lp.title)
+                put("platform", lp.platform)
+                lp.md5?.let { put("md5", it) }
+                put("at", lp.at)
+            })
+        }
+        ra?.let { r ->
+            put("ra", JSONObject().apply {
+                put("username", r.username)
+                put("points", r.points)
+                put("softcorePoints", r.softcorePoints)
+            })
+        }
+        put("updatedAt", updatedAt)
+    }.toString()
+
+    companion object {
+        const val VERSION = 1
+
+        /** Tolerant decode: returns null on malformed input or a missing required field. */
+        fun decode(json: String): FriendProfile? = runCatching {
+            val o = JSONObject(json)
+            val deviceId = o.optString("deviceId").takeIf { it.isNotBlank() } ?: return null
+            val displayName = o.optString("displayName").takeIf { it.isNotBlank() } ?: return null
+            val lastPlayed = o.optJSONObject("lastPlayed")?.let { lp ->
+                val title = lp.optString("title").takeIf { it.isNotBlank() } ?: return@let null
+                LastPlayed(
+                    title = title,
+                    platform = lp.optString("platform"),
+                    md5 = lp.optString("md5").takeIf { it.isNotBlank() },
+                    at = lp.optLong("at")
+                )
+            }
+            val ra = o.optJSONObject("ra")?.let { r ->
+                val username = r.optString("username").takeIf { it.isNotBlank() } ?: return@let null
+                RaInfo(username, r.optInt("points"), r.optInt("softcorePoints"))
+            }
+            FriendProfile(deviceId, displayName, lastPlayed, ra, o.optLong("updatedAt"))
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/friends/PendingFriendLink.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/friends/PendingFriendLink.kt
@@ -1,0 +1,19 @@
+package com.gamelaunch.frontend.domain.friends
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Holds a friend code parsed from an incoming `eor://friend/...` deep link until the UI can show a
+ * confirmation. Never auto-adds — the deep-link source is untrusted, so a user must explicitly accept.
+ */
+@Singleton
+class PendingFriendLink @Inject constructor() {
+    private val _pending = MutableStateFlow<FriendCode.Parsed?>(null)
+    val pending: StateFlow<FriendCode.Parsed?> = _pending
+
+    fun offer(parsed: FriendCode.Parsed) { _pending.value = parsed }
+    fun clear() { _pending.value = null }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/friends/RandomHandle.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/friends/RandomHandle.kt
@@ -1,0 +1,29 @@
+package com.gamelaunch.frontend.domain.friends
+
+import kotlin.random.Random
+
+/**
+ * Generates a friendly, retro-flavoured display name for users who don't set their own
+ * (e.g. "PixelFox-4821"). Purely local — no uniqueness guarantee is needed because the
+ * Syncthing device id disambiguates friends; the handle is only a human-readable label.
+ */
+object RandomHandle {
+
+    private val adjectives = listOf(
+        "Pixel", "Turbo", "Neon", "Retro", "Cosmic", "Arcade", "Blast", "Chrono", "Hyper", "Mega",
+        "Ultra", "Glitch", "Quantum", "Laser", "Astro", "Vapor", "Digital", "Rogue", "Shadow", "Golden",
+    )
+
+    private val nouns = listOf(
+        "Fox", "Raccoon", "Comet", "Ranger", "Wizard", "Ninja", "Falcon", "Goomba", "Dragon", "Knight",
+        "Otter", "Phoenix", "Samurai", "Racer", "Gamer", "Yeti", "Panda", "Robot", "Viper", "Wolf",
+    )
+
+    /** e.g. "NeonFalcon-3172". [random] is injectable for deterministic tests. */
+    fun generate(random: Random = Random.Default): String {
+        val adj = adjectives[random.nextInt(adjectives.size)]
+        val noun = nouns[random.nextInt(nouns.size)]
+        val number = random.nextInt(1000, 10000) // always 4 digits
+        return "$adj$noun-$number"
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/FriendRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/FriendRepository.kt
@@ -1,0 +1,51 @@
+package com.gamelaunch.frontend.domain.repository
+
+import com.gamelaunch.frontend.domain.friends.Friend
+import kotlinx.coroutines.flow.Flow
+
+/** Result of trying to add a friend from a code/link. */
+sealed interface AddFriendResult {
+    data class Requested(val displayName: String?) : AddFriendResult
+    object InvalidCode : AddFriendResult
+    object EngineUnavailable : AddFriendResult
+    object AlreadyFriend : AddFriendResult
+    object Self : AddFriendResult
+}
+
+/**
+ * The Friends feature's data + P2P orchestration boundary. All state is on-device; identity is the
+ * Syncthing device id. No accounts, no server.
+ */
+interface FriendRepository {
+    /** All friends and pending requests (ACTIVE + PENDING_*), reactive from the local DB. */
+    fun observeFriends(): Flow<List<Friend>>
+
+    /** True once the Friends feature is usable on this device (the sync engine is supported). */
+    fun engineSupported(): Boolean
+
+    /** My display name, generating and persisting a random one on first use if unset. */
+    suspend fun myDisplayName(): String
+    suspend fun setMyDisplayName(name: String)
+
+    /** My friend identity (Syncthing device id); null if the engine hasn't come up yet. */
+    suspend fun myDeviceId(): String?
+    /** Shareable eor:// link for my identity, or null if the engine isn't up. */
+    suspend fun myShareLink(): String?
+
+    /** Add a friend from a scanned/pasted/deep-linked code or link (mutual — they must add back). */
+    suspend fun addFriend(codeOrLink: String): AddFriendResult
+
+    /** Accept an incoming request (they added me); completes the friendship. */
+    suspend fun acceptRequest(deviceId: String)
+    suspend fun declineRequest(deviceId: String)
+    suspend fun removeFriend(deviceId: String)
+
+    /** Recompute and write my profile.json (last-played + RA), if the feature is enabled. */
+    suspend fun publishMyProfile()
+
+    /** Read friends' inbound profiles + incoming requests into the local DB. */
+    suspend fun refreshFriends()
+
+    /** Enable/disable the whole feature: (de)registers the profile folder and tears down sharing. */
+    suspend fun setEnabled(enabled: Boolean)
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -33,6 +33,10 @@ interface SettingsRepository {
     val raToken: Flow<String>
     val raPoints: Flow<Int>
     val raSoftcorePoints: Flow<Int>
+    val friendsEnabled: Flow<Boolean>
+    val friendDisplayName: Flow<String>
+    val friendShareLastPlayed: Flow<Boolean>
+    val friendShareRa: Flow<Boolean>
     val hiddenPlatforms: Flow<Set<String>>
     val excludedPaths: Flow<Set<String>>
 
@@ -71,4 +75,8 @@ interface SettingsRepository {
     suspend fun clearRaCredentials()
     suspend fun setPlatformHidden(platformId: String, hidden: Boolean)
     suspend fun addExcludedPath(romPath: String)
+    suspend fun setFriendsEnabled(enabled: Boolean)
+    suspend fun setFriendDisplayName(name: String)
+    suspend fun setFriendShareLastPlayed(enabled: Boolean)
+    suspend fun setFriendShareRa(enabled: Boolean)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchGameUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchGameUseCase.kt
@@ -1,18 +1,22 @@
 package com.gamelaunch.frontend.domain.usecase
 
 import com.gamelaunch.frontend.domain.model.Game
+import com.gamelaunch.frontend.domain.repository.FriendRepository
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.launcher.EmulatorLauncher
 import javax.inject.Inject
 
 class LaunchGameUseCase @Inject constructor(
     private val emulatorLauncher: EmulatorLauncher,
-    private val gameRepository: GameRepository
+    private val gameRepository: GameRepository,
+    private val friendRepository: FriendRepository
 ) {
     suspend operator fun invoke(game: Game): Result<Unit> {
         val result = emulatorLauncher.launch(game)
         if (result.isSuccess) {
             gameRepository.recordPlay(game.id)
+            // Refresh the profile we share with friends (no-op when Friends is disabled).
+            runCatching { friendRepository.publishMyProfile() }
         }
         return result
     }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/friends/FriendsScreen.kt
@@ -1,0 +1,196 @@
+package com.gamelaunch.frontend.ui.screen.friends
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import com.gamelaunch.frontend.domain.friends.Friend
+import com.gamelaunch.frontend.domain.model.raAvatarUrl
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+
+@Composable
+fun FriendsScreen(
+    onGoToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FriendsViewModel = hiltViewModel()
+) {
+    val ui by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) { viewModel.refresh() }
+
+    if (ui.active.isEmpty() && ui.incoming.isEmpty()) {
+        EmptyFriends(onGoToSettings, modifier)
+        return
+    }
+
+    LazyColumn(
+        modifier = modifier.padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 12.dp)
+    ) {
+        if (ui.incoming.isNotEmpty()) {
+            item {
+                Card(
+                    onClick = onGoToSettings,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(14.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+                ) {
+                    Text(
+                        "${ui.incoming.size} friend request${if (ui.incoming.size == 1) "" else "s"} — open Settings ▸ Friends to accept",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(14.dp)
+                    )
+                }
+            }
+        }
+        items(ui.active, key = { it.deviceId }) { friend -> FriendCard(friend) }
+    }
+}
+
+@Composable
+private fun FriendCard(friend: Friend) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Avatar: RA profile pic if available, else a generic badge.
+            if (friend.ra != null) {
+                AsyncImage(
+                    model = raAvatarUrl(friend.ra.username),
+                    contentDescription = null,
+                    modifier = Modifier.size(46.dp).clip(CircleShape)
+                )
+            } else {
+                Box(
+                    modifier = Modifier.size(46.dp).clip(CircleShape),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(Icons.Default.Group, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                }
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    friend.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.height(2.dp))
+                val lp = friend.lastPlayed
+                if (lp != null) {
+                    val platform = PlatformDefinitions.byId[lp.platform]?.displayName ?: lp.platform
+                    Text(
+                        "Playing ${lp.title}${if (platform.isNotBlank()) " · $platform" else ""}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                } else {
+                    Text(
+                        "No games played yet",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text(
+                    lastSeen(friend.profileUpdatedAt),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (friend.ra != null) {
+                Spacer(Modifier.width(10.dp))
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.EmojiEvents,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            "${friend.ra.points}",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Text("points", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyFriends(onGoToSettings: () -> Unit, modifier: Modifier) {
+    Box(modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(Icons.Default.Group, contentDescription = null, modifier = Modifier.size(48.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(12.dp))
+            Text("No friends yet", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Add friends from Settings ▸ Friends to see their last-played game and RetroAchievements score.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(16.dp))
+            Card(onClick = onGoToSettings, shape = RoundedCornerShape(12.dp)) {
+                Text("Open Settings", modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp))
+            }
+        }
+    }
+}
+
+/** Human-friendly "updated Xm ago" from a friend's own profile timestamp. */
+private fun lastSeen(updatedAt: Long?): String {
+    if (updatedAt == null || updatedAt <= 0) return "Not synced yet"
+    val mins = (System.currentTimeMillis() - updatedAt) / 60_000
+    return when {
+        mins < 1 -> "Updated just now"
+        mins < 60 -> "Updated ${mins}m ago"
+        mins < 1440 -> "Updated ${mins / 60}h ago"
+        else -> "Updated ${mins / 1440}d ago"
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/friends/FriendsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/friends/FriendsViewModel.kt
@@ -2,6 +2,7 @@ package com.gamelaunch.frontend.ui.screen.friends
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gamelaunch.frontend.data.friends.NearbyBeacon
 import com.gamelaunch.frontend.domain.friends.Friend
 import com.gamelaunch.frontend.domain.friends.FriendCode
 import com.gamelaunch.frontend.domain.friends.FriendStatus
@@ -26,7 +27,8 @@ import javax.inject.Inject
 class FriendsViewModel @Inject constructor(
     private val friendRepository: FriendRepository,
     private val settingsRepository: SettingsRepository,
-    private val pendingFriendLink: PendingFriendLink
+    private val pendingFriendLink: PendingFriendLink,
+    private val nearbyBeacon: NearbyBeacon
 ) : ViewModel() {
 
     data class UiState(
@@ -40,7 +42,9 @@ class FriendsViewModel @Inject constructor(
         val incoming: List<Friend> = emptyList(),
         val outgoing: List<Friend> = emptyList(),
         val status: String? = null,
-        val pendingLink: FriendCode.Parsed? = null
+        val pendingLink: FriendCode.Parsed? = null,
+        val scanningNearby: Boolean = false,
+        val nearby: List<NearbyBeacon.NearbyPeer> = emptyList()
     )
 
     private val _uiState = MutableStateFlow(UiState(engineSupported = friendRepository.engineSupported()))
@@ -71,6 +75,10 @@ class FriendsViewModel @Inject constructor(
 
         pendingFriendLink.pending
             .onEach { parsed -> _uiState.update { it.copy(pendingLink = parsed) } }
+            .launchIn(viewModelScope)
+
+        nearbyBeacon.peers
+            .onEach { peers -> _uiState.update { it.copy(nearby = peers) } }
             .launchIn(viewModelScope)
 
         viewModelScope.launch {
@@ -124,6 +132,30 @@ class FriendsViewModel @Inject constructor(
     fun removeFriend(deviceId: String) = viewModelScope.launch { friendRepository.removeFriend(deviceId) }
 
     fun refresh() = viewModelScope.launch { friendRepository.refreshFriends() }
+
+    /** Start broadcasting/listening on the LAN so nearby devices can be tapped to add. */
+    fun startNearby() {
+        if (_uiState.value.scanningNearby) return
+        viewModelScope.launch {
+            val id = friendRepository.myDeviceId() ?: return@launch
+            nearbyBeacon.start(id, friendRepository.myDisplayName())
+            _uiState.update { it.copy(scanningNearby = true) }
+        }
+    }
+
+    fun stopNearby() {
+        nearbyBeacon.stop()
+        _uiState.update { it.copy(scanningNearby = false, nearby = emptyList()) }
+    }
+
+    fun addNearby(peer: NearbyBeacon.NearbyPeer) {
+        addFriend(peer.deviceId)
+    }
+
+    override fun onCleared() {
+        nearbyBeacon.stop()
+        super.onCleared()
+    }
 
     fun confirmPendingLink() {
         val parsed = _uiState.value.pendingLink ?: return

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/friends/FriendsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/friends/FriendsViewModel.kt
@@ -1,0 +1,140 @@
+package com.gamelaunch.frontend.ui.screen.friends
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gamelaunch.frontend.domain.friends.Friend
+import com.gamelaunch.frontend.domain.friends.FriendCode
+import com.gamelaunch.frontend.domain.friends.FriendStatus
+import com.gamelaunch.frontend.domain.friends.PendingFriendLink
+import com.gamelaunch.frontend.domain.repository.AddFriendResult
+import com.gamelaunch.frontend.domain.repository.FriendRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FriendsViewModel @Inject constructor(
+    private val friendRepository: FriendRepository,
+    private val settingsRepository: SettingsRepository,
+    private val pendingFriendLink: PendingFriendLink
+) : ViewModel() {
+
+    data class UiState(
+        val enabled: Boolean = false,
+        val engineSupported: Boolean = true,
+        val engineStarting: Boolean = false,
+        val myDeviceId: String? = null,
+        val myShareLink: String? = null,
+        val displayName: String = "",
+        val active: List<Friend> = emptyList(),
+        val incoming: List<Friend> = emptyList(),
+        val outgoing: List<Friend> = emptyList(),
+        val status: String? = null,
+        val pendingLink: FriendCode.Parsed? = null
+    )
+
+    private val _uiState = MutableStateFlow(UiState(engineSupported = friendRepository.engineSupported()))
+    val uiState: StateFlow<UiState> = _uiState
+
+    private val friends: StateFlow<List<Friend>> =
+        friendRepository.observeFriends().stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    init {
+        // Reactive: friends list, enabled flag, display name.
+        combine(
+            friends,
+            settingsRepository.friendsEnabled,
+            settingsRepository.friendDisplayName
+        ) { list, enabled, name ->
+            Triple(list, enabled, name)
+        }.onEach { (list, enabled, name) ->
+            _uiState.update {
+                it.copy(
+                    enabled = enabled,
+                    displayName = name,
+                    active = list.filter { f -> f.status == FriendStatus.ACTIVE },
+                    incoming = list.filter { f -> f.status == FriendStatus.PENDING_IN },
+                    outgoing = list.filter { f -> f.status == FriendStatus.PENDING_OUT }
+                )
+            }
+        }.launchIn(viewModelScope)
+
+        pendingFriendLink.pending
+            .onEach { parsed -> _uiState.update { it.copy(pendingLink = parsed) } }
+            .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            if (settingsRepository.friendsEnabled.first() && friendRepository.engineSupported()) {
+                bringUpEngine()
+            }
+        }
+    }
+
+    private suspend fun bringUpEngine() {
+        _uiState.update { it.copy(engineStarting = true) }
+        val id = friendRepository.myDeviceId()
+        val link = friendRepository.myShareLink()
+        _uiState.update { it.copy(engineStarting = false, myDeviceId = id, myShareLink = link) }
+        friendRepository.publishMyProfile()
+        friendRepository.refreshFriends()
+    }
+
+    fun setEnabled(on: Boolean) {
+        _uiState.update { it.copy(status = null) }
+        viewModelScope.launch {
+            friendRepository.setEnabled(on)
+            if (on) bringUpEngine()
+            else _uiState.update { it.copy(myDeviceId = null, myShareLink = null) }
+        }
+    }
+
+    fun saveDisplayName(name: String) {
+        viewModelScope.launch {
+            friendRepository.setMyDisplayName(name)
+            _uiState.update { it.copy(myShareLink = friendRepository.myShareLink()) }
+        }
+    }
+
+    fun addFriend(codeOrLink: String) {
+        viewModelScope.launch {
+            val msg = when (val r = friendRepository.addFriend(codeOrLink)) {
+                is AddFriendResult.Requested ->
+                    "Request sent to ${r.displayName ?: "friend"} — you'll connect once they add you back."
+                AddFriendResult.InvalidCode -> "That doesn't look like a valid friend code."
+                AddFriendResult.EngineUnavailable -> "The connection engine isn't ready yet — try again in a moment."
+                AddFriendResult.AlreadyFriend -> "You're already friends with them."
+                AddFriendResult.Self -> "That's your own friend code."
+            }
+            _uiState.update { it.copy(status = msg) }
+        }
+    }
+
+    fun acceptRequest(deviceId: String) = viewModelScope.launch { friendRepository.acceptRequest(deviceId) }
+    fun declineRequest(deviceId: String) = viewModelScope.launch { friendRepository.declineRequest(deviceId) }
+    fun removeFriend(deviceId: String) = viewModelScope.launch { friendRepository.removeFriend(deviceId) }
+
+    fun refresh() = viewModelScope.launch { friendRepository.refreshFriends() }
+
+    fun confirmPendingLink() {
+        val parsed = _uiState.value.pendingLink ?: return
+        pendingFriendLink.clear()
+        addFriend(FriendCode.buildLink(parsed.deviceId, parsed.displayName))
+    }
+
+    fun dismissPendingLink() {
+        pendingFriendLink.clear()
+        _uiState.update { it.copy(pendingLink = null) }
+    }
+
+    fun clearStatus() = _uiState.update { it.copy(status = null) }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SportsEsports
@@ -235,6 +236,7 @@ fun HomeScreen(
             }
         }
         TopTab.RETROACHIEVEMENTS -> false
+        TopTab.FRIENDS -> false
     }
 
     // Hold a direction to keep moving: first press fires immediately, then after a short delay
@@ -382,6 +384,7 @@ fun HomeScreen(
 
                         // ══ RETROACHIEVEMENTS ════════════════════════════
                         TopTab.RETROACHIEVEMENTS -> false
+                        TopTab.FRIENDS -> false
                     }
                 }
         ) {
@@ -460,6 +463,7 @@ fun HomeScreen(
                             selected = state.topTab,
                             showRecentlyPlayed = state.showRecentlyPlayed,
                             showRetroAchievements = state.showRetroAchievements,
+                            showFriends = state.showFriends,
                             onSelect = { tab ->
                                 viewModel.selectTopTab(tab)
                                 if (tab == TopTab.APPS) appsViewModel.refresh()
@@ -543,6 +547,12 @@ fun HomeScreen(
                                 modifier             = Modifier.fillMaxSize()
                             )
 
+                        state.topTab == TopTab.FRIENDS ->
+                            com.gamelaunch.frontend.ui.screen.friends.FriendsScreen(
+                                onGoToSettings = onSettingsClick,
+                                modifier       = Modifier.fillMaxSize()
+                            )
+
                         else -> RetroAchievementsScreen(
                             onGoToSettings = onSettingsClick,
                             modifier       = Modifier.fillMaxSize()
@@ -574,7 +584,8 @@ private val tabSpecs = listOf(
     TabSpec(TopTab.GAMES, "Games", Icons.Default.SportsEsports),
     TabSpec(TopTab.RECENTLY_PLAYED, "Recent", Icons.Default.History),
     TabSpec(TopTab.APPS, "Apps", Icons.Default.Apps),
-    TabSpec(TopTab.RETROACHIEVEMENTS, "RetroAchievements", Icons.Default.EmojiEvents)
+    TabSpec(TopTab.RETROACHIEVEMENTS, "RetroAchievements", Icons.Default.EmojiEvents),
+    TabSpec(TopTab.FRIENDS, "Friends", Icons.Default.Group)
 )
 
 @Composable
@@ -582,12 +593,14 @@ private fun ModeTabBar(
     selected: TopTab,
     showRecentlyPlayed: Boolean,
     showRetroAchievements: Boolean,
+    showFriends: Boolean,
     onSelect: (TopTab) -> Unit
 ) {
     val pill = RoundedCornerShape(50)
     val tabs = tabSpecs.filter {
         (it.tab != TopTab.RECENTLY_PLAYED  || showRecentlyPlayed) &&
-        (it.tab != TopTab.RETROACHIEVEMENTS || showRetroAchievements)
+        (it.tab != TopTab.RETROACHIEVEMENTS || showRetroAchievements) &&
+        (it.tab != TopTab.FRIENDS || showFriends)
     }
     val darkMode = LocalDarkMode.current
     val unselectedTint = if (darkMode) IceWhite.copy(alpha = 0.8f) else TileText.copy(alpha = 0.8f)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
 
-enum class TopTab { GAMES, RECENTLY_PLAYED, APPS, RETROACHIEVEMENTS }
+enum class TopTab { GAMES, RECENTLY_PLAYED, APPS, RETROACHIEVEMENTS, FRIENDS }
 
 data class HomeUiState(
     val topTab: TopTab = TopTab.GAMES,
@@ -41,6 +41,7 @@ data class HomeUiState(
     val selectedPlatform: String? = null,
     val showRecentlyPlayed: Boolean = true,
     val showRetroAchievements: Boolean = true,
+    val showFriends: Boolean = false,
     val recentlyPlayed: List<Game> = emptyList(),
     val games: List<Game> = emptyList(),
     val gameSort: GameSort = GameSort.DEFAULT,
@@ -259,6 +260,14 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }.collect { }
+        }
+        viewModelScope.launch {
+            settingsRepository.friendsEnabled.collect { on ->
+                _uiState.update {
+                    val fallback = if (!on && it.topTab == TopTab.FRIENDS) TopTab.GAMES else it.topTab
+                    it.copy(showFriends = on, topTab = fallback)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SaveSyncViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SaveSyncViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.data.sync.ConflictFile
 import com.gamelaunch.frontend.data.sync.RunConditions
 import com.gamelaunch.frontend.data.sync.SaveFilesManager
+import com.gamelaunch.frontend.data.sync.SyncEngineManager
 import com.gamelaunch.frontend.data.sync.SyncthingController
 import com.gamelaunch.frontend.data.sync.SyncthingService
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
@@ -37,6 +38,7 @@ class SaveSyncViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val syncthingController: SyncthingController,
     private val saveFilesManager: SaveFilesManager,
+    private val syncEngineManager: SyncEngineManager,
     private val runConditions: RunConditions
 ) : ViewModel() {
 
@@ -140,7 +142,7 @@ class SaveSyncViewModel @Inject constructor(
             return
         }
         _uiState.update { it.copy(engineStarting = true, engineError = null) }
-        SyncthingService.start(context)
+        syncEngineManager.ensureRunning()
         viewModelScope.launch {
             val id = syncthingController.awaitDeviceId()
             if (id == null) {
@@ -170,7 +172,8 @@ class SaveSyncViewModel @Inject constructor(
     }
 
     private fun stopEngine() {
-        SyncthingService.stop(context)
+        // Only actually stops the daemon if Friends isn't using it too.
+        viewModelScope.launch { syncEngineManager.refresh() }
         _uiState.update { it.copy(engineRunning = false, engineStarting = false, deviceId = null) }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.gamelaunch.frontend.ui.screen.settings
 
+import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -31,7 +32,12 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.EmojiEvents
+import com.gamelaunch.frontend.domain.friends.Friend
+import com.gamelaunch.frontend.domain.friends.FriendStatus
+import com.gamelaunch.frontend.ui.screen.friends.FriendsViewModel
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.PermMedia
 import androidx.compose.material.icons.filled.Tune
@@ -107,7 +113,8 @@ private enum class SettingsTab(val label: String, val icon: ImageVector) {
     MEDIA("Media", Icons.Default.PermMedia),
     GAMES("Games", Icons.Default.VideogameAsset),
     RETRO_ACHIEVEMENTS("RetroAchievements", Icons.Default.EmojiEvents),
-    SAVE_SYNC("Save Sync", Icons.Default.Sync)
+    SAVE_SYNC("Save Sync", Icons.Default.Sync),
+    FRIENDS("Friends", Icons.Default.Group)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -160,11 +167,18 @@ fun SettingsScreen(
         uri?.let { viewModel.importBackgroundImage(it) }
     }
 
+    // The Friends tab only exists while the feature is enabled (opt-out fully hides it).
+    val visibleTabs = SettingsTab.entries.filter { it != SettingsTab.FRIENDS || state.friendsEnabled }
+
+    // If Friends was turned off while its tab was open, fall back to General.
+    LaunchedEffect(state.friendsEnabled) {
+        if (!state.friendsEnabled && selectedTab == SettingsTab.FRIENDS) selectedTab = SettingsTab.GENERAL
+    }
+
     // L1 / R1 cycle between tabs (with wraparound), mirroring the home screen.
     fun cycleTab(delta: Int) {
-        val entries = SettingsTab.entries
-        val cur = entries.indexOf(selectedTab)
-        selectedTab = entries[(cur + delta + entries.size) % entries.size]
+        val cur = visibleTabs.indexOf(selectedTab).coerceAtLeast(0)
+        selectedTab = visibleTabs[(cur + delta + visibleTabs.size) % visibleTabs.size]
     }
 
     val tabFocusRequester = remember { FocusRequester() }
@@ -260,7 +274,7 @@ fun SettingsScreen(
     ) { paddingValues ->
         Column(Modifier.fillMaxSize().padding(paddingValues)) {
 
-            SettingsTabBar(selected = selectedTab, onSelect = { selectedTab = it })
+            SettingsTabBar(tabs = visibleTabs, selected = selectedTab, onSelect = { selectedTab = it })
 
             // Fresh scroll state per tab so switching tabs starts at the top.
             key(selectedTab) {
@@ -288,6 +302,8 @@ fun SettingsScreen(
                                     )
                                 }
                             )
+                            Spacer(Modifier.height(4.dp))
+                            FriendsToggleSection(state, viewModel)
                         }
                         SettingsTab.MEDIA -> {
                             MediaStorageSection(
@@ -326,6 +342,7 @@ fun SettingsScreen(
                         }
                         SettingsTab.RETRO_ACHIEVEMENTS -> RetroAchievementsSection(state, viewModel)
                         SettingsTab.SAVE_SYNC -> SaveSyncSection()
+                        SettingsTab.FRIENDS -> FriendsSettingsSection()
                     }
                     Spacer(Modifier.height(24.dp))
                 }
@@ -337,7 +354,7 @@ fun SettingsScreen(
 }
 
 @Composable
-private fun SettingsTabBar(selected: SettingsTab, onSelect: (SettingsTab) -> Unit) {
+private fun SettingsTabBar(tabs: List<SettingsTab>, selected: SettingsTab, onSelect: (SettingsTab) -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -346,7 +363,7 @@ private fun SettingsTabBar(selected: SettingsTab, onSelect: (SettingsTab) -> Uni
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        SettingsTab.entries.forEach { tab ->
+        tabs.forEach { tab ->
             val isSel = tab == selected
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -1636,5 +1653,173 @@ private fun LoadingStatusRow(text: String, color: Color) {
         )
         Spacer(Modifier.width(6.dp))
         Text(text, style = MaterialTheme.typography.labelSmall, color = color)
+    }
+}
+
+// ── Section: Friends ──────────────────────────────────────────────────────
+
+/** The master opt-in/out toggle, shown in the General tab so it's always reachable. */
+@Composable
+private fun FriendsToggleSection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    SettingsSectionHeader("Friends")
+    SettingsCard {
+        Text(
+            "See a friend's last-played game and RetroAchievements score. Peer-to-peer — no account, " +
+                "nothing stored online. Turning this off hides the feature everywhere and stops all sharing.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        CardSwitchRow("Enable Friends", state.friendsEnabled, viewModel::setFriendsEnabled)
+    }
+}
+
+/** Pairing + friends-management, shown as its own Settings tab (only while Friends is enabled). */
+@Composable
+private fun FriendsSettingsSection() {
+    val vm: FriendsViewModel = hiltViewModel()
+    val ui by vm.uiState.collectAsState()
+    val context = LocalContext.current
+    var codeInput by rememberSaveable { mutableStateOf("") }
+
+    if (!ui.engineSupported) {
+        SettingsSectionHeader("Friends")
+        SettingsCard { Text("Friends needs the sync engine, which isn't available on this device.") }
+        return
+    }
+
+    // Incoming deep-link confirmation (adding from an eor:// link always needs explicit confirm).
+    ui.pendingLink?.let { parsed ->
+        SettingsSectionHeader("Friend request")
+        SettingsCard {
+            Text("Add ${parsed.displayName ?: parsed.deviceId.take(12) + "…"} as a friend?")
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                GradientFillButton("Add", onClick = { vm.confirmPendingLink() }, modifier = Modifier.weight(1f))
+                GradientOutlineButton("Dismiss", onClick = { vm.dismissPendingLink() }, modifier = Modifier.weight(1f))
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+    }
+
+    // My code card
+    SettingsSectionHeader("My friend code")
+    SettingsCard {
+        var nameInput by rememberSaveable(ui.displayName) { mutableStateOf(ui.displayName) }
+        OutlinedTextField(
+            value = nameInput,
+            onValueChange = { nameInput = it },
+            label = { Text("Display name") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(6.dp))
+        GradientOutlineButton(
+            "Save name",
+            onClick = { vm.saveDisplayName(nameInput) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(10.dp))
+        when {
+            ui.engineStarting -> LoadingStatusRow("Starting the connection engine…", MaterialTheme.colorScheme.onSurfaceVariant)
+            ui.myShareLink != null -> {
+                Text(
+                    "Share this code with a friend. They add you, you add them back — then you're connected.",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                GradientFillButton(
+                    "Share my friend code",
+                    onClick = {
+                        val send = Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, "Add me on eOr: ${ui.myShareLink}")
+                        }
+                        context.startActivity(Intent.createChooser(send, "Share friend code"))
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            else -> Text("Bringing the engine up…", style = MaterialTheme.typography.labelSmall)
+        }
+    }
+
+    Spacer(Modifier.height(12.dp))
+
+    // Add a friend
+    SettingsSectionHeader("Add a friend")
+    SettingsCard {
+        OutlinedTextField(
+            value = codeInput,
+            onValueChange = { codeInput = it },
+            label = { Text("Paste a friend code or link") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(6.dp))
+        GradientFillButton(
+            "Add friend",
+            onClick = { vm.addFriend(codeInput); codeInput = "" },
+            enabled = codeInput.isNotBlank(),
+            modifier = Modifier.fillMaxWidth()
+        )
+        ui.status?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+
+    // Incoming requests
+    if (ui.incoming.isNotEmpty()) {
+        Spacer(Modifier.height(12.dp))
+        SettingsSectionHeader("Friend requests")
+        SettingsCard {
+            ui.incoming.forEachIndexed { i, f ->
+                if (i > 0) CardDivider()
+                Row(
+                    Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(f.displayName, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        GradientFillButton("Accept", onClick = { vm.acceptRequest(f.deviceId) })
+                        GradientOutlineButton("Decline", onClick = { vm.declineRequest(f.deviceId) })
+                    }
+                }
+            }
+        }
+    }
+
+    // My friends
+    Spacer(Modifier.height(12.dp))
+    SettingsSectionHeader("My friends")
+    SettingsCard {
+        val all = ui.active + ui.outgoing
+        if (all.isEmpty()) {
+            Text("No friends yet. Share your code to get started.", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        } else {
+            all.forEachIndexed { i, f ->
+                if (i > 0) CardDivider()
+                Row(
+                    Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(f.displayName, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            if (f.status == FriendStatus.PENDING_OUT) "Waiting for them to add you back" else "Connected",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    GradientOutlineButton("Remove", onClick = { vm.removeFriend(f.deviceId) })
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        GradientOutlineButton("Refresh", onClick = { vm.refresh() }, modifier = Modifier.fillMaxWidth())
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -1767,6 +1768,44 @@ private fun FriendsSettingsSection() {
         ui.status?.let {
             Spacer(Modifier.height(8.dp))
             Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+
+    Spacer(Modifier.height(12.dp))
+
+    // Add nearby (same Wi-Fi) — stop the beacon when this section leaves the screen.
+    DisposableEffect(Unit) { onDispose { vm.stopNearby() } }
+    SettingsSectionHeader("Add nearby")
+    SettingsCard {
+        Text(
+            "On the same Wi-Fi? Both of you open this, then tap each other to connect — no code needed.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        if (!ui.scanningNearby) {
+            GradientFillButton("Find nearby friends", onClick = { vm.startNearby() }, modifier = Modifier.fillMaxWidth())
+        } else {
+            GradientOutlineButton("Stop searching", onClick = { vm.stopNearby() }, modifier = Modifier.fillMaxWidth())
+            Spacer(Modifier.height(8.dp))
+            if (ui.nearby.isEmpty()) {
+                LoadingStatusRow("Searching for nearby players…", MaterialTheme.colorScheme.onSurfaceVariant)
+            } else {
+                ui.nearby.forEachIndexed { i, peer ->
+                    if (i > 0) CardDivider()
+                    Row(
+                        Modifier.fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable { vm.addNearby(peer) }
+                            .padding(vertical = 8.dp, horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(peer.displayName, style = MaterialTheme.typography.bodyMedium)
+                        Text("Tap to add", style = MaterialTheme.typography.labelSmall, color = ElectricBlue)
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -59,6 +59,7 @@ data class SettingsUiState(
     val esdeImportStatus: EsdeImportStatus? = null,
     val showRecentlyPlayed: Boolean = true,
     val showRetroAchievements: Boolean = true,
+    val friendsEnabled: Boolean = false,
     val darkMode: Boolean = false,
     val backgroundImageEnabled: Boolean = false,
     val backgroundImagePath: String = "",
@@ -83,6 +84,7 @@ class SettingsViewModel @Inject constructor(
     private val convertBackgroundImageUseCase: ConvertBackgroundImageUseCase,
     private val raRepository: RetroAchievementsRepository,
     private val gameRepository: GameRepository,
+    private val friendRepository: com.gamelaunch.frontend.domain.repository.FriendRepository,
     private val launchBoxDao: LaunchBoxDao
 ) : ViewModel() {
 
@@ -159,6 +161,11 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.friendsEnabled.collect { on ->
+                _uiState.update { it.copy(friendsEnabled = on) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.darkMode.collect { dark ->
                 _uiState.update { it.copy(darkMode = dark) }
             }
@@ -223,6 +230,12 @@ class SettingsViewModel @Inject constructor(
 
     fun setShowRetroAchievements(enabled: Boolean) {
         viewModelScope.launch { settingsRepository.setShowRetroAchievements(enabled) }
+    }
+
+    /** Master opt-in/out for the Friends feature; routes through the repo so the P2P engine and
+     *  profile sharing are brought up or fully torn down. */
+    fun setFriendsEnabled(enabled: Boolean) {
+        viewModelScope.launch { friendRepository.setEnabled(enabled) }
     }
 
     fun setDarkMode(enabled: Boolean) {

--- a/app/src/test/java/com/gamelaunch/frontend/FriendCodeTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/FriendCodeTest.kt
@@ -1,0 +1,52 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.domain.friends.FriendCode
+import com.gamelaunch.frontend.domain.friends.FriendFolders
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FriendCodeTest {
+
+    // A plausible 56-char base32 Syncthing id (8 groups of 7; alphabet A–Z and 2–7 only).
+    private val id = "ABCDEFG-HIJKLMN-OPQRSTU-VWXYZ23-4567ABC-DEFGHIJ-KLMNOPQ-RSTUVWX"
+
+    @Test fun `build then parse link recovers id and name`() {
+        val link = FriendCode.buildLink(id, "Neon Falcon")
+        val parsed = FriendCode.parse(link)!!
+        assertEquals(id.uppercase(), parsed.deviceId)
+        assertEquals("Neon Falcon", parsed.displayName)
+    }
+
+    @Test fun `link without name parses with null name`() {
+        val parsed = FriendCode.parse(FriendCode.buildLink(id))!!
+        assertEquals(id.uppercase(), parsed.deviceId)
+        assertNull(parsed.displayName)
+    }
+
+    @Test fun `bare pasted id parses`() {
+        val parsed = FriendCode.parse("  ${id.lowercase()}  ")!!
+        assertEquals(id.uppercase(), parsed.deviceId)
+    }
+
+    @Test fun `garbage and wrong host reject`() {
+        assertNull(FriendCode.parse(""))
+        assertNull(FriendCode.parse("hello world"))
+        assertNull(FriendCode.parse("eor://save/$id"))          // wrong host
+        assertNull(FriendCode.parse("eor://friend/tooshort"))   // invalid id
+    }
+
+    @Test fun `name with special chars survives encode-decode`() {
+        val parsed = FriendCode.parse(FriendCode.buildLink(id, "A&B=C ?x"))!!
+        assertEquals("A&B=C ?x", parsed.displayName)
+    }
+
+    @Test fun `profile folder id is deterministic and owner-specific`() {
+        val a = FriendFolders.profileFolderId(id)
+        assertEquals(a, FriendFolders.profileFolderId(id.lowercase())) // case-insensitive
+        assertTrue(a.startsWith(FriendFolders.PREFIX))
+        assertNotEquals(a, FriendFolders.profileFolderId(id.dropLast(1) + "G"))
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/FriendProfileTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/FriendProfileTest.kt
@@ -1,0 +1,42 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.domain.friends.FriendProfile
+import com.gamelaunch.frontend.domain.friends.LastPlayed
+import com.gamelaunch.frontend.domain.friends.RaInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FriendProfileTest {
+
+    @Test fun `full profile round-trips`() {
+        val p = FriendProfile(
+            deviceId = "ABC-123",
+            displayName = "NeonFalcon-3172",
+            lastPlayed = LastPlayed("Chrono Trigger", "snes", "abcd1234", 1_690_000_000_000L),
+            ra = RaInfo("kev", 4200, 55),
+            updatedAt = 1_690_000_100_000L
+        )
+        assertEquals(p, FriendProfile.decode(p.encode()))
+    }
+
+    @Test fun `profile without RA or last-played round-trips`() {
+        val p = FriendProfile("ID", "PixelOtter-9001", lastPlayed = null, ra = null, updatedAt = 5L)
+        val decoded = FriendProfile.decode(p.encode())
+        assertEquals(p, decoded)
+        assertNull(decoded!!.ra)
+        assertNull(decoded.lastPlayed)
+    }
+
+    @Test fun `md5 omitted when null`() {
+        val p = FriendProfile("ID", "Name", LastPlayed("Tetris", "gb", null, 1L), null, 2L)
+        val decoded = FriendProfile.decode(p.encode())!!
+        assertNull(decoded.lastPlayed!!.md5)
+    }
+
+    @Test fun `malformed json decodes to null`() {
+        assertNull(FriendProfile.decode("not json"))
+        assertNull(FriendProfile.decode("{}"))                       // missing required fields
+        assertNull(FriendProfile.decode("""{"deviceId":"x"}"""))     // missing displayName
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/FriendsMigrationSchemaTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/FriendsMigrationSchemaTest.kt
@@ -1,0 +1,39 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.di.DatabaseModule
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+/**
+ * Guards MIGRATION_2_3 against drift from FriendEntity. The v3 schema JSON is frozen, so the DDL the
+ * migration runs must stay byte-identical to what Room expects — otherwise Room's schema validation
+ * fails at runtime (or the destructive fallback silently wipes the user's library). If FriendEntity
+ * changes, that's a new schema version + migration, not an edit to v3.
+ *
+ * Reads the generated schema as raw text (Android's org.json is a non-functional stub in JVM unit
+ * tests, so we can't parse it as JSON here). The full on-device migration is covered by the
+ * MigrationTestHelper androidTest.
+ */
+class FriendsMigrationSchemaTest {
+
+    @Test fun `migration DDL matches frozen v3 schema`() {
+        val schemaText = findSchemaText(3)
+        // Pull every "createSql": "..." value, then pick the one for the friends table (unique col).
+        val createSqls = Regex("\"createSql\":\\s*\"((?:[^\"\\\\]|\\\\.)*)\"")
+            .findAll(schemaText).map { it.groupValues[1] }.toList()
+        val friendsSql = createSqls.single { it.contains("device_id") }
+            .replace("\\u0060", "`") // some Room versions unicode-escape backticks in the JSON
+            .replace("\${TABLE_NAME}", "friends")
+        assertEquals(friendsSql, DatabaseModule.FRIENDS_CREATE_SQL)
+    }
+
+    private fun findSchemaText(version: Int): String {
+        // Unit tests may run with the working dir at the module or repo root; try both.
+        val root = listOf("schemas", "app/schemas").map { File(it) }.firstOrNull { it.isDirectory }
+            ?: error("schema dir not found from ${File(".").absolutePath}")
+        val json = root.walkTopDown().firstOrNull { it.name == "$version.json" }
+            ?: error("$version.json not found under ${root.absolutePath}")
+        return json.readText()
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/RandomHandleTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/RandomHandleTest.kt
@@ -1,0 +1,31 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.domain.friends.RandomHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class RandomHandleTest {
+
+    private val format = Regex("^[A-Za-z]+-\\d{4}$")
+
+    @Test fun `handle matches Adjective+Noun-NNNN format`() {
+        repeat(200) {
+            val handle = RandomHandle.generate()
+            assertTrue("bad handle: $handle", format.matches(handle))
+        }
+    }
+
+    @Test fun `same seed is deterministic`() {
+        assertEquals(RandomHandle.generate(Random(7)), RandomHandle.generate(Random(7)))
+    }
+
+    @Test fun `number is always four digits`() {
+        repeat(200) {
+            val number = RandomHandle.generate().substringAfterLast('-')
+            assertEquals(4, number.length)
+            assertTrue(number.all { it.isDigit() })
+        }
+    }
+}


### PR DESCRIPTION
## What

A **serverless, on-device Friends feature**: see a friend's last-played game and RetroAchievements score. No accounts, no login, no user database, nothing stored online. Identity is the device's **Syncthing id** (the same engine Save Sync already bundles); a tiny `profile.json` syncs peer-to-peer to accepted friends only.

Built to the spec agreed up front: on-device only, no server, optional/auto-assigned username, camera-free adding (most handhelds have no camera), and a one-tap complete opt-out.

## How you add a friend (camera-free)
- **Share a link** — `eor://friend/<id>` via the Android share sheet; the friend taps it (→ confirm) or pastes the code.
- **Add nearby** — on the same Wi-Fi, both open the screen and tap each other (UDP LAN discovery, no code).
- Nintendo-style **request/accept**: adds are mutual; deep-link adds always require explicit confirmation (never silent).

## Safety / privacy (enforced in code)
- Friend peers use a distinct `friendsync-` folder prefix (never `eor-`), `introducer:false`, `autoAcceptFolders:false`, and explicit per-friend device lists — **your game saves are never shared with friends** and the friend graph isn't leaked. Fully isolated from Save Sync.
- Only user-authored/already-public data leaves the device (display name, last-played title/platform/md5, public RA username+score). No credentials, tokens, saves, or paths.
- `SyncEngineManager` centralizes the daemon so Save Sync and Friends coexist (runs if either is on; neither stops it unilaterally).

## Data
- New `friends` Room table + `FriendDao`; **AppDatabase v2→v3 with an explicit `MIGRATION_2_3`** (guarded by a test) so existing libraries are **not** wiped by the destructive fallback.
- `friends_enabled` / display name / share toggles in DataStore. `RandomHandle` assigns a name when unset.

## UI
- **General settings** master toggle fully hides the feature (Home tab + Settings tab) and tears down all sharing when off.
- **Settings → Friends**: my code/share, add (paste + nearby), incoming requests, friends list.
- **Home → Friends** tab: friend cards with last-played game + RA score.

## Tests
Profile JSON round-trip, `eor://` parse, folder-id determinism, `RandomHandle`, and a migration-schema guard — green alongside the existing suite.

## Verified on a Retroid Pocket 4 Pro
Enable → engine up → device id + share link + auto handle; deep-link `eor://friend/...` shows a user-confirmed add card; **library preserved across the migration**; opt-out hides everything; nearby scanning starts/stops with no socket or permission errors.

## Not covered here (needs two devices)
The actual cross-device exchange — a friend's profile appearing on the *other* device and the request→accept handshake completing — is untested with a single device; it depends on the Syncthing `pending-devices` behavior flagged as a spike. Everything up to the sync boundary is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)