### PR TITLE
This change replaces the old Xenia Android support with Xeo (org.adars.xeo) across the application components (launcher, save location registry, definitions, package queries). It also adds 32-bit ARM architecture support for the syncthing daemon alongside the existing 64-bit support, and adds the @OptIn FlowPreview annotation in HomeScreen.kt to address the compilation warning.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,28 +178,36 @@ val syncthingVersion = "1.28.1"
 val syncthingJniDir = layout.buildDirectory.dir("syncthing-jni").get().asFile
 
 val fetchSyncthing = tasks.register("fetchSyncthing") {
-    // Capture everything into task-local vals at configuration time so the action closure holds no
-    // references to script objects (required by the Gradle configuration cache).
-    val out = File(syncthingJniDir, "arm64-v8a/libsyncthing.so")
+    val outDir = syncthingJniDir
     val url = "https://github.com/syncthing/syncthing-android/releases/download/$syncthingVersion/app-release.apk"
     val version = syncthingVersion
     val tmpDir = temporaryDir
-    outputs.file(out)
+    outputs.dir(outDir)
     doLast {
-        if (out.exists() && out.length() > 1_000_000L) return@doLast
-        out.parentFile.mkdirs()
+        val outArm64 = File(outDir, "arm64-v8a/libsyncthing.so")
+        val outArmeabiV7a = File(outDir, "armeabi-v7a/libsyncthing.so")
+        val outArmeabi = File(outDir, "armeabi/libsyncthing.so")
+        if (outArm64.exists() && outArmeabiV7a.exists() && outArmeabi.exists() &&
+            outArm64.length() > 1_000_000L && outArmeabiV7a.length() > 1_000_000L && outArmeabi.length() > 1_000_000L) return@doLast
+
+        outArm64.parentFile.mkdirs()
+        outArmeabiV7a.parentFile.mkdirs()
+        outArmeabi.parentFile.mkdirs()
         val apk = File(tmpDir, "syncthing-android.apk")
-        // temporaryDir is captured at configuration time; a preceding `clean` in the same
-        // invocation deletes it, so recreate it before writing the downloaded APK.
         apk.parentFile.mkdirs()
         println("Fetching Syncthing $version daemon…")
         URL(url).openStream().use { input -> apk.outputStream().use { output -> input.copyTo(output) } }
         ZipFile(apk).use { zip ->
-            val entry = zip.getEntry("lib/arm64-v8a/libsyncthing.so")
-                ?: error("libsyncthing.so not found in $url")
-            zip.getInputStream(entry).use { input -> out.outputStream().use { output -> input.copyTo(output) } }
+            val entry64 = zip.getEntry("lib/arm64-v8a/libsyncthing.so")
+                ?: error("arm64-v8a libsyncthing.so not found in $url")
+            zip.getInputStream(entry64).use { input -> outArm64.outputStream().use { output -> input.copyTo(output) } }
+
+            val entryArm = zip.getEntry("lib/armeabi/libsyncthing.so")
+                ?: error("armeabi libsyncthing.so not found in $url")
+            zip.getInputStream(entryArm).use { input -> outArmeabiV7a.outputStream().use { output -> input.copyTo(output) } }
+            zip.getInputStream(entryArm).use { input -> outArmeabi.outputStream().use { output -> input.copyTo(output) } }
         }
-        println("Syncthing daemon ready (${out.length()} bytes)")
+        println("Syncthing daemon ready for ARM (arm64-v8a and armeabi-v7a/armeabi)")
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
         <!-- Other -->
         <package android:name="ru.playsoftware.j2meloader" />
         <!-- Xbox 360 -->
-        <package android:name="com.xenia.android" />
+        <package android:name="org.adars.xeo" />
     </queries>
 
     <application

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
@@ -217,7 +217,7 @@ object PlatformDefinitions {
             id = "xbox360", displayName = "Xbox 360", scraperSystemId = 33,
             extensions = listOf(".iso", ".xex", ".stfs"),
             folderNames = listOf("xbox360", "Xbox 360", "x360", "360"),
-            defaultEmulatorPackage = "com.xenia.android"
+            defaultEmulatorPackage = "org.adars.xeo"
         ),
         Platform(
             id = "c64", displayName = "Commodore 64", scraperSystemId = 66,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/sync/SaveLocationRegistry.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/sync/SaveLocationRegistry.kt
@@ -132,8 +132,8 @@ object SaveLocationRegistry {
             note = "Saves in Android/data — not directly syncable on this Android version."
         ),
         EmulatorSaveSpec(
-            packages = listOf("com.xenia.android"),
-            displayName = "Xenia (Xbox 360)",
+            packages = listOf("org.adars.xeo"),
+            displayName = "Xeo (Xbox 360)",
             storageClass = SaveStorageClass.APP_PRIVATE,
             note = "Saves in Android/data — not directly syncable on this Android version."
         ),

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
@@ -220,9 +220,9 @@ class EmulatorLauncher @Inject constructor(
         "dev.eden.emulator"       to LaunchSpec("org.yuzu.yuzu_emu.activities.EmulationActivity"),
         "org.yuzu.yuzu_emu"       to LaunchSpec("org.yuzu.yuzu_emu.activities.EmulationActivity"),
         "org.sudachi.sudachi_emu" to LaunchSpec("org.sudachi.sudachi_emu.activities.EmulationActivity"),
-        // Xbox 360 — Xenia Android accepts VIEW intent with scheme="file" and mimeType="application/octet-stream"
-        "com.xenia.android"       to LaunchSpec(
-            activity = "com.xenia.android.ui.MainActivity",
+        // Xbox 360 — Xeo accepts VIEW intent with scheme="file" and mimeType="application/octet-stream"
+        "org.adars.xeo"           to LaunchSpec(
+            activity = "org.adars.xeo.ui.MainActivity",
             action = Intent.ACTION_VIEW,
             mimeType = "application/octet-stream"
         ),

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
@@ -62,7 +62,7 @@ class PackageManagerHelper @Inject constructor(
         "com.saber.gamehub"                  to "GameHub",
         // Other
         "ru.playsoftware.j2meloader"         to "J2ME Loader",
-        "com.xenia.android"                  to "Xenia (Xbox 360)",
+        "org.adars.xeo"                      to "Xeo (Xbox 360)",
         // Frontends & Launchers
         "org.es_de.frontend"                 to "ES-DE (Frontend)",
         "com.magneticchen.daijishou"         to "Daijishō (Frontend)",
@@ -113,7 +113,7 @@ class PackageManagerHelper @Inject constructor(
         "wiiu"      to listOf("info.cemu.cemu", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "psvita"    to listOf("org.vita3k.emulator"),
         "steam"     to listOf("com.gamenative.android", "com.saber.gamehub", "com.valvesoftware.steamlink"),
-        "xbox360"   to listOf("com.xenia.android")
+        "xbox360"   to listOf("org.adars.xeo")
     )
 
     fun getInstalledEmulators(): List<InstalledEmulator> {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -100,6 +100,7 @@ import com.gamelaunch.frontend.ui.screen.retroachievements.RetroAchievementsScre
 // Carousel has no grid to report a screenful, so bumper page-jumps there step a fixed stride.
 private const val CAROUSEL_PAGE = 10
 
+@OptIn(kotlinx.coroutines.FlowPreview::class)
 @Composable
 fun HomeScreen(
     onGameClick: (Long) -> Unit,


### PR DESCRIPTION
This change replaces the old Xenia Android support with Xeo (org.adars.xeo) across the application components (launcher, save location registry, definitions, package queries). It also adds 32-bit ARM architecture support for the syncthing daemon alongside the existing 64-bit support, and adds the @OptIn FlowPreview annotation in HomeScreen.kt to address the compilation warning.

