### PR TITLE
release: 2.4.2 — Eden support + launch/settings fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ System console icons are from **[retro-game-console-icons](https://github.com/Ky
 Thanks to everyone who has helped improve eOr:
 
 - **[@aarvsn](https://github.com/aarvsn)** — database cleanup, emulator-mapping, and scanner fixes ([#41](https://github.com/keweis2/eOr/pull/41)); **Xbox 360 (Xenia) integration** ([#56](https://github.com/keweis2/eOr/pull/56))
+- **[@picodspi](https://github.com/picodspi)** — **Eden (Switch) support** — FileProvider content-URI launching plus update/DLC/firmware scan filtering ([#68](https://github.com/keweis2/eOr/pull/68))
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 37
-        versionName = "2.4.1"
+        versionCode = 38
+        versionName = "2.4.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Release prep for **v2.4.2**.

- Bump `versionCode` 37 → 38, `versionName` 2.4.1 → 2.4.2
- Credit **@picodspi** for the Eden (Switch) support in the README contributors list

Ships the work already merged to `main`:
- #68 — Eden (Switch) support (@picodspi)
- #69 — launcher FileProvider guard
- #70 — settings auto-focus fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)