### PR TITLE
Alot of stuff

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanAndroidGamesUseCase.kt
@@ -93,10 +93,11 @@ class ScanAndroidGamesUseCase @Inject constructor(
         }
 
         // Remove android-platform games whose packages are no longer installed.
-        if (validPaths.isEmpty()) {
+        val installedPaths = packageManagerHelper.getInstalledApps().map { "package:${it.packageName}" }
+        if (installedPaths.isEmpty()) {
             gameRepository.deleteAllAndroidGames()
         } else {
-            gameRepository.deleteAndroidGamesNotIn(validPaths)
+            gameRepository.deleteAndroidGamesNotIn(installedPaths)
         }
 
         emit(ScanProgress(packages.size, packages.size, added = added))

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScrapeGameUseCase.kt
@@ -28,6 +28,63 @@ class ScrapeGameUseCase @Inject constructor(
         val platform = PlatformDefinitions.byId[game.platformId]
             ?: return ScrapeResult.Error(game.id, IllegalArgumentException("Unknown platform: ${game.platformId}"))
 
+        // ── Play Store Scraper for Android Platform ──
+        if (game.platformId == "android") {
+            val pkg = game.romFilename
+            val url = "https://play.google.com/store/apps/details?id=$pkg"
+            val result = runCatching {
+                val httpClient = okhttp3.OkHttpClient()
+                val request = okhttp3.Request.Builder()
+                    .url(url)
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                    .build()
+                httpClient.newCall(request).execute().use { resp ->
+                    if (!resp.isSuccessful) return@runCatching null
+                    val html = resp.body?.string() ?: return@runCatching null
+
+                    val titleRegex = """<meta\s+property="og:title"\s+content="([^"]+)"""".toRegex(RegexOption.IGNORE_CASE)
+                    val descRegex = """<meta\s+property="og:description"\s+content="([^"]+)"""".toRegex(RegexOption.IGNORE_CASE)
+                    val imageRegex = """<meta\s+property="og:image"\s+content="([^"]+)"""".toRegex(RegexOption.IGNORE_CASE)
+
+                    val scrapedTitle = titleRegex.find(html)?.groupValues?.get(1)?.substringBefore(" - Apps on Google Play") ?: game.title
+                    val scrapedDesc = descRegex.find(html)?.groupValues?.get(1)
+                    val scrapedImageUrl = imageRegex.find(html)?.groupValues?.get(1)
+
+                    Triple(scrapedTitle, scrapedDesc, scrapedImageUrl)
+                }
+            }.getOrNull()
+
+            if (result != null) {
+                val (scrapedTitle, scrapedDesc, scrapedImageUrl) = result
+                if (config.scrapeMetadata) {
+                    gameRepository.updateScrapedMetadata(
+                        gameId        = game.id,
+                        scraperGameId = null,
+                        title         = scrapedTitle,
+                        description   = scrapedDesc,
+                        genre         = "Android Game",
+                        releaseYear   = null,
+                        rating        = null
+                    )
+                } else {
+                    gameRepository.markScraped(game.id, game.title)
+                }
+
+                if (scrapedImageUrl != null) {
+                    val media = GameMedia(
+                        gameId             = game.id,
+                        boxArtRemoteUrl    = scrapedImageUrl,
+                        scraperTimestampMs = System.currentTimeMillis()
+                    )
+                    mediaRepository.upsertMedia(media)
+                    runCatching { mediaRepository.downloadAndCacheBoxArt(game.id, scrapedImageUrl) }
+                }
+                return ScrapeResult.Success(game.id, if (config.scrapeMetadata) scrapedTitle else game.title)
+            } else {
+                return ScrapeResult.NotFound(game.id, game.romFilename)
+            }
+        }
+
         // ── ScreenScraper (default/preferred — requires user to have a free SS account) ──
         // Dev credentials (devid/devpassword) are compiled in from local.properties.
         // User credentials (ssid/sspassword) must be set in Settings.

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
@@ -61,7 +61,17 @@ class PackageManagerHelper @Inject constructor(
         "com.gamenative.android"              to "GameNative",
         "com.saber.gamehub"                  to "GameHub",
         // Other
-        "ru.playsoftware.j2meloader"         to "J2ME Loader"
+        "ru.playsoftware.j2meloader"         to "J2ME Loader",
+        // Frontends & Launchers
+        "org.es_de.frontend"                 to "ES-DE (Frontend)",
+        "com.magneticchen.daijishou"         to "Daijishō (Frontend)",
+        "org.pegasus_frontend.pegasus"       to "Pegasus (Frontend)",
+        "org.pegasus_frontend.Pegasus"       to "Pegasus (Frontend)",
+        "com.digdroid.alman.dig"             to "Dig (Frontend)",
+        "com.retrogamer.resetcollection"     to "Reset Collection (Frontend)",
+        "com.unbrokensoftware.launchbox"     to "LaunchBox (Frontend)",
+        "com.lucasfeis.beacon"               to "Beacon (Frontend)",
+        "com.k2.consolelauncher"             to "Console Launcher (Frontend)"
     )
 
     /** Packages eOr treats as emulators/launchers — excluded from the Android games scan. */

--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
@@ -1,5 +1,6 @@
 package com.gamelaunch.frontend.ui.component
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,8 +12,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.graphics.drawable.toBitmap
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import java.io.File
@@ -23,7 +26,8 @@ fun AsyncGameArtwork(
     remoteUrl: String?,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    contentScale: ContentScale = ContentScale.Crop
+    contentScale: ContentScale = ContentScale.Crop,
+    packageName: String? = null
 ) {
     // Prefer a local file that actually exists; fall back to remote URL
     val data = remember(localPath, remoteUrl) {
@@ -65,17 +69,44 @@ fun AsyncGameArtwork(
             )
         },
         error = {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    Icons.Default.SportsEsports,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            val context = LocalContext.current
+            val appIconBitmap = remember(packageName) {
+                if (packageName != null) {
+                    runCatching {
+                        context.packageManager.getApplicationIcon(packageName)
+                            .toBitmap(width = 144, height = 144)
+                            .asImageBitmap()
+                    }.getOrNull()
+                } else null
+            }
+
+            if (appIconBitmap != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        bitmap = appIconBitmap,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(0.5f)
+                    )
+                }
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        Icons.Default.SportsEsports,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/detail/GameDetailScreen.kt
@@ -148,7 +148,8 @@ fun GameDetailScreen(
                             // differently here than in the library.
                             .aspectRatio(boxArtAspectRatio(game.platformId))
                             .shadow(14.dp, RoundedCornerShape(12.dp))
-                            .clip(RoundedCornerShape(12.dp))
+                            .clip(RoundedCornerShape(12.dp)),
+                        packageName        = if (game.platformId == "android") game.romFilename else null
                     )
                     Spacer(Modifier.height(14.dp))
                     Text(
@@ -261,7 +262,8 @@ fun GameDetailScreen(
                                 localPath          = media?.screenshotLocalPath ?: media?.boxArtLocalPath,
                                 remoteUrl          = media?.screenshotRemoteUrl ?: media?.boxArtRemoteUrl,
                                 contentDescription = game.title,
-                                modifier           = Modifier.fillMaxSize()
+                                modifier           = Modifier.fillMaxSize(),
+                                packageName        = if (game.platformId == "android") game.romFilename else null
                             )
                         }
                     }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -86,8 +86,18 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.ui.focus.onFocusChanged
+import com.gamelaunch.frontend.ui.component.AppIcon
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -347,6 +357,10 @@ fun SettingsScreen(
         }
     }
     }
