### PR TITLE
fix(launcher): guard preferred-intent construction against FileProvider failure

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
@@ -120,22 +120,26 @@ class EmulatorLauncher @Inject constructor(
         // Preferred path: each known emulator has a verified launch recipe (explicit activity +
         // either a ROM path extra or a file:// data URI).
         if (spec != null) {
-            val intent = Intent(spec.action).apply {
-                setClassName(pkg, spec.activity)
-                if (spec.romExtraKey != null) {
-                    // ROM handed over as a plain path string — no Uri, nothing to expose.
-                    putExtra(spec.romExtraKey, game.romPath)
-                } else {
-                    setDataAndType(romUriFor(spec.romUriMode, file), spec.mimeType)
+            // Build inside the runCatching so a failure to construct the intent (e.g. FileProvider
+            // can't represent the ROM path) falls back like a failed launch instead of crashing —
+            // every other launch path is already guarded this way. If the explicit activity is
+            // unavailable, try a package-targeted VIEW intent before opening the emulator's game list.
+            return runCatching {
+                val intent = Intent(spec.action).apply {
+                    setClassName(pkg, spec.activity)
+                    if (spec.romExtraKey != null) {
+                        // ROM handed over as a plain path string — no Uri, nothing to expose.
+                        putExtra(spec.romExtraKey, game.romPath)
+                    } else {
+                        setDataAndType(romUriFor(spec.romUriMode, file), spec.mimeType)
+                    }
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    grantRomReadPermissionIfNeeded()
+                    mapping.intentExtras.forEach { (k, v) -> putExtra(k, v) }
                 }
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                grantRomReadPermissionIfNeeded()
-                mapping.intentExtras.forEach { (k, v) -> putExtra(k, v) }
+                context.startActivity(intent, options)
             }
-            // If the explicit activity is unavailable, try a package-targeted VIEW intent before
-            // falling back to the emulator's game list.
-            return tryStartActivity(intent, options)
                 .recoverCatching {
                     context.startActivity(fallbackViewIntent(pkg, file, mapping, spec.romUriMode), options)
                 }


### PR DESCRIPTION
## What

Follow-up to #68. The preferred standalone launch path in `EmulatorLauncher.launchStandalone` constructed its `Intent` **before** the `runCatching` guard:

```kotlin
val intent = Intent(spec.action).apply {
    ...
    setDataAndType(romUriFor(spec.romUriMode, file), spec.mimeType) // can throw
}
return tryStartActivity(intent, options)  // guard starts here
```

`romUriFor` calls `FileProvider.getUriForFile`, which can throw `IllegalArgumentException` for a path it can't represent. Because construction sat outside the guard, that would crash the launch — whereas every other path (`fallbackViewIntent`, `openAppIntent`) is already wrapped in `runCatching`/`recoverCatching` and degrades gracefully to a package-targeted VIEW intent and ultimately the emulator's own game list.

## Change

Move the intent build inside the `runCatching` so a construction failure recovers into the same fallback chain instead of propagating. Behavior on the success path is unchanged; `tryStartActivity` remains in use by the other three launch paths.

Compiles clean (`:app:compileFullDebugKotlin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)