### PR TITLE
DS mode: gear polish, marquee shadow/glow, selection fix, d-pad settings

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -216,6 +217,18 @@ class MainActivity : ComponentActivity() {
                             navController    = navController,
                             startDestination = startDestination
                         )
+                        // Tell the artwork (top) screen when we're in the Settings area, so it shows
+                        // a gear instead of the last game's art. Driven here (not by HomeViewModel)
+                        // because HomeViewModel's selection stream doesn't know about navigation.
+                        LaunchedEffect(navController) {
+                            navController.currentBackStackEntryFlow.collect { entry ->
+                                val route = entry.destination.route
+                                artworkBus.setSettingsActive(
+                                    route == Screen.Settings.route ||
+                                    route == Screen.EmulatorConfig.route
+                                )
+                            }
+                        }
                         // System Back (the Retroid's B maps to it): pop the nav stack so the
                         // detail/settings screens return to where they came from. If the stack has
                         // nothing to pop — e.g. eOr was resumed on a sub-screen via a launcher

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkBus.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkBus.kt
@@ -48,11 +48,20 @@ class ArtworkBus @Inject constructor() {
     private val _darkMode = MutableStateFlow(false)
     val darkMode: StateFlow<Boolean> = _darkMode.asStateFlow()
 
+    // True while the user is in the Settings area. Driven by the Activity's nav observer (not the
+    // HomeViewModel selection stream), so the top panel can show a gear instead of the last game art.
+    private val _settingsActive = MutableStateFlow(false)
+    val settingsActive: StateFlow<Boolean> = _settingsActive.asStateFlow()
+
     fun publish(state: ArtworkUiState) {
         _state.value = state
     }
 
     fun setDarkMode(dark: Boolean) {
         _darkMode.value = dark
+    }
+
+    fun setSettingsActive(active: Boolean) {
+        _settingsActive.value = active
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkPresentation.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkPresentation.kt
@@ -3,6 +3,7 @@ package com.gamelaunch.frontend.ui.dualscreen
 import android.app.Presentation
 import android.graphics.Color as AndroidColor
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.view.Display
 import android.view.View
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -22,8 +24,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.foundation.layout.offset
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
@@ -92,18 +99,33 @@ private fun ArtworkScreen(artworkBus: ArtworkBus) {
     // Live light/dark so the ambient gradient below re-themes when the user flips the setting,
     // without rebuilding the Presentation. AppTheme lives inside the observed scope for that reason.
     val darkMode by artworkBus.darkMode.collectAsState()
+    val settingsActive by artworkBus.settingsActive.collectAsState()
 
     AppTheme(darkMode = darkMode) {
         // Continue the app's ambient gradient onto this screen so both panels read as one surface,
         // instead of a flat black fill.
         AmbientBackground(Modifier.fillMaxSize()) {
-            when (state.mode) {
+            when {
+                // In the Settings area the top panel shows a gear over the gradient, not the last
+                // game's art — mirrors the gear the user just selected on the bottom screen.
+                settingsActive -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = null,
+                        // Pure black on light, pure white on dark, so the gear reads cleanly against
+                        // the ambient gradient in either theme.
+                        tint = if (darkMode) Color.White else Color.Black,
+                        modifier = Modifier.fillMaxSize(0.34f)
+                    )
+                }
+                else -> when (state.mode) {
                 // Game select + game detail: show the game's marquee (wheel-logo) art centred over
                 // the gradient, so the top panel reads as branded title art rather than a raw
                 // screenshot. Falls back to the game title text when no marquee is available.
                 ArtworkMode.GAME -> MarqueeArtwork(
                     marquee = marqueeImage(state.media),
                     title = state.title,
+                    darkMode = darkMode,
                     modifier = Modifier.fillMaxSize()
                 )
 
@@ -117,8 +139,9 @@ private fun ArtworkScreen(artworkBus: ArtworkBus) {
                         .padding(20.dp)
                 )
 
-                ArtworkMode.IDLE -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    BrandPlaceholder()
+                    ArtworkMode.IDLE -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        BrandPlaceholder()
+                    }
                 }
             }
         }
@@ -131,16 +154,54 @@ private fun ArtworkScreen(artworkBus: ArtworkBus) {
  * top panel never streams over the network (important on low-power/dual-screen).
  */
 @Composable
-private fun MarqueeArtwork(marquee: String?, title: String?, modifier: Modifier = Modifier) {
+private fun MarqueeArtwork(
+    marquee: String?,
+    title: String?,
+    darkMode: Boolean,
+    modifier: Modifier = Modifier
+) {
     Box(modifier.padding(32.dp), contentAlignment = Alignment.Center) {
         if (marquee != null) {
             // A local file when imported/cached, or a remote URL (small logo PNG) as a fallback.
             val data: Any = if (marquee.startsWith("http")) marquee else File(marquee)
+            val request = ImageRequest.Builder(LocalContext.current)
+                .data(data)
+                .crossfade(true)
+                .build()
+
+            // Shadow / glow: a blurred, tinted copy of the same logo drawn behind the crisp one, so
+            // the effect follows the logo's alpha shape rather than its bounding box. Light mode gets
+            // a soft dark drop shadow offset downward; dark mode gets a subtle centred outer glow.
+            // blur() is a no-op below API 31, so we skip the layer there to avoid a hard silhouette.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                if (darkMode) {
+                    AsyncImage(
+                        model = request,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        colorFilter = ColorFilter.tint(Color.White),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .blur(26.dp, BlurredEdgeTreatment.Unbounded)
+                            .alpha(0.30f)
+                    )
+                } else {
+                    AsyncImage(
+                        model = request,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        colorFilter = ColorFilter.tint(Color.Black),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .offset(y = 6.dp)
+                            .blur(14.dp, BlurredEdgeTreatment.Unbounded)
+                            .alpha(0.45f)
+                    )
+                }
+            }
+
             AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(data)
-                    .crossfade(true)
-                    .build(),
+                model = request,
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowRightAlt
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Group
@@ -451,14 +452,23 @@ fun HomeScreen(
                             val idx = if (state.layoutMode == LayoutMode.CAROUSEL) state.selectedGameIndex else gridFocusIndex
                             val hoveredGame = state.games.getOrNull(idx)
                             if (hoveredGame != null) {
+                                // Arrow as a vector Icon rather than a "→" glyph in the title text:
+                                // the Row centres it vertically, whereas the glyph sat low on the
+                                // text baseline and looked like it was resting on the bottom.
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.ArrowRightAlt,
+                                    contentDescription = null,
+                                    tint = BrandBlue,
+                                    modifier = Modifier.padding(horizontal = 6.dp).size(22.dp)
+                                )
                                 Text(
-                                    "  →  " + hoveredGame.title,
+                                    hoveredGame.title,
                                     fontSize = 17.sp,
                                     fontWeight = FontWeight.Medium,
                                     color = BrandBlue,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f).padding(start = 2.dp)
+                                    modifier = Modifier.weight(1f)
                                 )
                             } else {
                                 Spacer(Modifier.weight(1f))

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -320,13 +320,24 @@ class HomeViewModel @Inject constructor(
                 settingsRepository.gameSort
             ) { games, sort -> games.sortedBy(sort) }
                 .collect { games ->
-                    val firstMedia = _uiState.value.mediaForGames[games.firstOrNull()?.id]
                     _uiState.update { state ->
+                        // Preserve the current selection across re-emissions. Room re-queries this
+                        // flow whenever the games table changes — e.g. a favourite toggle or a
+                        // play-count/last-played bump after returning from a launched game — and a
+                        // blind reset to index 0 would snap the selection (and the top-screen marquee)
+                        // back to the first game. Re-find the selected game by id; only fall back to 0
+                        // when it's genuinely gone (platform switch, game removed).
+                        val previousId = state.games.getOrNull(state.selectedGameIndex)?.id
+                        val newIndex = previousId
+                            ?.let { id -> games.indexOfFirst { it.id == id } }
+                            ?.takeIf { it >= 0 }
+                            ?: 0
+                        val selectedGame = games.getOrNull(newIndex)
                         state.copy(
                             games             = games,
-                            selectedGameIndex = 0,
+                            selectedGameIndex = newIndex,
                             shouldPlayVideo   = false,
-                            selectedGameMedia = firstMedia
+                            selectedGameMedia = selectedGame?.let { g -> state.mediaForGames[g.id] }
                         )
                     }
                 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -69,9 +70,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -81,15 +85,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.platform.LocalContext
@@ -110,6 +118,7 @@ import com.gamelaunch.frontend.domain.sync.SyncReadiness
 import com.gamelaunch.frontend.ui.component.QrCode
 import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
+import com.gamelaunch.frontend.ui.input.GamepadA
 import com.gamelaunch.frontend.ui.input.GamepadL1
 import com.gamelaunch.frontend.ui.input.GamepadR1
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
@@ -122,6 +131,42 @@ import com.journeyapps.barcodescanner.ScanOptions
 import kotlin.math.roundToInt
 
 private val gradientBrush = Brush.horizontalGradient(listOf(ElectricBlue, NeonPurple))
+
+/**
+ * Holds the click action of whichever settings control currently has d-pad focus. Compose's
+ * [clickable] only self-activates on Enter / DPAD-center, not the gamepad **A** button
+ * (KEYCODE_BUTTON_A), so the screen-level key handler reads this to fire A on the focused control.
+ */
+private val LocalFocusedAction = compositionLocalOf<MutableState<(() -> Unit)?>> {
+    error("LocalFocusedAction not provided")
+}
+
+/**
+ * Turns a settings control into a d-pad focus target: draws a highlight ring while focused, registers
+ * its [onClick] so the screen's A-button handler can activate it, and keeps the ordinary touch click.
+ * Use this in place of [clickable] on interactive settings rows/chips/buttons.
+ */
+@Composable
+private fun Modifier.dpadFocusable(
+    enabled: Boolean = true,
+    shape: Shape = RoundedCornerShape(10.dp),
+    onClick: () -> Unit
+): Modifier {
+    if (!enabled) return this
+    val focusedAction = LocalFocusedAction.current
+    var focused by remember { mutableStateOf(false) }
+    return this
+        .onFocusChanged {
+            focused = it.isFocused
+            if (it.isFocused) focusedAction.value = onClick
+        }
+        .border(
+            width = if (focused) 2.dp else 0.dp,
+            color = if (focused) ElectricBlue else Color.Transparent,
+            shape = shape
+        )
+        .clickable(onClick = onClick)
+}
 
 private enum class SettingsTab(val label: String, val icon: ImageVector) {
     GENERAL("General", Icons.Default.Tune),
@@ -192,21 +237,38 @@ fun SettingsScreen(
         selectedTab = visibleTabs[(cur + delta + visibleTabs.size) % visibleTabs.size]
     }
 
-    val tabFocusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { runCatching { tabFocusRequester.requestFocus() } }
+    // D-pad navigation: focus is driven into the scrolling content (see the Column below), and this
+    // screen-level handler turns the d-pad into focus movement plus A-to-activate. focusedAction is
+    // the click of whatever control is focused, so A fires it (Compose's clickable ignores BUTTON_A).
+    val focusManager = LocalFocusManager.current
+    val contentFocus = remember { FocusRequester() }
+    val focusedAction = remember { mutableStateOf<(() -> Unit)?>(null) }
+
+    // On entry and on every tab switch, drop focus onto the first control of the (rebuilt) content.
+    LaunchedEffect(selectedTab) {
+        focusedAction.value = null
+        runCatching { contentFocus.requestFocus() }
+    }
 
     // Honour the user's light/dark choice for this screen's Material components.
     ThemedScreen {
+    CompositionLocalProvider(LocalFocusedAction provides focusedAction) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .focusRequester(tabFocusRequester)
-            .focusable()
             .onKeyEvent { event ->
                 if (event.type != KeyEventType.KeyDown) return@onKeyEvent false
                 when (event.key) {
                     GamepadL1 -> { cycleTab(-1); true }
                     GamepadR1 -> { cycleTab(+1); true }
+                    Key.DirectionDown  -> focusManager.moveFocus(FocusDirection.Down)
+                    Key.DirectionUp    -> focusManager.moveFocus(FocusDirection.Up)
+                    Key.DirectionLeft  -> focusManager.moveFocus(FocusDirection.Left)
+                    Key.DirectionRight -> focusManager.moveFocus(FocusDirection.Right)
+                    GamepadA, Key.DirectionCenter, Key.Enter -> {
+                        val action = focusedAction.value
+                        if (action != null) { action(); true } else false
+                    }
                     else -> false
                 }
             }
@@ -292,6 +354,10 @@ fun SettingsScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
+                        // Focus target for the screen: requesting this moves focus to the first
+                        // focusable control inside, and focusGroup keeps d-pad traversal contained.
+                        .focusRequester(contentFocus)
+                        .focusGroup()
                         .verticalScroll(rememberScrollState())
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -363,6 +429,7 @@ fun SettingsScreen(
     }
     }
     }
+    }
 
     if (state.showAndroidGameSelection) {
         AndroidGameSelectionDialog(state = state, viewModel = viewModel)
@@ -390,7 +457,7 @@ private fun SettingsTabBar(tabs: List<SettingsTab>, selected: SettingsTab, onSel
                         if (isSel) Modifier.background(gradientBrush)
                         else Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
                     )
-                    .clickable { onSelect(tab) }
+                    .dpadFocusable(shape = RoundedCornerShape(50)) { onSelect(tab) }
                     .padding(horizontal = 14.dp, vertical = 9.dp)
             ) {
                 Icon(
@@ -553,7 +620,7 @@ private fun SystemSortSection(state: SettingsUiState, viewModel: SettingsViewMod
                     .fillMaxWidth()
                     .padding(vertical = 5.dp)
                     .clip(RoundedCornerShape(10.dp))
-                    .clickable(enabled = !disabled) { viewModel.toggleSystemSort(sort) }
+                    .dpadFocusable(enabled = !disabled) { viewModel.toggleSystemSort(sort) }
                     .padding(vertical = 8.dp, horizontal = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -989,7 +1056,7 @@ private fun BackgroundModeChip(
                 if (selected) Modifier.background(gradientBrush)
                 else Modifier.background(MaterialTheme.colorScheme.surfaceVariant)
             )
-            .clickable(onClick = onClick),
+            .dpadFocusable(shape = RoundedCornerShape(21.dp), onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -1030,7 +1097,7 @@ private fun ThemeOption(
                 color = if (selected) accent else MaterialTheme.colorScheme.outline,
                 shape = RoundedCornerShape(14.dp)
             )
-            .clickable(onClick = onClick)
+            .dpadFocusable(shape = RoundedCornerShape(14.dp), onClick = onClick)
             .padding(8.dp)
     ) {
         // Mini UI mock-up: background, a top accent bar and three colourful tiles.
@@ -1104,7 +1171,7 @@ private fun RomLibrarySection(
                             .weight(1f)
                             .clip(RoundedCornerShape(10.dp))
                             .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .clickable { viewModel.setRomRootPath(path) }
+                            .dpadFocusable(shape = RoundedCornerShape(10.dp)) { viewModel.setRomRootPath(path) }
                             .padding(horizontal = 12.dp, vertical = 10.dp),
                         contentAlignment = Alignment.Center
                     ) {
@@ -1664,7 +1731,7 @@ private fun SegmentedTabs(
                     .weight(1f)
                     .clip(RoundedCornerShape(9.dp))
                     .then(if (isSel) Modifier.background(gradientBrush) else Modifier)
-                    .clickable { onSelect(i) }
+                    .dpadFocusable(shape = RoundedCornerShape(9.dp)) { onSelect(i) }
                     .padding(vertical = 9.dp),
                 contentAlignment = Alignment.Center
             ) {
@@ -1792,7 +1859,7 @@ private fun CardSwitchRow(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(8.dp))
-            .clickable { onCheckedChange(!checked) }
+            .dpadFocusable(shape = RoundedCornerShape(8.dp)) { onCheckedChange(!checked) }
             .padding(horizontal = 4.dp, vertical = 6.dp),
         verticalAlignment   = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
@@ -1832,7 +1899,7 @@ private fun GradientFillButton(
                     )
                 )
             )
-            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
+            .then(if (enabled) Modifier.dpadFocusable(shape = RoundedCornerShape(23.dp), onClick = onClick) else Modifier),
         contentAlignment = Alignment.Center
     ) {
         if (loading) {
@@ -1859,7 +1926,7 @@ private fun GradientOutlineButton(
             .height(46.dp)
             .clip(RoundedCornerShape(23.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
-            .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
+            .then(if (enabled) Modifier.dpadFocusable(shape = RoundedCornerShape(23.dp), onClick = onClick) else Modifier),
         contentAlignment = Alignment.Center
     ) {
         Text(


### PR DESCRIPTION
Dual-screen enhancements (all tested on the RG DS; top-screen visuals still to be eyeballed).

## Changes
- **Top-screen Settings gear** — pure black in light / pure white in dark, and slightly larger (28% → 34% of the panel).
- **Marquee shadow/glow** — the marquee logo now casts a shape-following effect: a soft dark drop shadow (offset down) in light mode, a subtle centred outer glow in dark mode. Drawn as a blurred, tinted copy behind the crisp logo so it follows the alpha shape rather than the bounding box; guarded to API 31+ so older devices just show the crisp logo.
- **Marquee reset fix** — the top-screen marquee no longer snaps back to the first game when you press a button on the detail page or return from a launched game. Root cause: `loadGamesForPlatform` reset `selectedGameIndex = 0` on *every* Room re-emission (a favourite toggle or play-count/last-played bump re-queries the table). It now re-finds the selected game by id and only falls back to 0 when it's genuinely gone.
- **D-pad navigable Settings** — controls show a focus ring, the d-pad moves focus, and **A** activates the focused control via a small focused-action registry (Compose's `clickable` ignores gamepad `BUTTON_A`). L1/R1 still switch tabs.
- **Breadcrumb arrow** — the game-grid breadcrumb `→` is now a vertically-centred vector icon instead of a low-sitting text glyph.

## Testing
- Built `assembleLiteDebug`, installed on the RG DS.
- Settings d-pad navigation + focus ring + A-to-activate confirmed on-device.

## Follow-ups (not in this PR)
- Folder-picker IconButtons and path text fields in Settings are reachable by d-pad but not yet A-activatable / focus-ringed.
- Top-screen items (gear, marquee shadow/glow, marquee-reset) need a visual confirm on the top panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)