### PR TITLE
Dual-screen support (Anbernic RG DS / AYN Thor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 </div>
 
+> 🖥️ **Coming soon: Dual-screen support** — on dual-screen handhelds like the **Anbernic RG DS** and **AYN Thor**, eOr will automatically detect the second display and split itself in two: the menu on the bottom screen, live game artwork and video previews on the top. No setup required.
+
 ---
 
 ## ✨ Why eOr?

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -1,10 +1,12 @@
 package com.gamelaunch.frontend
 
 import android.Manifest
+import android.app.ActivityOptions
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
+import android.view.Display
 import android.content.pm.PackageManager
 import android.graphics.BitmapFactory
 import android.net.Uri
@@ -28,6 +30,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,6 +54,9 @@ import com.gamelaunch.frontend.domain.usecase.AppUpdate
 import com.gamelaunch.frontend.domain.usecase.CheckForUpdateUseCase
 import com.gamelaunch.frontend.ui.component.LoadingScreen
 import com.gamelaunch.frontend.ui.component.UpdateBanner
+import com.gamelaunch.frontend.platform.display.DualScreenManager
+import com.gamelaunch.frontend.ui.dualscreen.ArtworkBus
+import com.gamelaunch.frontend.ui.dualscreen.LocalDualScreenActive
 import com.gamelaunch.frontend.ui.navigation.AppNavGraph
 import com.gamelaunch.frontend.ui.navigation.Screen
 import com.gamelaunch.frontend.ui.navigation.backOrHome
@@ -63,6 +69,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -81,6 +88,12 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var syncEngineManager: com.gamelaunch.frontend.data.sync.SyncEngineManager
     @Inject lateinit var friendRepository: com.gamelaunch.frontend.domain.repository.FriendRepository
     @Inject lateinit var pendingFriendLink: com.gamelaunch.frontend.domain.friends.PendingFriendLink
+    @Inject lateinit var artworkBus: ArtworkBus
+
+    // Drives the second (artwork) screen on dual-screen handhelds; a no-op on single-screen devices.
+    private lateinit var dualScreenManager: DualScreenManager
+    // Latest dark-mode choice, read by the artwork Presentation when it's (re)shown.
+    @Volatile private var currentDarkMode = false
 
     // Set when a newer GitHub release is found; drives the in-app update banner.
     private val updateState = mutableStateOf<AppUpdate?>(null)
@@ -106,6 +119,16 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        dualScreenManager = DualScreenManager(this, artworkBus) { currentDarkMode }
+
+        // On top-primary dual-screen devices (e.g. AYN Thor) the interactive menu belongs on the
+        // *secondary* display, so relaunch there once before any UI setup. This is a no-op on the
+        // Anbernic RG DS and on every single-screen device (requiredMenuDisplayId() == DEFAULT_DISPLAY),
+        // and a one-shot intent guard prevents any relaunch loop.
+        if (relaunchOnMenuDisplayIfNeeded()) return
+
+        observeDualScreenPreferences()
 
         // No SplashScreen API: on API 31+ it forces the system splash (which doesn't render on some
         // devices, e.g. the Retroid) and suppresses the window's starting background. Instead the
@@ -153,7 +176,10 @@ class MainActivity : ComponentActivity() {
                 opacity = bgOpacity
             )
 
+            val dualScreenActive by dualScreenManager.active.collectAsState()
+
             AppTheme(darkMode = darkMode, branding = branding) {
+              CompositionLocalProvider(LocalDualScreenActive provides dualScreenActive) {
                 Box(Modifier.fillMaxSize()) {
                 val navController = rememberNavController()
                 // Use null as initial so NavHost isn't created until we know the real value.
@@ -201,6 +227,7 @@ class MainActivity : ComponentActivity() {
                     )
                 }
                 }
+              }
             }
         }
     }
@@ -269,6 +296,46 @@ class MainActivity : ComponentActivity() {
             ?.asImageBitmap()
     }.getOrNull()
 
