### PR TITLE
fix(settings): stop auto-focusing first control on tab open

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -244,10 +244,12 @@ fun SettingsScreen(
     val contentFocus = remember { FocusRequester() }
     val focusedAction = remember { mutableStateOf<(() -> Unit)?>(null) }
 
-    // On entry and on every tab switch, drop focus onto the first control of the (rebuilt) content.
+    // Clear any carried-over activation action when the tab changes. We intentionally do NOT
+    // auto-request focus into the content on entry/tab-switch: when the first control is a text
+    // field that pops the soft keyboard on handhelds and makes the screen un-navigable. The d-pad
+    // still grabs focus via moveFocus on the first directional press.
     LaunchedEffect(selectedTab) {
         focusedAction.value = null
-        runCatching { contentFocus.requestFocus() }
     }
 
     // Honour the user's light/dark choice for this screen's Material components.


### PR DESCRIPTION
## Problem

The d-pad settings work (commit `e9bb575`) auto-requested focus into the tab content on entry and on every tab switch:

```kotlin
LaunchedEffect(selectedTab) {
    focusedAction.value = null
    runCatching { contentFocus.requestFocus() }
}
```

When the first focusable control on a tab is a text field, requesting focus pops the soft keyboard on handhelds (e.g. Retroid Pocket), which covers the screen and hijacks d-pad input — making the settings screen un-navigable.

## Fix

Drop the auto-request. Settings now opens with nothing pre-selected; the d-pad grabs focus via `focusManager.moveFocus` on the first directional press, which is the pre-existing "normal" behavior. The `focusedAction` reset on tab change is kept so a stale activation action doesn't linger from the previous tab. The `contentFocus` `FocusRequester` wiring stays in place so a smarter (text-field-aware) auto-focus can be reintroduced later.

## Testing

Built `assembleFullRelease` (minified, R8 full mode) and installed on a Retroid Pocket 4 Pro. Settings launches clean, no soft keyboard on tab open, d-pad navigation works across tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)