### PR TITLE
README: add live total-downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 **eOr** — short for *emulation, organized* — is a fast, gorgeous game launcher for Android handhelds and phones. Point it at your ROMs, let it pull box art, screenshots and video previews automatically, and launch straight into your emulators — all wrapped in a polished, controller-first interface.
 
 [![Latest release](https://img.shields.io/github/v/release/keweis2/eOr?style=flat-square&color=4D7FFF)](https://github.com/keweis2/eOr/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/keweis2/eOr/total?style=flat-square&color=8B5CF6&label=downloads)](https://github.com/keweis2/eOr/releases)
 [![Platform](https://img.shields.io/badge/platform-Android%208.0%2B-3DDC84?style=flat-square&logo=android&logoColor=white)](#requirements)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 


### PR DESCRIPTION
Adds a live [shields.io](https://shields.io) total-downloads badge to the README badge row (matches the existing flat-square style), summing `download_count` across all release APKs and updating automatically.

`![Downloads](https://img.shields.io/github/downloads/keweis2/eOr/total?style=flat-square&color=8B5CF6&label=downloads)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)