+    /** Feed the persisted dual-screen prefs (enable + manual swap) and dark-mode into the manager. */
+    private fun observeDualScreenPreferences() {
+        lifecycleScope.launch {
+            combine(
+                settingsRepository.dualScreenEnabled,
+                settingsRepository.dualScreenSwap
+            ) { enabled, swap -> enabled to swap }
+                .collect { (enabled, swap) -> dualScreenManager.setPreferences(enabled, swap) }
+        }
+        lifecycleScope.launch {
+            settingsRepository.darkMode.collect { currentDarkMode = it }
+        }
+    }
+
+    /**
+     * MENU_ON_SECONDARY devices (e.g. AYN Thor): move the interactive Activity onto the secondary
+     * (bottom) display once, so the menu ends up on the bottom panel and artwork on the top. Returns
+     * true if a relaunch was started (the caller must then abort the rest of onCreate).
+     *
+     * Safe by construction: [DualScreenManager.requiredMenuDisplayId] returns DEFAULT_DISPLAY on the
+     * RG DS and on every single-screen device, and a one-shot intent extra prevents any relaunch
+     * loop. NOTE: implemented but not yet validated on real Thor hardware.
+     */
+    private fun relaunchOnMenuDisplayIfNeeded(): Boolean {
+        if (intent.getBooleanExtra(EXTRA_DS_RELAUNCHED, false)) return false
+        val target = dualScreenManager.requiredMenuDisplayId()
+        if (target == Display.DEFAULT_DISPLAY) return false
+        if (DualScreenManager.currentDisplayId(this) == target) return false
+        return runCatching {
+            val options = ActivityOptions.makeBasic().setLaunchDisplayId(target)
+            val relaunch = Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                putExtra(EXTRA_DS_RELAUNCHED, true)
+            }
+            startActivity(relaunch, options.toBundle())
+            finish()
+            true
+        }.getOrDefault(false)
+    }
+
     /** If the user left Save Sync on, bring the Syncthing daemon back up when eOr launches. */
     private fun startSaveSyncIfEnabled() {
         lifecycleScope.launch {
@@ -304,6 +371,16 @@ class MainActivity : ComponentActivity() {
         // Re-check for updates whenever the app comes to the foreground (cold start included), so a
         // release published while the app is open/backgrounded surfaces without a force-close.
         checkForUpdate()
+        // Attach the artwork screen (if a second display is present). Skipped on the finishing
+        // instance during a MENU_ON_SECONDARY relaunch.
+        if (::dualScreenManager.isInitialized && !isFinishing) dualScreenManager.start()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // Release the second screen while eOr is backgrounded (e.g. a game/emulator launched) so it
+        // can take over the top panel; re-attached in onStart.
+        if (::dualScreenManager.isInitialized) dualScreenManager.stop()
     }
 
     private fun checkForUpdate() {
@@ -459,5 +536,7 @@ class MainActivity : ComponentActivity() {
         // Minimum gap between foreground update checks. Long enough to spare GitHub's API during
         // rapid game-launch/return cycles, short enough to notice a new release soon after returning.
         private const val UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000L
+        // One-shot guard so a MENU_ON_SECONDARY relaunch (Thor) can never loop.
+        private const val EXTRA_DS_RELAUNCHED = "dual_screen_relaunched"
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -41,6 +41,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val SHOW_RECENTLY_PLAYED = booleanPreferencesKey("show_recently_played")
         val SHOW_RETRO_ACHIEVEMENTS = booleanPreferencesKey("show_retro_achievements")
         val DARK_MODE = booleanPreferencesKey("dark_mode")
+        // Dual-screen (Anbernic RG DS / AYN Thor): auto-detect a second display and split the UI.
+        val DUAL_SCREEN_ENABLED = booleanPreferencesKey("dual_screen_enabled")
+        // Manual override that flips the top/bottom (artwork/menu) assignment on unknown devices.
+        val DUAL_SCREEN_SWAP = booleanPreferencesKey("dual_screen_swap")
         val BG_IMAGE_ENABLED = booleanPreferencesKey("background_image_enabled")
         val BG_IMAGE_PATH = stringPreferencesKey("background_image_path")
         val BG_IMAGE_MODE = stringPreferencesKey("background_image_mode")
@@ -87,6 +91,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val showRecentlyPlayed: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RECENTLY_PLAYED] ?: true }
     val showRetroAchievements: Flow<Boolean> = context.dataStore.data.map { it[Keys.SHOW_RETRO_ACHIEVEMENTS] ?: true }
     val darkMode: Flow<Boolean> = context.dataStore.data.map { it[Keys.DARK_MODE] ?: false }
+    // Dual-screen is on by default: it only ever activates when a second display is actually present.
+    val dualScreenEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.DUAL_SCREEN_ENABLED] ?: true }
+    val dualScreenSwap: Flow<Boolean> = context.dataStore.data.map { it[Keys.DUAL_SCREEN_SWAP] ?: false }
     // Optional user-supplied branded background. Path points at the processed single-colour
     // mask PNG in filesDir; mode is FILL (one full-width silhouette) or TILE (repeating pattern).
     val backgroundImageEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.BG_IMAGE_ENABLED] ?: false }
@@ -138,6 +145,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setShowRecentlyPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RECENTLY_PLAYED] = enabled }
     suspend fun setShowRetroAchievements(enabled: Boolean) = context.dataStore.edit { it[Keys.SHOW_RETRO_ACHIEVEMENTS] = enabled }
     suspend fun setDarkMode(enabled: Boolean) = context.dataStore.edit { it[Keys.DARK_MODE] = enabled }
+    suspend fun setDualScreenEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.DUAL_SCREEN_ENABLED] = enabled }
+    suspend fun setDualScreenSwap(swap: Boolean) = context.dataStore.edit { it[Keys.DUAL_SCREEN_SWAP] = swap }
     suspend fun setBackgroundImageEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.BG_IMAGE_ENABLED] = enabled }
     suspend fun setBackgroundImagePath(path: String) = context.dataStore.edit { it[Keys.BG_IMAGE_PATH] = path }
     suspend fun setBackgroundImageMode(mode: String) = context.dataStore.edit { it[Keys.BG_IMAGE_MODE] = mode }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -53,6 +53,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override val showRecentlyPlayed: Flow<Boolean> = dataStore.showRecentlyPlayed
     override val showRetroAchievements: Flow<Boolean> = dataStore.showRetroAchievements
     override val darkMode: Flow<Boolean> = dataStore.darkMode
+    override val dualScreenEnabled: Flow<Boolean> = dataStore.dualScreenEnabled
+    override val dualScreenSwap: Flow<Boolean> = dataStore.dualScreenSwap
     override val backgroundImageEnabled: Flow<Boolean> = dataStore.backgroundImageEnabled
     override val backgroundImagePath: Flow<String> = dataStore.backgroundImagePath
     override val backgroundImageMode: Flow<String> = dataStore.backgroundImageMode
@@ -107,6 +109,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setShowRecentlyPlayed(enabled: Boolean) { dataStore.setShowRecentlyPlayed(enabled) }
     override suspend fun setShowRetroAchievements(enabled: Boolean) { dataStore.setShowRetroAchievements(enabled) }
     override suspend fun setDarkMode(enabled: Boolean) { dataStore.setDarkMode(enabled) }
