### PR TITLE
Soften the fast-scroll overlay (later popup, lighter blur)

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/SectionScrollIndicator.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/SectionScrollIndicator.kt
@@ -26,10 +26,13 @@ import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassChip
 import kotlinx.coroutines.delay
 
-// How long a hold must be sustained before the section popup appears. Lite catches up more slowly,
-// so it earns the popup sooner; the smooth full build waits longer so quick nudges don't flash it.
-private const val HOLD_SHOW_MS_LITE = 250L
-private const val HOLD_SHOW_MS_FULL = 500L
+// How long a continuous hold must be sustained before the section popup (and, on lite, the grid
+// blur) appears. Both builds now wait the same, longer beat: the popup is a power-scroll aid, so it
+// should only surface once the user is clearly holding through the list — not on a few quick nudges.
+// (Lite used to appear sooner to mask its laggy grid; lite scroll is on par with full now.) Kept as
+// two constants so the lite delay can diverge again if needed.
+private const val HOLD_SHOW_MS_LITE = 900L
+private const val HOLD_SHOW_MS_FULL = 900L
 // Gaps larger than this between focus steps start a fresh hold (so separate presses don't accrue).
 private const val MAX_GAP_MS = 400L
 // Once the cursor has been still this long (and the list has finished catching up), fade the popup.

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -103,7 +103,7 @@ fun GridHomeContent(
     val indicatorAlpha = section.alpha
 
     val blurRadius by animateDpAsState(
-        targetValue   = if (reduceMotion && section.active) 14.dp else 0.dp,
+        targetValue   = if (reduceMotion && section.active) 4.dp else 0.dp,
         animationSpec = tween(160),
         label = "gridScrollBlur"
     )

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/list/ListHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/list/ListHomeContent.kt
@@ -121,7 +121,7 @@ fun ListHomeContent(
     // On the low-power build, blur the list while fast-scrolling so the right-hand box art (which
     // reloads on every focus step) doesn't visibly pop — the crisp section token stays on top.
     val blurRadius by animateDpAsState(
-        targetValue   = if (reduceMotion && section.active) 14.dp else 0.dp,
+        targetValue   = if (reduceMotion && section.active) 4.dp else 0.dp,
         animationSpec = tween(160),
         label = "listScrollBlur"
     )


### PR DESCRIPTION
## Summary

Follow-up feel tweaks to the fast-scroll "you are here" section popup and its hold-scroll blur, now that lite scroll performs on par with the full build.

- **Popup/blur appears later** — raise the hold-before-show delay to **900ms** on both builds (was 250ms lite / 500ms full). The overlay now only surfaces during a clearly sustained power-scroll, not on a few quick d-pad nudges. (The lite build used to show it sooner to mask its laggy grid; that's no longer needed.)
- **Blur is barely visible** — drop the lite hold-scroll blur radius **14dp → 4dp** in both the grid and list layouts, so it's a faint softening instead of a heavy blur.

Both are gated exactly as before (`reduceMotion && section.active`), so full-build behavior is unchanged except for the shared 900ms delay.

## Testing

- Built & installed the lite release APK on the RG DS: popup/blur hold off until a sustained hold, and the blur is now subtle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)