### PR TITLE
perf(nsp): invalidate prod.keys cache at scan start instead of TTL

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ProdKeysLocator.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ProdKeysLocator.kt
@@ -19,40 +19,32 @@ class ProdKeysLocator @Inject constructor(
 ) {
     private val cacheLock = Any()
     @Volatile private var cache: List<File>? = null
-    @Volatile private var cacheComputedAt = 0L
 
     /**
      * Every usable key file found on the storage volumes. The caller validates it against the
      * package being opened, so a stale emulator key file cannot mask a current one.
      *
-     * The result is materialised and memoised for [CACHE_TTL_MS]: the underlying search walks the
-     * entire internal-storage and SD-card trees, and a library scan asks for keys once per NSP.
-     * Without the cache that full walk would run once for every NSP on every scan — including the
-     * common no-keys case, where the walk still has to complete to prove the result is empty.
+     * The completed search is materialised and memoised: it walks the entire internal-storage and
+     * SD-card trees, and a library scan asks for keys once per NSP. Without the cache that full
+     * walk would run once for every NSP on every scan — including the common no-keys case, where
+     * the walk still has to complete to prove the result is empty. Call [invalidate] at the start
+     * of a scan so keys the user added since the last scan are picked up.
      */
     fun findAll(): Sequence<File> {
-        cache?.let { if (System.currentTimeMillis() - cacheComputedAt < CACHE_TTL_MS) return it.asSequence() }
+        cache?.let { return it.asSequence() }
         return synchronized(cacheLock) {
-            val existing = cache
-            if (existing != null && System.currentTimeMillis() - cacheComputedAt < CACHE_TTL_MS) {
-                existing
-            } else {
-                findAllInRoots(
-                    StorageUtils.getStorageVolumes(context).map { (_, rootPath) -> File(rootPath) }
-                ).toList().also {
-                    cache = it
-                    cacheComputedAt = System.currentTimeMillis()
-                }
-            }
+            cache ?: findAllInRoots(
+                StorageUtils.getStorageVolumes(context).map { (_, rootPath) -> File(rootPath) }
+            ).toList().also { cache = it }
         }.asSequence()
     }
 
-    internal companion object {
-        /** How long a completed key search is reused. Long enough that a single library scan walks
-         * storage once instead of once per NSP; short enough that keys added between scans are
-         * picked up on the next scan. */
-        const val CACHE_TTL_MS = 60_000L
+    /** Drops the memoised result so the next [findAll] re-walks storage. Called at scan start. */
+    fun invalidate() {
+        cache = null
+    }
 
+    internal companion object {
         /** Searches every readable directory below the supplied storage roots, without assuming
          * an emulator name or a particular folder layout. */
         fun findAllInRoots(roots: List<File>): Sequence<File> = roots

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -26,7 +26,8 @@ class ScanRomsUseCase @Inject constructor(
     private val gameRepository: GameRepository,
     private val platformDetector: PlatformDetector,
     private val settingsRepository: SettingsRepository,
-    private val importEmbeddedArtwork: ImportEmbeddedArtworkUseCase
+    private val importEmbeddedArtwork: ImportEmbeddedArtworkUseCase,
+    private val prodKeysLocator: ProdKeysLocator
 ) {
     private val skipExtensions = setOf(
         ".txt", ".xml", ".nfo", ".jpg", ".png", ".mp4", ".rar",
@@ -45,6 +46,11 @@ class ScanRomsUseCase @Inject constructor(
     )
 
     operator fun invoke(rootPath: String): Flow<ScanProgress> = flow {
+        // Refresh the prod.keys search once per scan. The locator memoises its (expensive) storage
+        // walk so it runs once for the whole scan rather than once per NSP; invalidating here keeps
+        // that cache from hiding a key file the user added since the previous scan.
+        prodKeysLocator.invalidate()
+
         val resolvedPath = StorageUtils.resolveStoredPath(rootPath)
         val rootDir = File(resolvedPath)
         if (!rootDir.exists() || !rootDir.isDirectory) {

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.gamelaunch.frontend.domain.platform.PlatformDetector
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.domain.usecase.ImportEmbeddedArtworkUseCase
+import com.gamelaunch.frontend.domain.usecase.ProdKeysLocator
 import com.gamelaunch.frontend.domain.usecase.ScanRomsUseCase
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -33,13 +34,14 @@ class ScanRomsUseCaseTest {
     private val gameRepository: GameRepository = mock()
     private val settingsRepository: SettingsRepository = mock()
     private val importEmbeddedArtwork: ImportEmbeddedArtworkUseCase = mock()
+    private val prodKeysLocator: ProdKeysLocator = mock()
     private val platformDetector = PlatformDetector()
     private lateinit var useCase: ScanRomsUseCase
 
     @Before fun setup() {
         whenever(settingsRepository.excludedPaths).thenReturn(flowOf(emptySet()))
         useCase = ScanRomsUseCase(
-            gameRepository, platformDetector, settingsRepository, importEmbeddedArtwork
+            gameRepository, platformDetector, settingsRepository, importEmbeddedArtwork, prodKeysLocator
         )
     }
 
@@ -47,6 +49,17 @@ class ScanRomsUseCaseTest {
         val results = useCase("/nonexistent/path").toList()
         assertEquals(1, results.size)
         assertTrue(results[0].currentFile.startsWith("Root folder not found"))
+    }
+
+    @Test fun `refreshes the prod keys cache at the start of a scan`() = runTest {
+        val nesDir = tmpFolder.newFolder("NES")
+        File(nesDir, "mario.nes").createNewFile()
+        whenever(gameRepository.insertGame(any())).thenReturn(1L)
+        whenever(gameRepository.deleteGamesNotInPaths(any())).thenReturn(0)
+
+        useCase(tmpFolder.root.absolutePath).toList()
+
+        verify(prodKeysLocator).invalidate()
     }
 
     @Test fun `detects nes roms in NES subfolder`() = runTest {


### PR DESCRIPTION
## Missing piece of #73

PR #73 was merged at its first commit (the time-based cache), so `main` currently memoizes the `prod.keys` storage walk with a **60s TTL**. The follow-up commit that replaced the TTL with **explicit invalidation at scan start** landed on the branch after the merge commit was cut, so it never reached `main`. This PR brings just that delta in.

## Change
- **`ProdKeysLocator`**: memoize the completed storage walk until `invalidate()` is called; drop the 60s TTL and its timestamp bookkeeping.
- **`ScanRomsUseCase`**: call `prodKeysLocator.invalidate()` at the start of each scan (adds `ProdKeysLocator` as a dependency).

### Why explicit invalidation over the TTL
Both collapse the per-NSP storage walk into one walk per scan. The difference is freshness: with the TTL, a `prod.keys` the user adds right after a scan isn't seen until the window expires; invalidating at scan start means the walk runs exactly once per scan and always with a current view — the newly added key is picked up on the very next scan, with no time-window staleness.

No change to artwork output; `findAll()` still returns `Sequence<File>`.

## Testing
`:app:testFullDebugUnitTest` green for `ProdKeysLocatorTest`, `ScanRomsUseCaseTest` (incl. a new test asserting the scan invalidates the key cache), `NspArtworkExtractorTest`, and `ImportEmbeddedArtworkUseCaseTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)