### PR TITLE
Grid: fast-scroll section popup + hold-scroll blur

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/domain/model/GameSort.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/model/GameSort.kt
@@ -13,6 +13,36 @@ enum class GameSort(val label: String) {
     }
 }
 
+/**
+ * The section a game falls into under the given [sort] — a short "you are here" token for the
+ * fast-scroll indicator. It always matches the active order: an alphabetical letter for title
+ * order, a recency bucket for the time-based sorts, and a star for the favourites block. Adjacent
+ * games in the sorted list share a token, so scrolling shows the section sliding past.
+ */
+fun Game.sectionLabel(sort: GameSort, now: Long = System.currentTimeMillis()): String = when (sort) {
+    GameSort.ALPHABETICAL    -> alphaBucket(title)
+    GameSort.FAVORITES       -> if (isFavorite) "★" else alphaBucket(title)
+    GameSort.RECENTLY_PLAYED -> recencyBucket(lastPlayedMs, now, neverLabel = "Never")
+    GameSort.RECENTLY_ADDED  -> recencyBucket(dateAdded, now, neverLabel = "Older")
+}
+
+private fun alphaBucket(title: String): String {
+    val c = title.trimStart().firstOrNull() ?: '#'
+    return if (c.isLetter()) c.uppercaseChar().toString() else "#"
+}
+
+private fun recencyBucket(ts: Long?, now: Long, neverLabel: String): String {
+    if (ts == null || ts <= 0L) return neverLabel
+    val days = (now - ts).coerceAtLeast(0L) / 86_400_000L   // ms per day
+    return when {
+        days < 1L   -> "Today"
+        days < 7L   -> "This Week"
+        days < 30L  -> "This Month"
+        days < 365L -> "This Year"
+        else        -> "Older"
+    }
+}
+
 /** Apply a [GameSort] to a list of games. Ties fall back to title so the order is stable. */
 fun List<Game>.sortedBy(sort: GameSort): List<Game> = when (sort) {
     GameSort.ALPHABETICAL    -> sortedBy { it.title.lowercase() }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.R
+import com.gamelaunch.frontend.domain.model.GameSort
 import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.component.platformDisplayName
 import com.gamelaunch.frontend.ui.dualscreen.LocalDualScreenActive
@@ -549,6 +550,7 @@ fun HomeScreen(
                                     mediaForGames    = state.mediaForGames,
                                     focusedGameIndex = gridFocusIndex,
                                     onPageSizeChange = { gridPageSize = it },
+                                    gameSort         = state.gameSort,
                                     modifier         = Modifier.fillMaxSize()
                                 )
                             }
@@ -569,6 +571,9 @@ fun HomeScreen(
                                     columns            = recentGridColumns,
                                     mediaForGames      = state.mediaForGames,
                                     focusedGameIndex   = recentFocusIndex,
+                                    // The Recent tab is already in most-recently-played order, so the
+                                    // popup shows recency buckets (Today / This Week…).
+                                    gameSort           = GameSort.RECENTLY_PLAYED,
                                     uniformAspectRatio = 0.72f,
                                     modifier         = Modifier.fillMaxSize()
                                 )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -1,28 +1,58 @@
 package com.gamelaunch.frontend.ui.theme.grid
 
+import android.os.Build
+import android.os.SystemClock
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
+import com.gamelaunch.frontend.domain.model.GameSort
+import com.gamelaunch.frontend.domain.model.sectionLabel
 import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
