### PR TITLE
Grid perf: fast-scroll mask + cut the real scroll cost underneath

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
@@ -9,16 +9,19 @@ import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.drawable.toBitmap
-import coil.compose.SubcomposeAsyncImage
+import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
 import coil.request.ImageRequest
-import java.io.File
 
 @Composable
 fun AsyncGameArtwork(
@@ -29,85 +32,86 @@ fun AsyncGameArtwork(
     contentScale: ContentScale = ContentScale.Crop,
     packageName: String? = null
 ) {
-    // Prefer a local file that actually exists; fall back to remote URL
-    val data = remember(localPath, remoteUrl) {
-        val file = localPath?.let { File(it) }
-        when {
-            file != null && file.exists() && file.length() > 0 -> file
-            remoteUrl != null -> remoteUrl
-            file != null -> file  // last resort: let Coil try (shows error if truly missing)
-            else -> null
-        }
-    }
+    // Prefer a local file, falling back to the remote URL. We deliberately do NOT probe the
+    // filesystem here (File.exists()/length()): that was main-thread I/O running on every tile
+    // (re)composition while scrolling, and boxArtLocalPath is only written to Room after a
+    // successful download, so a present-but-missing local file is a rare edge (e.g. the user
+    // cleared their media dir) that the error state below handles gracefully.
+    val data = remember(localPath, remoteUrl) { localPath ?: remoteUrl }
 
     // A stable, size-independent memory-cache key so a cover decoded once (e.g. prewarmed behind
     // the splash, or seen at a different tile size) is reused everywhere. Without this, Coil's
     // default key includes the request size, so the same art re-decodes per size and flashes the
     // grey placeholder before crossfading in.
-    val cacheKey = remember(data) {
-        when (data) {
-            is File   -> data.absolutePath
-            is String -> data
-            else      -> null
-        }
+    val context = LocalContext.current
+    val request = remember(data) {
+        ImageRequest.Builder(context)
+            .data(data)
+            .memoryCacheKey(data)
+            .crossfade(true)
+            .build()
     }
 
-    SubcomposeAsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(data)
-            .memoryCacheKey(cacheKey)
-            .crossfade(true)
-            .build(),
-        contentDescription = contentDescription,
-        contentScale = contentScale,
-        modifier = modifier,
-        loading = {
-            Box(
-                modifier = Modifier
+    // Plain AsyncImage (not SubcomposeAsyncImage): subcomposition per tile is a well-known
+    // LazyGrid scroll-jank source on weak hardware. We render the loading/error visuals from a
+    // lightweight onState-driven overlay instead of subcomposed slots — a single recomposition per
+    // tile on load, versus subcomposing every tile every frame.
+    var state by remember { mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty) }
+
+    Box(modifier) {
+        AsyncImage(
+            model              = request,
+            contentDescription = contentDescription,
+            contentScale       = contentScale,
+            modifier           = Modifier.fillMaxSize(),
+            onState            = { state = it }
+        )
+
+        when (state) {
+            is AsyncImagePainter.State.Success -> Unit  // art is drawn by AsyncImage
+            is AsyncImagePainter.State.Error   -> ArtworkFallback(packageName)
+            else -> Box(
+                Modifier
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.surfaceVariant)
             )
-        },
-        error = {
-            val context = LocalContext.current
-            val appIconBitmap = remember(packageName) {
-                if (packageName != null) {
-                    runCatching {
-                        context.packageManager.getApplicationIcon(packageName)
-                            .toBitmap(width = 144, height = 144)
-                            .asImageBitmap()
-                    }.getOrNull()
-                } else null
-            }
-
-            if (appIconBitmap != null) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Image(
-                        bitmap = appIconBitmap,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize(0.5f)
-                    )
-                }
-            } else {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        Icons.Default.SportsEsports,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
         }
-    )
+    }
+}
+
+/** Shown when box art fails to load: the app's launcher icon for Android apps, else a generic pad. */
+@Composable
+private fun ArtworkFallback(packageName: String?) {
+    val context = LocalContext.current
+    val appIconBitmap = remember(packageName) {
+        if (packageName != null) {
+            runCatching {
+                context.packageManager.getApplicationIcon(packageName)
+                    .toBitmap(width = 144, height = 144)
+                    .asImageBitmap()
+            }.getOrNull()
+        } else null
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center
+    ) {
+        if (appIconBitmap != null) {
+            Image(
+                bitmap = appIconBitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize(0.5f)
+            )
+        } else {
+            Icon(
+                Icons.Default.SportsEsports,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -21,6 +21,7 @@ import com.gamelaunch.frontend.ui.perf.PerformanceState
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -319,6 +321,10 @@ class HomeViewModel @Inject constructor(
                 gameRepository.getGamesByPlatform(platformId),
                 settingsRepository.gameSort
             ) { games, sort -> games.sortedBy(sort) }
+                // Sort a large library off the main thread. Room re-emits this flow on every games
+                // table change (favourite toggle, play-count/last-played bump), and sorting on Main
+                // was dropping frames on the lite build's RK3568.
+                .flowOn(Dispatchers.Default)
                 .collect { games ->
                     _uiState.update { state ->
                         // Preserve the current selection across re-emissions. Room re-queries this

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -53,7 +53,10 @@ fun GridGameCard(
     // Container shape. Defaults to the system's real box proportions; callers showing a mixed-system
     // list (e.g. Recently played) pass a fixed value to keep every tile the same rectangle.
     aspectRatio: Float = boxArtAspectRatio(game.platformId),
-    onClick: () -> Unit
+    // Stable click callback taking the game id. Kept as a (Long) -> Unit — rather than a pre-built
+    // () -> Unit — so the parent doesn't allocate a fresh lambda per item per recomposition, which
+    // would make this card un-skippable and recompose every visible tile on any media-map change.
+    onGameClick: (Long) -> Unit
 ) {
     val shape = RoundedCornerShape(12.dp)
 
@@ -108,7 +111,7 @@ fun GridGameCard(
             .fillMaxWidth()
             .aspectRatio(aspectRatio)
             .then(if (isFocused) Modifier.border(2.dp, ElectricBlue, shape) else Modifier)
-            .clickable(onClick = onClick)
+            .clickable { onGameClick(game.id) }
     ) {
         AsyncGameArtwork(
             localPath          = media?.boxArtLocalPath,

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -173,7 +173,9 @@ fun GridHomeContent(
                     isFocused      = index == focusedGameIndex,
                     animateOnEntry = entranceWindowOpen,
                     aspectRatio    = uniformAspectRatio ?: boxArtAspectRatio(game.platformId),
-                    onClick        = { onGameClick(game.id) }
+                    // Pass the stable callback straight through — the card builds its own click
+                    // lambda internally, so no per-item allocation happens here.
+                    onGameClick    = onGameClick
                 )
             }
         }


### PR DESCRIPTION
Improves game-grid performance on the lite build (target: the RG DS's RK3568), while keeping the fast-scroll mask intact. Two layers, in two commits:

## 1. Fast-scroll section popup + hold-scroll blur (`5ebd496`, was PR #58)
A draw-only overlay that masks lite-build grid jank during a sustained d-pad hold: a "you are here" section token (letter / bucket / ★) plus, on lite, a brief grid blur so half-decoded cards don't visibly pop while the grid catches up. Does not touch scroll mechanics or input handling.

## 2. Cut the real cost underneath the mask (`33e15ef`)
Reduces the underlying per-tile and per-emission work so there's less for the mask to hide — **scroll behaviour and the blur/popup are unchanged**.

- **`AsyncGameArtwork`** — `SubcomposeAsyncImage` → plain `AsyncImage` (removes per-tile subcomposition, a known LazyGrid scroll-jank source); loading/error visuals now come from a lightweight `onState` overlay. Also drops the main-thread `File.exists()/length()` probe that ran in composition on every (re)composed tile while scrolling.
- **`GridGameCard`** — takes a stable `onGameClick(Long)` instead of a per-item `onClick` lambda, so the card is now **`restartable skippable`** (verified via Compose compiler metrics) and unchanged tiles skip recomposition on media-map updates.
- **`HomeViewModel`** — sorts the library off the main thread (`flowOn(Default)`); Room re-emits on every favourite/play-count change and the sort was running on Main.

## Testing
- `assembleLiteDebug` + `assembleFullDebug` build clean.
- Compose compiler metrics confirm `GridGameCard` is `restartable skippable` with all-stable params.
- Installed `liteDebug` on the RG DS (RK3568) and hold-scrolled the grid: blur + section popup trigger as before, box art loads normally.

## Notes
- An earlier attempt also decoupled scroll from focus (instant `scrollToItem` + skip-if-visible). It made the grid scroll in chunks and feel slow, and undercut the fast-hold the overlay keys off of, so it was reverted — scroll mechanics are byte-for-byte the original.
- No release/version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)