+    override suspend fun setDualScreenEnabled(enabled: Boolean) { dataStore.setDualScreenEnabled(enabled) }
+    override suspend fun setDualScreenSwap(swap: Boolean) { dataStore.setDualScreenSwap(swap) }
     override suspend fun setBackgroundImageEnabled(enabled: Boolean) { dataStore.setBackgroundImageEnabled(enabled) }
     override suspend fun setBackgroundImagePath(path: String) { dataStore.setBackgroundImagePath(path) }
     override suspend fun setBackgroundImageMode(mode: String) { dataStore.setBackgroundImageMode(mode) }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -18,6 +18,8 @@ interface SettingsRepository {
     val showRecentlyPlayed: Flow<Boolean>
     val showRetroAchievements: Flow<Boolean>
     val darkMode: Flow<Boolean>
+    val dualScreenEnabled: Flow<Boolean>
+    val dualScreenSwap: Flow<Boolean>
     val backgroundImageEnabled: Flow<Boolean>
     val backgroundImagePath: Flow<String>
     val backgroundImageMode: Flow<String>
@@ -59,6 +61,8 @@ interface SettingsRepository {
     suspend fun setShowRecentlyPlayed(enabled: Boolean)
     suspend fun setShowRetroAchievements(enabled: Boolean)
     suspend fun setDarkMode(enabled: Boolean)
+    suspend fun setDualScreenEnabled(enabled: Boolean)
+    suspend fun setDualScreenSwap(swap: Boolean)
     suspend fun setBackgroundImageEnabled(enabled: Boolean)
     suspend fun setBackgroundImagePath(path: String)
     suspend fun setBackgroundImageMode(mode: String)

--- a/app/src/main/java/com/gamelaunch/frontend/platform/display/DualScreenDevices.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/platform/display/DualScreenDevices.kt
@@ -1,0 +1,59 @@
+package com.gamelaunch.frontend.platform.display
+
+import android.os.Build
+
+/**
+ * Maps a dual-screen handheld to how its two panels relate to Android's primary/secondary displays.
+ *
+ * Android exposes no API for a display's physical top/bottom position, and the target devices are
+ * mirror images of each other, so we classify the known ones by [Build] identity. eOr always wants
+ * the **interactive menu on the bottom panel** and **artwork on the top panel**.
+ */
+object DualScreenDevices {
+
+    enum class Layout {
+        /**
+         * The bottom (menu) panel is already the primary display, so the Activity stays where it
+         * launches and the artwork [android.app.Presentation] goes on the secondary (top) panel.
+         * No Activity relaunch needed. This is the Anbernic RG DS, and the safe default.
+         */
+        ARTWORK_ON_SECONDARY,
+
+        /**
+         * The top panel is the primary display, so the bottom (menu) panel is the *secondary* one.
+         * The interactive Activity must be relaunched onto the secondary display and the artwork
+         * Presentation shown on the primary (top). This is the AYN Thor.
+         */
+        MENU_ON_SECONDARY;
+
+        fun flipped(): Layout =
+            if (this == ARTWORK_ON_SECONDARY) MENU_ON_SECONDARY else ARTWORK_ON_SECONDARY
+    }
+
+    /**
+     * Classify the running device. Unknown devices default to [Layout.ARTWORK_ON_SECONDARY], which
+     * never relaunches the Activity — the safe choice — and can be corrected with the manual
+     * "Swap screens" setting (see [layoutFor]'s `swap` handling in DualScreenManager).
+     */
+    fun layoutFor(
+        manufacturer: String = Build.MANUFACTURER,
+        model: String = Build.MODEL,
+        device: String = Build.DEVICE
+    ): Layout {
+        val mf = manufacturer.lowercase()
+        val m = model.lowercase()
+        val d = device.lowercase()
+        return when {
+            // AYN Thor — top screen is primary; the menu belongs on the secondary (bottom) panel.
+            mf.contains("ayn") || m.contains("thor") || d.contains("thor") ->
+                Layout.MENU_ON_SECONDARY
+
+            // Anbernic RG DS — bottom (menu) is already primary; artwork goes on the secondary (top).
+            mf.contains("anbernic") || m.contains("rg ds") || m.contains("rgds") ||
+                d.contains("rgds") || d.contains("rg_ds") ->
+                Layout.ARTWORK_ON_SECONDARY
+
+            else -> Layout.ARTWORK_ON_SECONDARY
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/platform/display/DualScreenManager.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/platform/display/DualScreenManager.kt
@@ -1,0 +1,154 @@
+package com.gamelaunch.frontend.platform.display
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.util.Log
+import android.view.Display
+import androidx.activity.ComponentActivity
+import com.gamelaunch.frontend.ui.dualscreen.ArtworkBus
+import com.gamelaunch.frontend.ui.dualscreen.ArtworkPresentation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Detects a second physical display and drives eOr's dual-screen layout: the interactive menu on
+ * the bottom panel, game artwork on the top panel (see [DualScreenDevices]).
+ *
+ * Owned by [ComponentActivity]. On single-screen devices it does nothing and [active] stays false,
+ * so the app behaves exactly as before. It listens for hot-plug events (clamshell open/close, a
+ * panel powering on/off) and re-evaluates on each.
+ */
+class DualScreenManager(
+    private val activity: ComponentActivity,
+    private val artworkBus: ArtworkBus,
+    private val darkModeProvider: () -> Boolean
+) {
+    private val displayManager =
+        activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+
+    private var presentation: ArtworkPresentation? = null
+
+    private val _active = MutableStateFlow(false)
+    /** True while artwork is being presented on a second screen. Drives `LocalDualScreenActive`. */
+    val active: StateFlow<Boolean> = _active.asStateFlow()
+
+    private var enabled = true
+    private var swap = false
+    private var started = false
+
+    private val listener = object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) = refresh()
+        override fun onDisplayRemoved(displayId: Int) = refresh()
+        override fun onDisplayChanged(displayId: Int) = refresh()
+    }
+
+    fun start() {
+        if (started) return
+        started = true
+        displayManager.registerDisplayListener(listener, null)
+        refresh()
+    }
+
+    fun stop() {
+        if (!started) return
+        started = false
+        runCatching { displayManager.unregisterDisplayListener(listener) }
+        dismiss()
+        _active.value = false
+    }
+
+    /** Apply the latest persisted preferences (dual-screen on/off and the manual top/bottom swap). */
+    fun setPreferences(enabled: Boolean, swap: Boolean) {
+        if (this.enabled == enabled && this.swap == swap) return
+        this.enabled = enabled
+        this.swap = swap
+        if (started) refresh()
+    }
+
+    /**
+     * The display id the interactive Activity should run on. For the common
+     * [DualScreenDevices.Layout.ARTWORK_ON_SECONDARY] case this is the default display (no move
+     * needed). For [DualScreenDevices.Layout.MENU_ON_SECONDARY] (Thor) it's the secondary display,
+     * so [com.gamelaunch.frontend.MainActivity] can relaunch itself there. Returns
+     * [Display.DEFAULT_DISPLAY] when single-screen or disabled.
+     */
+    fun requiredMenuDisplayId(): Int {
+        val secondary = secondaryDisplay() ?: return Display.DEFAULT_DISPLAY
+        return when (effectiveLayout()) {
+            DualScreenDevices.Layout.ARTWORK_ON_SECONDARY -> Display.DEFAULT_DISPLAY
+            DualScreenDevices.Layout.MENU_ON_SECONDARY -> secondary.displayId
+        }
+    }
+
+    private fun effectiveLayout(): DualScreenDevices.Layout =
+        DualScreenDevices.layoutFor().let { if (swap) it.flipped() else it }
+
+    /** The first powered-on display that isn't the default one, or null if there's only one screen. */
+    private fun secondaryDisplay(): Display? =
+        displayManager.displays.firstOrNull {
+            it.displayId != Display.DEFAULT_DISPLAY && it.state == Display.STATE_ON
+        }
+
+    /** Re-evaluate which display (if any) should show artwork and (re)attach the Presentation. */
+    fun refresh() {
+        val secondary = if (enabled) secondaryDisplay() else null
+        if (secondary == null) {
+            dismiss()
+            _active.value = false
+            return
+        }
+
+        // Where the artwork goes:
+        //  - ARTWORK_ON_SECONDARY (RG DS): artwork on the secondary (top) panel; menu Activity stays.
+        //  - MENU_ON_SECONDARY (Thor): the Activity is relaunched onto the secondary (bottom) panel
+        //    by MainActivity, so artwork goes on the default (top) display.
+        val artworkDisplay = when (effectiveLayout()) {
+            DualScreenDevices.Layout.ARTWORK_ON_SECONDARY -> secondary
+            DualScreenDevices.Layout.MENU_ON_SECONDARY ->
+                displayManager.getDisplay(Display.DEFAULT_DISPLAY) ?: secondary
+        }
+
+        showOn(artworkDisplay)
+        _active.value = true
+    }
+
+    private fun showOn(display: Display) {
+        val current = presentation
+        if (current != null && current.display?.displayId == display.displayId && current.isShowing) {
+            return
+        }
+        dismiss()
+        val next = ArtworkPresentation(
+            activity = activity,
+            display = display,
+            artworkBus = artworkBus,
+            darkMode = darkModeProvider()
+        )
+        runCatching { next.show() }
+            .onSuccess { presentation = next }
+            .onFailure { Log.w(TAG, "Failed to show artwork presentation on display ${display.displayId}", it) }
+    }
+
+    fun dismiss() {
+        presentation?.let { runCatching { it.dismiss() } }
+        presentation = null
+    }
+
+    companion object {
+        private const val TAG = "DualScreenManager"
+
+        /**
+         * The display id the Activity currently occupies. Used by MainActivity to decide whether a
+         * MENU_ON_SECONDARY relaunch is needed.
+         */
+        fun currentDisplayId(activity: ComponentActivity): Int =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activity.display?.displayId ?: Display.DEFAULT_DISPLAY
+            } else {
+                @Suppress("DEPRECATION")
+                activity.windowManager.defaultDisplay?.displayId ?: Display.DEFAULT_DISPLAY
+            }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkBus.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkBus.kt
@@ -1,0 +1,45 @@
+package com.gamelaunch.frontend.ui.dualscreen
+
+import com.gamelaunch.frontend.domain.model.GameMedia
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** What the artwork (top) screen is currently showing. */
+enum class ArtworkMode {
+    /** No game context yet (onboarding, splash, non-Games tab) — show branding. */
+    IDLE,
+    /** Browsing the system grid — show the focused system's preview art. */
+    SYSTEM_GRID,
+    /** Inside a system — show the selected game's screenshot / video / box art. */
+    GAME
+}
+
+/** Immutable snapshot the [ArtworkPresentation] renders on the second screen. */
+data class ArtworkUiState(
+    val mode: ArtworkMode = ArtworkMode.IDLE,
+    val media: GameMedia? = null,
+    val shouldPlayVideo: Boolean = false,
+    val videoMuted: Boolean = true,
+    val systemPreviewArt: List<String> = emptyList(),
+    val title: String? = null
+)
+
+/**
+ * A process-wide hand-off channel from the interactive UI (bottom screen) to the artwork
+ * [ArtworkPresentation] (top screen). [HomeViewModel] publishes a derived snapshot whenever the
+ * selection/media changes; the Presentation observes [state]. Kept as a plain @Singleton (not a
+ * ViewModel) so it survives independently of any NavBackStackEntry-scoped ViewModel and can be
+ * read from the Activity that owns the Presentation.
+ */
+@Singleton
+class ArtworkBus @Inject constructor() {
+    private val _state = MutableStateFlow(ArtworkUiState())
+    val state: StateFlow<ArtworkUiState> = _state.asStateFlow()
+
+    fun publish(state: ArtworkUiState) {
+        _state.value = state
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkPresentation.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkPresentation.kt
@@ -1,0 +1,148 @@
+package com.gamelaunch.frontend.ui.dualscreen
+
+import android.app.Presentation
+import android.graphics.Color as AndroidColor
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.Display
+import android.view.View
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.component.VideoPlayer
+import com.gamelaunch.frontend.ui.theme.AppTheme
+
+/**
+ * A [Presentation] that renders eOr's game artwork full-bleed on a second physical display (the
+ * top panel of a dual-screen handheld). It is passive: [FLAG_NOT_FOCUSABLE] guarantees it never
+ * steals key/controller focus from the interactive menu Activity on the other screen.
+ *
+ * The content is Compose hosted in a [ComposeView]. Because a Presentation is not an Activity, the
+ * ComposeView's ViewTree owners must be wired up manually — we reuse the host [activity] as the
+ * lifecycle / view-model-store / saved-state owner. State comes from [ArtworkBus].
+ */
+class ArtworkPresentation(
+    private val activity: ComponentActivity,
+    display: Display,
+    private val artworkBus: ArtworkBus,
+    private val darkMode: Boolean
+) : Presentation(activity, display) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Passive display: black backdrop, never focusable so the menu Activity keeps input focus.
+        window?.apply {
+            setBackgroundDrawable(ColorDrawable(AndroidColor.BLACK))
+            addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+            // Full-bleed: no title, cover the whole panel.
+            decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                View.SYSTEM_UI_FLAG_FULLSCREEN or
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+            )
+        }
+
+        val composeView = ComposeView(context).apply {
+            // Reuse the Activity as the owner of the Compose ViewTree (a Presentation has no owners
+            // of its own). Without these, ComposeView throws when it composes.
+            setViewTreeLifecycleOwner(activity)
+            setViewTreeViewModelStoreOwner(activity)
+            setViewTreeSavedStateRegistryOwner(activity)
+            setContent {
+                AppTheme(darkMode = darkMode) {
+                    ArtworkScreen(artworkBus)
+                }
+            }
+        }
+        setContentView(composeView)
+    }
+}
+
+@Composable
+private fun ArtworkScreen(artworkBus: ArtworkBus) {
+    val state by artworkBus.state.collectAsState()
+
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+        contentAlignment = Alignment.Center
+    ) {
+        when (state.mode) {
+            ArtworkMode.GAME -> {
+                val media = state.media
+                if (state.shouldPlayVideo && media?.effectiveVideo != null) {
+                    VideoPlayer(
+                        videoPath = media.effectiveVideo,
+                        shouldPlay = true,
+                        isMuted = state.videoMuted,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    AsyncGameArtwork(
+                        // Same priority order the single-screen background uses.
+                        localPath = media?.screenshotLocalPath
+                            ?: media?.backgroundLocalPath
+                            ?: media?.boxArtLocalPath,
+                        remoteUrl = media?.screenshotRemoteUrl
+                            ?: media?.effectiveBackground
+                            ?: media?.boxArtRemoteUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+
+            ArtworkMode.SYSTEM_GRID -> {
+                val art = state.systemPreviewArt.firstOrNull()
+                if (art != null) {
+                    AsyncGameArtwork(
+                        localPath = art,
+                        remoteUrl = art,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(24.dp)
+                    )
+                } else {
+                    BrandPlaceholder()
+                }
+            }
+
+            ArtworkMode.IDLE -> BrandPlaceholder()
+        }
+    }
+}
+
+@Composable
+private fun BrandPlaceholder() {
+    Icon(
+        imageVector = Icons.Default.SportsEsports,
+        contentDescription = null,
+        tint = Color.White.copy(alpha = 0.25f),
+        modifier = Modifier.padding(48.dp)
+    )
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/LocalDualScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/LocalDualScreen.kt
@@ -1,0 +1,11 @@
+package com.gamelaunch.frontend.ui.dualscreen
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * True when eOr is running across two physical displays and the game artwork has been routed to the
+ * second (artwork) screen. The interactive Activity UI reads this to drop its own full-screen
+ * artwork/video backdrop — that layer now lives on the other screen — and let the menu take the
+ * whole panel. Defaults to false, so single-screen devices render exactly as before.
+ */
+val LocalDualScreenActive = staticCompositionLocalOf { false }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -65,6 +65,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.R
 import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.component.platformDisplayName
+import com.gamelaunch.frontend.ui.dualscreen.LocalDualScreenActive
 import kotlin.math.roundToInt
 import com.gamelaunch.frontend.ui.input.GamepadA
 import com.gamelaunch.frontend.ui.input.GamepadB
@@ -99,6 +100,10 @@ fun HomeScreen(
 ) {
     val state     by viewModel.uiState.collectAsState()
     val appsState by appsViewModel.uiState.collectAsState()
+
+    // On dual-screen devices the game artwork/video is rendered on the top panel (ArtworkPresentation),
+    // so the interactive content here drops its own full-screen backdrop.
+    val dualScreen = LocalDualScreenActive.current
 
     val darkMode      = LocalDarkMode.current
     val textPrimary   = if (darkMode) IceWhite else TileText
@@ -155,6 +160,16 @@ fun HomeScreen(
     LaunchedEffect(state.recentlyPlayed.size) {
         if (state.recentlyPlayed.isNotEmpty())
             recentFocusIndex = recentFocusIndex.coerceAtMost(state.recentlyPlayed.size - 1)
+    }
+    // Dual-screen: the grid layout tracks focus in local state (gridFocusIndex) and doesn't drive
+    // the shared selection the way the carousel does, so mirror it into the ViewModel to keep the
+    // artwork (top) screen in sync. No effect on single-screen devices (grid draws no backdrop).
+    if (dualScreen) {
+        LaunchedEffect(gridFocusIndex, state.gameViewActive, state.layoutMode) {
+            if (state.gameViewActive && state.layoutMode == LayoutMode.GRID) {
+                viewModel.onGameSelected(gridFocusIndex)
+            }
+        }
     }
 
     fun cyclePlatform(delta: Int) {
@@ -486,7 +501,8 @@ fun HomeScreen(
                                 previewArt      = state.systemPreviewArt,
                                 onSystemFocused = viewModel::focusSystem,
                                 onSystemClick   = { gridFocusIndex = 0; viewModel.enterSystem(it) },
-                                modifier        = Modifier.fillMaxSize()
+                                modifier        = Modifier.fillMaxSize(),
+                                showPreviewArt  = !dualScreen
                             )
 
                         state.topTab == TopTab.GAMES -> {
@@ -501,7 +517,8 @@ fun HomeScreen(
                                     onGameSelected    = viewModel::onGameSelected,
                                     onGameClick       = onGameClick,
                                     onMuteToggle      = viewModel::toggleMute,
-                                    modifier          = Modifier.fillMaxSize()
+                                    modifier          = Modifier.fillMaxSize(),
+                                    showBackgroundArtwork = !dualScreen
                                 )
                             } else {
                                 GridHomeContent(

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -14,6 +14,9 @@ import com.gamelaunch.frontend.domain.platform.sortedBySystems
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.MediaRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.ui.dualscreen.ArtworkBus
+import com.gamelaunch.frontend.ui.dualscreen.ArtworkMode
+import com.gamelaunch.frontend.ui.dualscreen.ArtworkUiState
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -61,7 +64,8 @@ class HomeViewModel @Inject constructor(
     @ApplicationContext private val appContext: Context,
     private val gameRepository: GameRepository,
     private val mediaRepository: MediaRepository,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val artworkBus: ArtworkBus
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -75,6 +79,35 @@ class HomeViewModel @Inject constructor(
         observeGameViewPrefs()
         observeAllMedia()
         observeRecentlyPlayed()
+        publishArtwork()
+    }
+
+    /**
+     * Mirror the current selection/media into [ArtworkBus] so the second (artwork) screen on
+     * dual-screen devices stays in sync. Harmless on single-screen devices — nothing observes the
+     * bus there. One collector covers every selection change, so no per-action wiring is needed.
+     */
+    private fun publishArtwork() {
+        viewModelScope.launch {
+            _uiState.collect { state ->
+                val selectedGame = state.games.getOrNull(state.selectedGameIndex)
+                val mode = when {
+                    state.topTab != TopTab.GAMES -> ArtworkMode.IDLE
+                    !state.gameViewActive -> ArtworkMode.SYSTEM_GRID
+                    else -> ArtworkMode.GAME
+                }
+                artworkBus.publish(
+                    ArtworkUiState(
+                        mode = mode,
+                        media = state.selectedGameMedia,
+                        shouldPlayVideo = state.shouldPlayVideo,
+                        videoMuted = state.videoMuted,
+                        systemPreviewArt = state.systemPreviewArt,
+                        title = selectedGame?.title
+                    )
+                )
+            }
+        }
     }
 
     /** The Select-menu options (game sort + fixed column count) for the game grid. */

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -70,7 +70,10 @@ fun SystemSelectionContent(
     previewArt: List<String> = emptyList(),
     onSystemFocused: (String) -> Unit = {},
     onSystemClick: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // When false (dual-screen: the focused system's art shows on the top panel), hide the preview
+    // fan here so the system carousel is the whole bottom panel.
+    showPreviewArt: Boolean = true
 ) {
     if (platforms.isEmpty()) {
         val darkMode = LocalDarkMode.current
@@ -79,7 +82,7 @@ fun SystemSelectionContent(
         }
         return
     }
-    SystemCarousel(platforms, counts, focusedIndex, previewArt, onSystemFocused, onSystemClick, modifier)
+    SystemCarousel(platforms, counts, focusedIndex, previewArt, onSystemFocused, onSystemClick, modifier, showPreviewArt)
 }
 
 @Composable
@@ -90,7 +93,8 @@ private fun SystemCarousel(
     previewArt: List<String>,
     onSystemFocused: (String) -> Unit,
     onSystemClick: (String) -> Unit,
-    modifier: Modifier
+    modifier: Modifier,
+    showPreviewArt: Boolean
 ) {
     val focused = platforms.getOrNull(focusedIndex)
 
@@ -128,6 +132,10 @@ private fun SystemCarousel(
         Column(Modifier.fillMaxSize()) {
 
             // ── Preview (top): covers rise from the bottom and fan out, centre largest ──
+            // On dual-screen devices this band is empty (the focused system's art is on the top panel).
+            if (!showPreviewArt) {
+                Spacer(Modifier.weight(1f))
+            } else
             Box(
                 modifier = Modifier.weight(1f).fillMaxWidth(),
                 contentAlignment = Alignment.Center

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -1,6 +1,9 @@
 package com.gamelaunch.frontend.ui.screen.settings
 
+import android.content.Context
 import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.view.Display
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -296,6 +299,7 @@ fun SettingsScreen(
                         SettingsTab.GENERAL -> {
                             DisplaySection(state, viewModel)
                             Spacer(Modifier.height(4.dp))
+                            DualScreenSection(state, viewModel)
                             SystemSortSection(state, viewModel)
                             Spacer(Modifier.height(4.dp))
                             HideSystemsSection(state, viewModel)
@@ -454,6 +458,46 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
         Spacer(Modifier.height(8.dp))
         ThemePicker(selectedDark = state.darkMode, onSelect = viewModel::setDarkMode)
     }
+}
+
+// ── Section: Dual Screen ──────────────────────────────────────────────────
+
+/**
+ * Only shown on dual-screen handhelds (a second physical display is present). Lets the user turn
+ * the split layout off and manually swap which panel shows the menu vs artwork if auto-detection
+ * guessed wrong for an unrecognised device.
+ */
+@Composable
+private fun DualScreenSection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    val context = LocalContext.current
+    val hasSecondScreen = remember {
+        val dm = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager
+        dm?.displays?.any { it.displayId != Display.DEFAULT_DISPLAY && it.state == Display.STATE_ON } == true
+    }
+    if (!hasSecondScreen) return
+
+    SettingsSectionHeader("Dual Screen")
+    SettingsCard {
+        Text(
+            "Two screens detected. eOr shows the menu on the bottom panel and game artwork on the top.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(8.dp))
+        CardSwitchRow(
+            label           = "Use both screens",
+            checked         = state.dualScreenEnabled,
+            onCheckedChange = viewModel::setDualScreenEnabled
+        )
+        if (state.dualScreenEnabled) {
+            CardSwitchRow(
+                label           = "Swap screens",
+                checked         = state.dualScreenSwap,
+                onCheckedChange = viewModel::setDualScreenSwap
+            )
+        }
+    }
+    Spacer(Modifier.height(4.dp))
 }
 
 // ── Section: Sort Systems ─────────────────────────────────────────────────

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -63,6 +63,8 @@ data class SettingsUiState(
     val showRetroAchievements: Boolean = true,
     val friendsEnabled: Boolean = false,
     val darkMode: Boolean = false,
+    val dualScreenEnabled: Boolean = true,
+    val dualScreenSwap: Boolean = false,
     val backgroundImageEnabled: Boolean = false,
     val backgroundImagePath: String = "",
     val backgroundImageMode: String = "FILL",
@@ -177,6 +179,16 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.dualScreenEnabled.collect { on ->
+                _uiState.update { it.copy(dualScreenEnabled = on) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.dualScreenSwap.collect { swap ->
+                _uiState.update { it.copy(dualScreenSwap = swap) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.systemSort.collect { sorts ->
                 _uiState.update { it.copy(systemSort = sorts) }
             }
@@ -248,6 +260,14 @@ class SettingsViewModel @Inject constructor(
      *  profile sharing are brought up or fully torn down. */
     fun setFriendsEnabled(enabled: Boolean) {
         viewModelScope.launch { friendRepository.setEnabled(enabled) }
+    }
+
+    fun setDualScreenEnabled(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setDualScreenEnabled(enabled) }
+    }
+
+    fun setDualScreenSwap(swap: Boolean) {
+        viewModelScope.launch { settingsRepository.setDualScreenSwap(swap) }
     }
 
     fun setDarkMode(enabled: Boolean) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselHomeContent.kt
@@ -53,7 +53,10 @@ fun CarouselHomeContent(
     onGameSelected: (Int) -> Unit,
     onGameClick: (Long) -> Unit,
     onMuteToggle: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // When false (dual-screen: artwork lives on the top panel), skip the full-screen video/art
+    // backdrop and its darkening gradient here so the bottom panel is just the menu.
+    showBackgroundArtwork: Boolean = true
 ) {
     val listState   = rememberLazyListState()
     val snapBehavior = rememberSnapFlingBehavior(lazyListState = listState)
@@ -75,40 +78,43 @@ fun CarouselHomeContent(
     val selectedGame = games.getOrNull(selectedIndex)
 
     Box(modifier = modifier) {
-        // Background fill: video or stretched box art
-        if (shouldPlayVideo && selectedGameMedia?.effectiveVideo != null) {
-            VideoPlayer(
-                videoPath  = selectedGameMedia.effectiveVideo,
-                shouldPlay = true,
-                isMuted    = videoMuted,
-                modifier   = Modifier.fillMaxSize()
-            )
-        } else {
-            AsyncGameArtwork(
-                localPath = selectedGameMedia?.screenshotLocalPath
-                    ?: selectedGameMedia?.backgroundLocalPath
-                    ?: selectedGameMedia?.boxArtLocalPath,
-                remoteUrl = selectedGameMedia?.screenshotRemoteUrl
-                    ?: selectedGameMedia?.effectiveBackground
-                    ?: selectedGameMedia?.boxArtRemoteUrl,
-                contentDescription = null,
-                modifier           = Modifier.fillMaxSize(),
-                packageName        = if (selectedGame?.platformId == "android") selectedGame.romFilename else null
+        // Background fill: video or stretched box art. On dual-screen devices this whole layer moves
+        // to the top panel (see ArtworkPresentation), so we skip it here.
+        if (showBackgroundArtwork) {
+            if (shouldPlayVideo && selectedGameMedia?.effectiveVideo != null) {
+                VideoPlayer(
+                    videoPath  = selectedGameMedia.effectiveVideo,
+                    shouldPlay = true,
+                    isMuted    = videoMuted,
+                    modifier   = Modifier.fillMaxSize()
+                )
+            } else {
+                AsyncGameArtwork(
+                    localPath = selectedGameMedia?.screenshotLocalPath
+                        ?: selectedGameMedia?.backgroundLocalPath
+                        ?: selectedGameMedia?.boxArtLocalPath,
+                    remoteUrl = selectedGameMedia?.screenshotRemoteUrl
+                        ?: selectedGameMedia?.effectiveBackground
+                        ?: selectedGameMedia?.boxArtRemoteUrl,
+                    contentDescription = null,
+                    modifier           = Modifier.fillMaxSize(),
+                    packageName        = if (selectedGame?.platformId == "android") selectedGame.romFilename else null
+                )
+            }
+
+            // Deep gradient — near-black at bottom, subtle tint at top
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0.0f to Color.Black.copy(alpha = 0.15f),
+                            0.45f to Color.Black.copy(alpha = 0.30f),
+                            1.0f to Color.Black.copy(alpha = 0.90f)
+                        )
+                    )
             )
         }
-
-        // Deep gradient — near-black at bottom, subtle tint at top
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.verticalGradient(
-                        0.0f to Color.Black.copy(alpha = 0.15f),
-                        0.45f to Color.Black.copy(alpha = 0.30f),
-                        1.0f to Color.Black.copy(alpha = 0.90f)
-                    )
-                )
-        )
 
         // Title + genre block
         games.getOrNull(selectedIndex)?.let { game ->

--- a/app/src/test/java/com/gamelaunch/frontend/DualScreenDevicesTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/DualScreenDevicesTest.kt
@@ -1,0 +1,35 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.platform.display.DualScreenDevices
+import com.gamelaunch.frontend.platform.display.DualScreenDevices.Layout
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DualScreenDevicesTest {
+
+    @Test fun `AYN Thor puts the menu on the secondary display`() {
+        assertEquals(
+            Layout.MENU_ON_SECONDARY,
+            DualScreenDevices.layoutFor(manufacturer = "AYN", model = "Thor", device = "thor")
+        )
+    }
+
+    @Test fun `Anbernic RG DS puts artwork on the secondary display`() {
+        assertEquals(
+            Layout.ARTWORK_ON_SECONDARY,
+            DualScreenDevices.layoutFor(manufacturer = "Anbernic", model = "RG DS", device = "rgds")
+        )
+    }
+
+    @Test fun `unknown device defaults to artwork-on-secondary (never relaunches)`() {
+        assertEquals(
+            Layout.ARTWORK_ON_SECONDARY,
+            DualScreenDevices.layoutFor(manufacturer = "Google", model = "Pixel 8", device = "shiba")
+        )
+    }
+
+    @Test fun `flipped inverts the layout`() {
+        assertEquals(Layout.MENU_ON_SECONDARY, Layout.ARTWORK_ON_SECONDARY.flipped())
+        assertEquals(Layout.ARTWORK_ON_SECONDARY, Layout.MENU_ON_SECONDARY.flipped())
+    }
+}


### PR DESCRIPTION
## Summary

Adds **dual-screen support** for stacked-display handhelds. eOr auto-detects a second physical display and splits the UI: **interactive menu on the bottom panel, live game artwork/video on the top panel**. On every other device it falls back to the existing single-screen layout unchanged.

> ⚠️ **No release yet** — merging this does not cut a release. The user wants to validate on real hardware first (Anbernic RG DS arriving to test; the AYN Thor path is implemented but not yet hardware-validated).

## How it works

- **`DualScreenManager`** detects a secondary `Display` via `DisplayManager` (with a hot-plug listener for clamshell open/close) and drives an `ArtworkPresentation` on the artwork display.
- **`DualScreenDevices`** classifies known devices by `Build` identity — the two targets are mirror images:
  - **Anbernic RG DS** → bottom is primary → artwork goes to the secondary (top) display; **no Activity relaunch**.
  - **AYN Thor** → top is primary → the Activity relaunches onto the secondary (bottom) display via `setLaunchDisplayId` (loop-guarded). *Implemented but unvalidated on Thor hardware.*
  - Unknown devices default to the safe no-relaunch path; a manual **Swap screens** setting corrects the mapping if needed.
- **`ArtworkPresentation`** renders the selected game's video/screenshot full-bleed via a `ComposeView` (passive, `FLAG_NOT_FOCUSABLE`, so it never steals controller focus), fed by a `@Singleton` **`ArtworkBus`** that `HomeViewModel` publishes selection changes into.
- **`HomeScreen` / `CarouselHomeContent` / `SystemSelectionContent`** drop their own full-screen backdrop when `LocalDualScreenActive` is set (that layer now lives on the top screen); grid focus is mirrored so the top screen stays in sync.
- **Settings → "Dual Screen"** section (shown only when a second display exists) with enable + swap toggles, persisted in DataStore.

## Testing

- `./gradlew clean assembleDebug` — builds a debug APK.
- `./gradlew testDebugUnitTest` — all pass, including a new `DualScreenDevicesTest` covering the RG DS / Thor / unknown-device classification and the swap flip.
- On-device validation on the RG DS is pending (hardware arriving).

## Notes

- No manifest changes required (`Presentation` renders from within the existing Activity); `minSdk 26` already covers `DisplayManager`/`Presentation` and `setLaunchDisplayId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)