### PR TITLE
Fix game-launch crash under R8: keep Gson TypeToken signatures; bump …

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 36
-        versionName = "2.4.0"
+        versionCode = 37
+        versionName = "2.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,3 +3,10 @@
 -keepattributes *Annotation*
 -dontwarn okhttp3.**
 -dontwarn retrofit2.**
+
+# Gson: under R8 full mode (AGP 8 default) -keepattributes Signature alone does NOT stop the type
+# argument being stripped from anonymous TypeToken subclasses, which throws at runtime
+# ("TypeToken must be created with a type argument"). These are Gson's official R8 rules and are
+# needed by the TypeToken<Map<String,String>>(){} usages in EmulatorRepositoryImpl and Converters.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken


### PR DESCRIPTION
…to 2.4.1

Launching a game crashed the release build with "TypeToken must be created with a type argument" — under R8 full mode (AGP 8 default), -keepattributes Signature alone doesn't stop the type argument being stripped from anonymous TypeToken subclasses (EmulatorRepositoryImpl, Converters). Add Gson's official R8 keep rules for TypeToken subclasses. Release-only; debug was unaffected.