+import com.gamelaunch.frontend.ui.perf.LocalReduceMotion
+import com.gamelaunch.frontend.ui.theme.IceWhite
+import com.gamelaunch.frontend.ui.theme.LocalDarkMode
+import com.gamelaunch.frontend.ui.theme.TileText
+import com.gamelaunch.frontend.ui.theme.glassChip
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+
+// How long a hold must be sustained before the section popup appears. Lite catches up more slowly,
+// so it earns the popup sooner; the smooth full build waits longer so quick nudges don't flash it.
+private const val HOLD_SHOW_MS_LITE = 250L
+private const val HOLD_SHOW_MS_FULL = 500L
+// Gaps larger than this between focus steps start a fresh hold (so separate presses don't accrue).
+private const val MAX_GAP_MS = 400L
+// Once the cursor has been still this long (and the grid has finished catching up), fade the popup.
+private const val HIDE_MS = 450L
 
 @Composable
 fun GridHomeContent(
@@ -32,6 +62,9 @@ fun GridHomeContent(
     mediaForGames: Map<Long, GameMedia> = emptyMap(),
     focusedGameIndex: Int = -1,
     onPageSizeChange: (Int) -> Unit = {},
+    // Drives the fast-scroll section popup ("A", "★", "This Week"…) so the token matches the order
+    // the games are actually in. Defaults to alphabetical.
+    gameSort: GameSort = GameSort.ALPHABETICAL,
     // When set, every tile uses this fixed aspect ratio instead of its system's box shape — used by
     // mixed-system lists (Recently played) so the grid stays a uniform rectangle.
     uniformAspectRatio: Float? = null,
@@ -65,6 +98,49 @@ fun GridHomeContent(
         }
     }
 
+    // ── Scroll section popup (+ blur) ────────────────────────────────────────────────────────
+    // Once a hold has been sustained past the show delay, show a big "you are here" section token —
+    // the letter/bucket the focused game sorts under — so the user can aim for a part of the list
+    // while the cards behind it are still catching up. On the low-power (lite) build we also blur the
+    // grid: the RK3568 can't repaint as fast as the cursor moves, so a hold-scroll otherwise shows
+    // half-decoded, popping cards — the blur masks that and buys the grid time to settle. A single
+    // nudge never raises it; it appears partway into a continuous hold (sooner on lite) and fades out
+    // once the cursor stops and the grid catches up. Draw-only overlay: it deliberately does not
+    // touch scroll mechanics or input handling (the source of the reverted double-move regression).
+    val reduceMotion = LocalReduceMotion.current
+    val showAfterMs = if (reduceMotion) HOLD_SHOW_MS_LITE else HOLD_SHOW_MS_FULL
+    var scrolling by remember { mutableStateOf(false) }
+    var lastChangeMs by remember { mutableLongStateOf(0L) }
+    var holdStartMs by remember { mutableLongStateOf(0L) }
+
+    LaunchedEffect(focusedGameIndex) {
+        if (focusedGameIndex < 0) return@LaunchedEffect
+        val now = SystemClock.uptimeMillis()
+        // A big gap (or the first move) begins a fresh hold; small gaps continue the current one.
+        if (now - lastChangeMs > MAX_GAP_MS) holdStartMs = now
+        lastChangeMs = now
+        // Reveal only once this hold has lasted long enough — so quick nudges stay hidden.
+        if (now - holdStartMs >= showAfterMs) scrolling = true
+        // This effect restarts on every move, so reaching past the delay means the cursor idled;
+        // then wait for the grid's scroll to land before hiding.
+        delay(HIDE_MS)
+        if (gridState.isScrollInProgress) {
+            snapshotFlow { gridState.isScrollInProgress }.first { !it }
+        }
+        scrolling = false
+    }
+
+    val blurRadius by animateDpAsState(
+        targetValue   = if (reduceMotion && scrolling) 14.dp else 0.dp,
+        animationSpec = tween(160),
+        label = "gridScrollBlur"
+    )
+    val indicatorAlpha by animateFloatAsState(
+        targetValue   = if (scrolling) 1f else 0f,
+        animationSpec = tween(140),
+        label = "gridScrollIndicator"
+    )
+
     // The entrance animation should fire once, when we load into a system — not every time a
     // card is recycled into view on scroll. Keep a short window open right after the games list
     // changes; cards composed during it animate, cards composed later appear instantly.
@@ -75,26 +151,69 @@ fun GridHomeContent(
         entranceWindowOpen = false
     }
 
-    LazyVerticalGrid(
-        columns               = GridCells.Fixed(columns),
-        state                 = gridState,
-        // Extra top padding so a focused top-row card (which scales 1.16× and bobs upward) clears
-        // the header instead of being clipped under it.
-        contentPadding        = PaddingValues(start = 8.dp, end = 8.dp, top = 30.dp, bottom = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement   = Arrangement.spacedBy(8.dp),
-        modifier              = modifier
-    ) {
-        itemsIndexed(games, key = { _, g -> g.id }) { index, game ->
-            GridGameCard(
-                game           = game,
-                index          = index,
-                media          = mediaForGames[game.id],
-                isFocused      = index == focusedGameIndex,
-                animateOnEntry = entranceWindowOpen,
-                aspectRatio    = uniformAspectRatio ?: boxArtAspectRatio(game.platformId),
-                onClick        = { onGameClick(game.id) }
+    Box(modifier.fillMaxSize()) {
+        LazyVerticalGrid(
+            columns               = GridCells.Fixed(columns),
+            state                 = gridState,
+            // Extra top padding so a focused top-row card (which scales 1.16× and bobs upward) clears
+            // the header instead of being clipped under it.
+            contentPadding        = PaddingValues(start = 8.dp, end = 8.dp, top = 30.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement   = Arrangement.spacedBy(8.dp),
+            modifier              = Modifier
+                .fillMaxSize()
+                // Modifier.blur no-ops on API < 31; the effect only runs where RenderEffect exists.
+                .then(if (Build.VERSION.SDK_INT >= 31) Modifier.blur(blurRadius) else Modifier)
+        ) {
+            itemsIndexed(games, key = { _, g -> g.id }) { index, game ->
+                GridGameCard(
+                    game           = game,
+                    index          = index,
+                    media          = mediaForGames[game.id],
+                    isFocused      = index == focusedGameIndex,
+                    animateOnEntry = entranceWindowOpen,
+                    aspectRatio    = uniformAspectRatio ?: boxArtAspectRatio(game.platformId),
+                    onClick        = { onGameClick(game.id) }
+                )
+            }
+        }
+
+        // Section token, sitting crisply on top of the (blurred) grid while scrolling.
+        if (indicatorAlpha > 0f) {
+            ScrollSectionIndicator(
+                label    = games.getOrNull(focusedGameIndex)?.sectionLabel(gameSort).orEmpty(),
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .graphicsLayer { alpha = indicatorAlpha }
             )
         }
+    }
+}
+
+/** Big frosted "you are here" token (a letter like "S", "★", or a short bucket like "This Week"). */
+@Composable
+private fun ScrollSectionIndicator(
+    label: String,
+    modifier: Modifier = Modifier
+) {
+    if (label.isBlank()) return
+    val dark = LocalDarkMode.current
+    val primary = if (dark) IceWhite else TileText
+    // Single letters/★ get the big splashy treatment; multi-word buckets shrink to fit on one line.
+    val fontSize = if (label.length <= 2) 60.sp else 30.sp
+    Box(
+        modifier = modifier
+            .glassChip(RoundedCornerShape(22.dp))
+            .defaultMinSize(minWidth = 104.dp, minHeight = 104.dp)
+            .padding(horizontal = 28.dp, vertical = 20.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text       = label,
+            color      = primary,
+            fontSize   = fontSize,
+            fontWeight = FontWeight.Bold,
+            maxLines   = 1
+        )
     }
 }


### PR DESCRIPTION
## What

While we work on the underlying grid scroll performance separately, this masks the lite-build jank with a **fast-scroll section popup** and a **hold-scroll blur**.

When a d-pad hold is sustained, the grid shows a big **"you are here" section token** — the letter/bucket the focused game sorts under — so you can aim for a part of the list while the cards behind it are still catching up. The token matches the **active sort**:

| Sort | Token |
|---|---|
| Alphabetical | First letter — `A`…`S`, `#` for non-letters |
| Favorites | `★` over the favorites block, then letters |
| Recently played / added | Recency bucket — `Today` / `This Week` / `This Month` / `This Year` / `Older` (`Never` for unplayed) |

On the **lite** build the grid also **blurs** while scrolling, so half-decoded, popping cards are hidden and the grid gets time to settle. Both the popup and blur lift once the cursor stops and the grid catches up.

## Timing — different per build

The popup appears once a hold has been **sustained** past a show-delay (a single tap never raises it). The delay differs by build:

- **Lite build: ~0.25s** — the low-power RK3568 grid lags more, so it earns the popup sooner.
- **Full build: ~0.5s** — smooth, so it waits longer and quick nudges don't flash it.

Tunables: `HOLD_SHOW_MS_LITE` (250) / `HOLD_SHOW_MS_FULL` (500), and the blur radius (`14.dp`) in `GridHomeContent`.

## Notes

- **Draw-only overlay** — it deliberately does not touch scroll mechanics or input handling, which is where the earlier double-move regression came from.
- Blur is gated to the lite build (`reduceMotion`) and no-ops below API 31.

## Files
- `GameSort.kt` — `Game.sectionLabel(sort)` for the popup token
- `GridHomeContent.kt` — sustained-hold detection, section popup, lite blur
- `HomeScreen.kt` — pass the active sort (and `RECENTLY_PLAYED` for the Recent tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)