+    }
+
+    if (state.showAndroidGameSelection) {
+        AndroidGameSelectionDialog(state = state, viewModel = viewModel)
     }
 }
 
@@ -1090,6 +1104,12 @@ private fun AndroidGamesSection(state: SettingsUiState, viewModel: SettingsViewM
             onClick  = { viewModel.scanAndroidGames() },
             modifier = Modifier.fillMaxWidth()
         )
+        Spacer(Modifier.height(8.dp))
+        GradientOutlineButton(
+            text     = "Select Games Manually",
+            onClick  = { viewModel.showAndroidGameSelection(true) },
+            modifier = Modifier.fillMaxWidth()
+        )
         state.androidScanResult?.let { result ->
             Spacer(Modifier.height(6.dp))
             StatusRow(
@@ -1097,6 +1117,154 @@ private fun AndroidGamesSection(state: SettingsUiState, viewModel: SettingsViewM
                 text  = result,
                 color = ElectricBlue
             )
+        }
+    }
+}
+
+@Composable
+private fun AndroidGameSelectionDialog(
+    state: SettingsUiState,
+    viewModel: SettingsViewModel
+) {
+    Dialog(
+        onDismissRequest = { viewModel.showAndroidGameSelection(false) },
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(20.dp)
+            ) {
+                // Header
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column {
+                        Text(
+                            text = "Select Android Games",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = "Check the apps you want to see in your Games section",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(
+                        onClick = { viewModel.showAndroidGameSelection(false) },
+                        modifier = Modifier.size(40.dp).background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Close",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                // Scrollable list of apps
+                Box(modifier = Modifier.weight(1f)) {
+                    if (state.installedApps.isEmpty()) {
+                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(color = ElectricBlue)
+                        }
+                    } else {
+                        LazyColumn(
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            items(state.installedApps, key = { it.packageName }) { app ->
+                                val isChecked = state.checkedPackages.contains(app.packageName)
+                                var isFocused by remember { mutableStateOf(false) }
+
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(12.dp))
+                                        .background(
+                                            if (isFocused) MaterialTheme.colorScheme.surfaceVariant
+                                            else Color.Transparent
+                                        )
+                                        .border(
+                                            width = if (isFocused) 2.dp else 1.dp,
+                                            color = if (isFocused) ElectricBlue else MaterialTheme.colorScheme.outlineVariant,
+                                            shape = RoundedCornerShape(12.dp)
+                                        )
+                                        .onFocusChanged { isFocused = it.isFocused }
+                                        .focusable()
+                                        .clickable {
+                                            viewModel.toggleAndroidGameSelection(app, !isChecked)
+                                        }
+                                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        AppIcon(
+                                            packageName = app.packageName,
+                                            packageManagerHelper = viewModel.packageManagerHelper,
+                                            modifier = Modifier.size(36.dp)
+                                        )
+                                        Spacer(Modifier.width(12.dp))
+                                        Column {
+                                            Text(
+                                                text = app.label,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                fontWeight = FontWeight.SemiBold,
+                                                color = MaterialTheme.colorScheme.onSurface,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
+                                            Text(
+                                                text = app.packageName,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
+                                        }
+                                    }
+                                    Checkbox(
+                                        checked = isChecked,
+                                        onCheckedChange = null, // Handled by row clickable
+                                        colors = CheckboxDefaults.colors(
+                                            checkedColor = ElectricBlue,
+                                            checkmarkColor = Color.White
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                // Done Button
+                GradientFillButton(
+                    text = "Done",
+                    onClick = { viewModel.showAndroidGameSelection(false) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -17,8 +17,10 @@ import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.ImportEsdeMediaUseCase
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
 import com.gamelaunch.frontend.domain.usecase.ScanAndroidGamesUseCase
+import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.usecase.SyncLaunchBoxUseCase
 import com.gamelaunch.frontend.ui.theme.LayoutMode
+import kotlinx.coroutines.flow.first
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -70,7 +72,10 @@ data class SettingsUiState(
     // Systems currently in the library (platform ids) and which of them the user has hidden,
     // for the "Hide Systems" settings section.
     val libraryPlatforms: List<String> = emptyList(),
-    val hiddenPlatforms: Set<String> = emptySet()
+    val hiddenPlatforms: Set<String> = emptySet(),
+    val showAndroidGameSelection: Boolean = false,
+    val installedApps: List<com.gamelaunch.frontend.domain.model.InstalledApp> = emptyList(),
+    val checkedPackages: Set<String> = emptySet()
 )
 
 @HiltViewModel
@@ -85,7 +90,8 @@ class SettingsViewModel @Inject constructor(
     private val raRepository: RetroAchievementsRepository,
     private val gameRepository: GameRepository,
     private val friendRepository: com.gamelaunch.frontend.domain.repository.FriendRepository,
-    private val launchBoxDao: LaunchBoxDao
+    private val launchBoxDao: LaunchBoxDao,
+    val packageManagerHelper: com.gamelaunch.frontend.launcher.PackageManagerHelper
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -220,6 +226,12 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.raToken.collect { t ->
                 _uiState.update { it.copy(raLoggedIn = t.isNotBlank()) }
+            }
+        }
+        viewModelScope.launch {
+            gameRepository.getGamesByPlatform("android").collect { games ->
+                val pkgs = games.map { it.romFilename }.toSet()
+                _uiState.update { it.copy(checkedPackages = pkgs) }
             }
         }
     }
@@ -486,5 +498,38 @@ class SettingsViewModel @Inject constructor(
 
     fun finishSetup() {
         viewModelScope.launch { settingsRepository.setFirstLaunchComplete() }
+    }
+
+    fun showAndroidGameSelection(show: Boolean) {
+        if (show) {
+            val apps = packageManagerHelper.getInstalledApps()
+            _uiState.update { it.copy(showAndroidGameSelection = true, installedApps = apps) }
+        } else {
+            _uiState.update { it.copy(showAndroidGameSelection = false) }
+        }
+    }
+
+    fun toggleAndroidGameSelection(app: com.gamelaunch.frontend.domain.model.InstalledApp, isChecked: Boolean) {
+        viewModelScope.launch {
+            val romPath = "package:${app.packageName}"
+            if (isChecked) {
+                val exists = _uiState.value.checkedPackages.contains(app.packageName)
+                if (!exists) {
+                    val game = Game(
+                        title       = app.label,
+                        romPath     = romPath,
+                        romFilename = app.packageName,
+                        platformId  = "android"
+                    )
+                    gameRepository.insertGame(game)
+                }
+            } else {
+                val games = gameRepository.getGamesByPlatform("android").first()
+                val game = games.find { it.romFilename == app.packageName }
+                if (game != null) {
+                    gameRepository.deleteGame(game.id)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselGameCard.kt
@@ -61,6 +61,7 @@ fun CarouselGameCard(
                     Modifier.shadow(8.dp, shape)
             )
             .clip(shape)
-            .clickable(onClick = onClick)
+            .clickable(onClick = onClick),
+        packageName        = if (game.platformId == "android") game.romFilename else null
     )
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselHomeContent.kt
@@ -72,6 +72,8 @@ fun CarouselHomeContent(
         }
     }
 
+    val selectedGame = games.getOrNull(selectedIndex)
+
     Box(modifier = modifier) {
         // Background fill: video or stretched box art
         if (shouldPlayVideo && selectedGameMedia?.effectiveVideo != null) {
@@ -90,7 +92,8 @@ fun CarouselHomeContent(
                     ?: selectedGameMedia?.effectiveBackground
                     ?: selectedGameMedia?.boxArtRemoteUrl,
                 contentDescription = null,
-                modifier           = Modifier.fillMaxSize()
+                modifier           = Modifier.fillMaxSize(),
+                packageName        = if (selectedGame?.platformId == "android") selectedGame.romFilename else null
             )
         }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -122,7 +122,8 @@ fun GridGameCard(
             localPath          = media?.boxArtLocalPath,
             remoteUrl          = media?.boxArtRemoteUrl,
             contentDescription = game.title,
-            modifier           = Modifier.fillMaxSize()
+            modifier           = Modifier.fillMaxSize(),
+            packageName        = if (game.platformId == "android") game.romFilename else null
         )
 
         // Glass title strip at bottom


### PR DESCRIPTION
This PR implements major improvements to the Android games section:

Excludes popular frontends, emulators, and launchers (ES-DE, Daijishō, Pegasus, Dig, LaunchBox, Beacon, Console Launcher, etc.) from the automatic games scan.
Changes the auto-scanner's clean-up logic so that manually added games are preserved; games are now only deleted from the database if they are uninstalled from the device.
Implements direct Google Play Store scraping for Android games to pull high-resolution box art (og:image), titles, and descriptions.
Updates AsyncGameArtwork to support displaying local Android app launcher icons as a fallback on the home grid cards, the carousel/fan background, and the game detail screens.
Adds a beautiful, focusable, D-pad navigable manual selection dialog in settings (with checkmarks) allowing users to easily select or deselect any installed Android apps as games.
