### PR TITLE
Harden home-launcher navigation reset (PR #76 review follow-up)

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.rememberNavController
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -223,13 +224,23 @@ class MainActivity : ComponentActivity() {
                             navController    = navController,
                             startDestination = startDestination
                         )
-                        LaunchedEffect(navController, homeNavigationRequest.value) {
-                            if (homeNavigationRequest.value > 0 &&
-                                navController.currentDestination?.route != Screen.Home.route
-                            ) {
-                                navController.navigate(Screen.Home.route) {
-                                    popUpTo(0) { inclusive = true }
+                        LaunchedEffect(navController, homeNavigationRequest.intValue) {
+                            if (homeNavigationRequest.intValue > 0) {
+                                // Don't yank a first-launch user out of onboarding, and don't
+                                // navigate when already at the library root.
+                                val current = navController.currentDestination?.route
+                                if (current != Screen.Home.route &&
+                                    current != Screen.Onboarding.route
+                                ) {
+                                    navController.navigate(Screen.Home.route) {
+                                        popUpTo(navController.graph.findStartDestination().id) {
+                                            inclusive = true
+                                        }
+                                    }
                                 }
+                                // Consume the request so a later recomposition that re-subscribes
+                                // this effect can't replay the navigation.
+                                homeNavigationRequest.intValue = 0
                             }
                         }
                         // Tell the artwork (top) screen when we're in the Settings area, so it shows
@@ -419,7 +430,7 @@ class MainActivity : ComponentActivity() {
         setIntent(intent)
         handleFriendDeepLink(intent)
         if (intent.action == Intent.ACTION_MAIN && intent.hasCategory(Intent.CATEGORY_HOME)) {
-            homeNavigationRequest.value++
+            homeNavigationRequest.intValue++
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -202,11 +202,11 @@ fun SettingsScreen(
     val storageVolumes = remember { StorageUtils.getStorageVolumes(context) }
 
     var isDefaultHome by remember { mutableStateOf(HomeLauncherHelper.isDefaultHome(context)) }
+    // No-op result callback: the picker/settings screens don't return a reliable result, so the
+    // ON_RESUME observer below refreshes the status when we come back instead.
     val homeLauncherPicker = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
-    ) {
-        isDefaultHome = HomeLauncherHelper.isDefaultHome(context)
-    }
+    ) {}
 
     fun openHomeLauncherSettings() {
         val opened = runCatching {


### PR DESCRIPTION
Follow-up hardening for the Home-launcher feature merged from #76.

## Changes
- **Consume the navigation request.** `homeNavigationRequest` is now reset to `0` after the effect handles it, so a recomposition that re-subscribes the `LaunchedEffect` can't replay the Home navigation and clobber the user's current screen.
- **Reset to the graph start destination** instead of the opaque `popUpTo(0)` magic number — uses `navController.graph.findStartDestination().id`.
- **Don't interrupt onboarding.** A Home press no longer force-navigates to the library root while a first-launch user is on the onboarding screen.
- **Use `MutableIntState.intValue`** instead of the deprecated `.value` compat shim.
- **Drop the redundant status refresh** in the picker's result callback; the `ON_RESUME` observer already refreshes `isDefaultHome` when returning from the picker/settings.

## Verification
- `:app:compileFullDebugKotlin` and `:app:compileFullDebugAndroidTestKotlin` both build successfully.
- No behavior change to `HomeLauncherHelper` or the Settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)