### PR TITLE
Scope fast-scroll popup + blur to game-selection screens only

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -585,6 +585,7 @@ fun HomeScreen(
                                     onGameSelected    = viewModel::onGameSelected,
                                     onGameClick       = onGameClick,
                                     onMuteToggle      = viewModel::toggleMute,
+                                    gameSort          = state.gameSort,
                                     modifier          = Modifier.fillMaxSize(),
                                     showBackgroundArtwork = !dualScreen
                                 )
@@ -627,10 +628,10 @@ fun HomeScreen(
                                     columns            = recentGridColumns,
                                     mediaForGames      = state.mediaForGames,
                                     focusedGameIndex   = recentFocusIndex,
-                                    // The Recent tab is already in most-recently-played order, so the
-                                    // popup shows recency buckets (Today / This Week…).
                                     gameSort           = GameSort.RECENTLY_PLAYED,
                                     uniformAspectRatio = 0.72f,
+                                    // Home list, not a per-system library — no fast-scroll popup/blur.
+                                    sectionPopupEnabled = false,
                                     modifier         = Modifier.fillMaxSize()
                                 )
                             }
@@ -650,10 +651,10 @@ fun HomeScreen(
                                     columns            = recentGridColumns,
                                     mediaForGames      = state.mediaForGames,
                                     focusedGameIndex   = favFocusIndex,
-                                    // Favorites mix systems, so keep a uniform portrait tile and a
-                                    // star section token while fast-scrolling.
                                     gameSort           = GameSort.FAVORITES,
                                     uniformAspectRatio = 0.72f,
+                                    // Home list, not a per-system library — no fast-scroll popup/blur.
+                                    sectionPopupEnabled = false,
                                     modifier           = Modifier.fillMaxSize()
                                 )
                             }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/carousel/CarouselHomeContent.kt
@@ -34,11 +34,17 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
+import com.gamelaunch.frontend.domain.model.GameSort
+import com.gamelaunch.frontend.domain.model.sectionLabel
 import com.gamelaunch.frontend.ui.component.AsyncGameArtwork
+import com.gamelaunch.frontend.ui.component.ScrollSectionIndicator
 import com.gamelaunch.frontend.ui.component.VideoPlayer
+import com.gamelaunch.frontend.ui.component.rememberSectionIndicatorState
+import com.gamelaunch.frontend.ui.perf.LocalReduceMotion
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -53,6 +59,7 @@ fun CarouselHomeContent(
     onGameSelected: (Int) -> Unit,
     onGameClick: (Long) -> Unit,
     onMuteToggle: () -> Unit,
+    gameSort: GameSort = GameSort.ALPHABETICAL,
     modifier: Modifier = Modifier,
     // When false (dual-screen: artwork lives on the top panel), skip the full-screen video/art
     // backdrop and its darkening gradient here so the bottom panel is just the menu.
@@ -76,6 +83,15 @@ fun CarouselHomeContent(
     }
 
     val selectedGame = games.getOrNull(selectedIndex)
+
+    // The carousel is the one game-selection view that scrolls horizontally, so it's the sole place
+    // the fast-scroll section popup is allowed to appear on a horizontal scroll.
+    val reduceMotion = LocalReduceMotion.current
+    val section = rememberSectionIndicatorState(
+        focusedIndex = selectedIndex,
+        reduceMotion = reduceMotion,
+        isScrollInProgress = { listState.isScrollInProgress }
+    )
 
     Box(modifier = modifier) {
         // Background fill: video or stretched box art. On dual-screen devices this whole layer moves
@@ -196,6 +212,16 @@ fun CarouselHomeContent(
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text("No games found", color = Color.White, style = MaterialTheme.typography.titleMedium)
             }
+        }
+
+        // Fast-scroll "you are here" section token, centred while flicking through the carousel.
+        if (section.alpha > 0f) {
+            ScrollSectionIndicator(
+                label    = games.getOrNull(selectedIndex)?.sectionLabel(gameSort).orEmpty(),
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .graphicsLayer { alpha = section.alpha }
+            )
         }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -49,6 +49,9 @@ fun GridHomeContent(
     // When set, every tile uses this fixed aspect ratio instead of its system's box shape — used by
     // mixed-system lists (Recently played) so the grid stays a uniform rectangle.
     uniformAspectRatio: Float? = null,
+    // The fast-scroll section popup + hold-scroll blur only belong on the per-system game grid.
+    // The home lists (Recently played, Favorites) pass false so neither appears there.
+    sectionPopupEnabled: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     if (games.isEmpty()) {
@@ -89,8 +92,11 @@ fun GridHomeContent(
     // once the cursor stops and the grid catches up. Draw-only overlay: it deliberately does not
     // touch scroll mechanics or input handling (the source of the reverted double-move regression).
     val reduceMotion = LocalReduceMotion.current
+    // Arm the popup on VERTICAL movement only: key it on the focused row, so nudging left/right
+    // within a row doesn't raise it. When disabled (home lists) pass -1 so it never arms.
+    val armRow = if (sectionPopupEnabled && focusedGameIndex >= 0) focusedGameIndex / columns else -1
     val section = rememberSectionIndicatorState(
-        focusedIndex = focusedGameIndex,
+        focusedIndex = armRow,
         reduceMotion = reduceMotion,
         isScrollInProgress = { gridState.isScrollInProgress }
     )


### PR DESCRIPTION
## Summary

Tightens where the fast-scroll section popup (and its hold-scroll blur) can appear. Follow-up to #60.

Before, the popup showed on any focus change — including left/right nudges and on the home lists. Now:

- **Grid (in a system):** armed on **vertical scrolling only** — keyed on the focused *row* instead of the raw index, so moving left/right within a row no longer raises the popup/blur.
- **Carousel (in a system):** the only game-selection view that scrolls horizontally, so it's the deliberate exception — it now shows the section token while flicking through (keyed on the selected index). No blur (it has its own backdrop).
- **List (in a system):** unchanged — already vertical-only.
- **Favorites & Recently Played:** new `sectionPopupEnabled = false` — no popup, no blur on these home lists.
- **Apps:** never had them.

Net: no popup on horizontal scrolling except the game-selection carousel, and nothing on the Favorites / Recent / Apps home pages.

## Testing
- `./gradlew clean :app:installLiteDebug` builds clean; installed and launched on the RG DS with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
