### PR TITLE
feat(steam): scan a Steam library folder and launch PC games via GameNative

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -26,6 +26,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val ROM_ROOT_PATH = stringPreferencesKey("rom_root_path")
         val MEDIA_FOLDER_PATH = stringPreferencesKey("media_folder_path")
         val MEDIA_STORAGE_PATH = stringPreferencesKey("media_storage_path")
+        // Folder holding a Steam library (a Winlator/GameNative/GameHub steamapps tree, or a Steam
+        // install root). Empty = not configured. Scanned for appmanifest_*.acf to add PC games.
+        val STEAM_LIBRARY_PATH = stringPreferencesKey("steam_library_path")
         val LAYOUT_MODE = stringPreferencesKey("layout_mode")
         val SS_ID = stringPreferencesKey("ss_id")
         val SS_PASSWORD = stringPreferencesKey("ss_password")
@@ -83,6 +86,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val mediaFolderPath: Flow<String> = context.dataStore.data.map { it[Keys.MEDIA_FOLDER_PATH] ?: "" }
     // Where scraped media is saved. Empty = app's internal default folder.
     val mediaStoragePath: Flow<String> = context.dataStore.data.map { it[Keys.MEDIA_STORAGE_PATH] ?: "" }
+    val steamLibraryPath: Flow<String> = context.dataStore.data.map { it[Keys.STEAM_LIBRARY_PATH] ?: "" }
     val layoutMode: Flow<String> = context.dataStore.data.map { it[Keys.LAYOUT_MODE] ?: "CAROUSEL" }
     val ssId: Flow<String> = context.dataStore.data.map { it[Keys.SS_ID] ?: "" }
     val ssPassword: Flow<String> = context.dataStore.data.map { it[Keys.SS_PASSWORD] ?: "" }
@@ -140,6 +144,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
     suspend fun setMediaStoragePath(path: String) = context.dataStore.edit { it[Keys.MEDIA_STORAGE_PATH] = path }
+    suspend fun setSteamLibraryPath(path: String) = context.dataStore.edit { it[Keys.STEAM_LIBRARY_PATH] = path }
     suspend fun setLayoutMode(mode: String) = context.dataStore.edit { it[Keys.LAYOUT_MODE] = mode }
     suspend fun setSsCredentials(id: String, password: String) = context.dataStore.edit {
         it[Keys.SS_ID] = id

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -21,6 +21,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override val romRootPath: Flow<String> = dataStore.romRootPath
     override val mediaFolderPath: Flow<String> = dataStore.mediaFolderPath
     override val mediaStoragePath: Flow<String> = dataStore.mediaStoragePath
+    override val steamLibraryPath: Flow<String> = dataStore.steamLibraryPath
 
     override val layoutMode: Flow<LayoutMode> = dataStore.layoutMode.map { name ->
         runCatching { LayoutMode.valueOf(name) }.getOrDefault(LayoutMode.CAROUSEL)
@@ -86,6 +87,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setRomRootPath(path: String) { dataStore.setRomRootPath(path) }
     override suspend fun setMediaFolderPath(path: String) { dataStore.setMediaFolderPath(path) }
     override suspend fun setMediaStoragePath(path: String) { dataStore.setMediaStoragePath(path) }
+    override suspend fun setSteamLibraryPath(path: String) { dataStore.setSteamLibraryPath(path) }
 
     override suspend fun setLayoutMode(mode: LayoutMode) { dataStore.setLayoutMode(mode.name) }
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
@@ -211,7 +211,7 @@ object PlatformDefinitions {
             id = "steam", displayName = "PC / Steam", scraperSystemId = 0,
             extensions = listOf(".lnk", ".url", ".exe"),
             folderNames = listOf("steam", "Steam", "pc", "PC", "Windows"),
-            defaultEmulatorPackage = "com.gamenative.android"
+            defaultEmulatorPackage = "app.gamenative"
         ),
         Platform(
             id = "xbox360", displayName = "Xbox 360", scraperSystemId = 33,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -11,6 +11,7 @@ interface SettingsRepository {
     val romRootPath: Flow<String>
     val mediaFolderPath: Flow<String>
     val mediaStoragePath: Flow<String>
+    val steamLibraryPath: Flow<String>
     val layoutMode: Flow<LayoutMode>
     val scraperConfig: Flow<ScraperConfig>
     val videoAutoplayDelayMs: Flow<Long>
@@ -50,6 +51,7 @@ interface SettingsRepository {
     suspend fun setRomRootPath(path: String)
     suspend fun setMediaFolderPath(path: String)
     suspend fun setMediaStoragePath(path: String)
+    suspend fun setSteamLibraryPath(path: String)
     suspend fun setLayoutMode(mode: LayoutMode)
     suspend fun setScraperCredentials(ssid: String, sspassword: String)
     suspend fun updateScraperOptions(

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanSteamLibraryUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanSteamLibraryUseCase.kt
@@ -1,0 +1,151 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import com.gamelaunch.frontend.domain.model.Game
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.util.StorageUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Adds PC games to the "steam" platform from a folder the user points
+ * [SettingsRepository.steamLibraryPath] at. Two folder shapes are understood:
+ *
+ *  1. **A GameNative "Export for ES-DE" directory (preferred).** GameNative writes one small file
+ *     per installed game, named `<title>.<ext>` where the extension is the store (`.steam`, `.epic`,
+ *     `.gog`, `.amazon`, `.pcgame`) and the file's text is the numeric app id. This lives on shared
+ *     storage and is exactly what an ES-DE-style frontend is meant to consume — filename → title,
+ *     contents → app id, extension → source.
+ *  2. **A raw Steam `steamapps` tree / Steam install root.** Falls back to parsing
+ *     `appmanifest_<appid>.acf` manifests (all treated as the STEAM source).
+ *
+ * Games are stored with romPath "steam:<SOURCE>:<appid>" (SOURCE omitted ⇒ STEAM);
+ * [com.gamelaunch.frontend.launcher.EmulatorLauncher] boots them by handing the id + source to the
+ * configured frontend (GameNative launches directly; others open the app).
+ *
+ * Note: a frontend that keeps its library in private app storage and has no export directory set
+ * exposes nothing eOr can read — a GameNative export dir on shared storage (or a steamapps tree on a
+ * mounted drive) is what makes this find anything.
+ */
+class ScanSteamLibraryUseCase @Inject constructor(
+    private val gameRepository: GameRepository,
+    private val settingsRepository: SettingsRepository
+) {
+    operator fun invoke(): Flow<ScanProgress> = flow {
+        val rawPath = settingsRepository.steamLibraryPath.first()
+        if (rawPath.isBlank()) {
+            emit(ScanProgress(0, 0, "No Steam library folder set"))
+            return@flow
+        }
+        val root = File(StorageUtils.resolveStoredPath(rawPath))
+
+        // Prefer GameNative's export files; only fall back to raw steamapps manifests if none exist.
+        val entries = findExportEntries(root).ifEmpty { findManifestEntries(root) }
+
+        emit(ScanProgress(0, entries.size, "Scanning Steam library…"))
+
+        var added = 0
+        entries.forEachIndexed { index, entry ->
+            emit(ScanProgress(index, entries.size, entry.title, added))
+            if (entry.appId in IGNORED_APP_IDS || entry.looksLikeRuntime()) return@forEachIndexed
+            // "steam:<appid>" for the default STEAM source keeps the path short; other stores carry
+            // their source so the launcher can pass the right game_source to GameNative.
+            val romPath =
+                if (entry.source == SOURCE_STEAM) "steam:${entry.appId}"
+                else "steam:${entry.source}:${entry.appId}"
+            val game = Game(
+                title       = entry.title,
+                romPath     = romPath,
+                romFilename = entry.installDir.ifBlank { entry.title },
+                platformId  = "steam"
+            )
+            // insertGame ignores rows that clash on the unique romPath (returns <= 0), so a rescan
+            // only counts genuinely new games — mirrors ScanAndroidGamesUseCase.
+            if (gameRepository.insertGame(game) > 0) added++
+        }
+
+        emit(ScanProgress(entries.size, entries.size, added = added))
+    }.flowOn(Dispatchers.IO)
+
+    // ── GameNative "Export for ES-DE" files ───────────────────────────────────────────────────────
+
+    /** Reads `<title>.<store-ext>` export files (title = filename, app id = contents). */
+    private fun findExportEntries(root: File): List<SteamApp> {
+        if (!root.isDirectory) return emptyList()
+        // Look in the folder itself and one level down (users may pick a parent of the export dir).
+        val files = root.walkTopDown().maxDepth(2)
+            .filter { it.isFile && EXPORT_EXTENSIONS.containsKey(it.extension.lowercase()) }
+        return files.mapNotNull { file ->
+            val source = EXPORT_EXTENSIONS[file.extension.lowercase()] ?: return@mapNotNull null
+            val appId = runCatching { file.readText().trim() }.getOrNull()?.toIntOrNull()
+                ?: return@mapNotNull null
+            SteamApp(appId, file.nameWithoutExtension.trim(), installDir = "", source = source)
+        }.distinctBy { it.source to it.appId }.toList()
+    }
+
+    // ── Raw steamapps `appmanifest_*.acf` fallback ────────────────────────────────────────────────
+
+    private fun findManifestEntries(root: File): List<SteamApp> =
+        findAppManifests(root).mapNotNull { parseManifest(it) }.distinctBy { it.appId }
+
+    private fun findAppManifests(root: File): List<File> {
+        if (!root.isDirectory) return emptyList()
+        val direct = (root.listAcf() + File(root, "steamapps").listAcf()).distinctBy { it.absolutePath }
+        if (direct.isNotEmpty()) return direct
+        return root.walkTopDown()
+            .maxDepth(6)
+            .filter { it.isFile && it.name.startsWith("appmanifest_") && it.extension == "acf" }
+            .toList()
+    }
+
+    private fun File.listAcf(): List<File> =
+        if (isDirectory) {
+            listFiles { f -> f.isFile && f.name.startsWith("appmanifest_") && f.extension == "acf" }
+                ?.toList() ?: emptyList()
+        } else emptyList()
+
+    private fun parseManifest(acf: File): SteamApp? {
+        val text = runCatching { acf.readText() }.getOrNull() ?: return null
+        val appId = KEY_APPID.find(text)?.groupValues?.get(1)?.toIntOrNull() ?: return null
+        val name = KEY_NAME.find(text)?.groupValues?.get(1)?.trim().orEmpty()
+        val installDir = KEY_INSTALLDIR.find(text)?.groupValues?.get(1)?.trim().orEmpty()
+        if (name.isBlank()) return null
+        return SteamApp(appId, name, installDir, SOURCE_STEAM)
+    }
+
+    private data class SteamApp(
+        val appId: Int,
+        val title: String,
+        val installDir: String,
+        val source: String
+    ) {
+        fun looksLikeRuntime(): Boolean =
+            RUNTIME_NAME_PREFIXES.any { title.startsWith(it, ignoreCase = true) }
+    }
+
+    private companion object {
+        const val SOURCE_STEAM = "STEAM"
+        // GameNative export extension → GameSource enum name it maps to (see FrontendSyncManager).
+        val EXPORT_EXTENSIONS = mapOf(
+            "steam" to "STEAM",
+            "epic" to "EPIC",
+            "gog" to "GOG",
+            "amazon" to "AMAZON",
+            "pcgame" to "CUSTOM_GAME"
+        )
+        // Steamworks Common Redistributables — GameNative writes this alongside real games.
+        val IGNORED_APP_IDS = setOf(228980)
+        val RUNTIME_NAME_PREFIXES = listOf(
+            "Steamworks Common", "Steam Linux Runtime", "Proton"
+        )
+        // ACF is Valve's VDF: `"key"\t\t"value"`. Whitespace between key and value varies.
+        val KEY_APPID = Regex("\"appid\"\\s+\"(\\d+)\"", RegexOption.IGNORE_CASE)
+        val KEY_NAME = Regex("\"name\"\\s+\"([^\"]*)\"", RegexOption.IGNORE_CASE)
+        val KEY_INSTALLDIR = Regex("\"installdir\"\\s+\"([^\"]*)\"", RegexOption.IGNORE_CASE)
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
@@ -51,6 +51,7 @@ class EmulatorLauncher @Inject constructor(
             }
             when {
                 mapping == null -> Result.failure(NoEmulatorConfiguredException(game.platformId))
+                game.romPath.startsWith("steam:") -> launchSteamGame(game, mapping, options)
                 mapping.isRetroArch -> launchRetroArch(game, mapping, options)
                 else -> launchStandalone(game, mapping, options)
             }
@@ -110,6 +111,36 @@ class EmulatorLauncher @Inject constructor(
             launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(launch, options)
         }
+    }
+
+    /**
+     * Steam / PC games (romPath "steam:<appid>") are booted by their configured frontend. GameNative
+     * accepts a direct-launch intent (verified against app.gamenative): action LAUNCH_GAME with the
+     * numeric app_id and a game_source. Other frontends (GameHub, Winlator, Steam Link) have no known
+     * per-game intent, so we open the app and let the user pick — better than a hard failure.
+     */
+    private fun launchSteamGame(game: Game, mapping: EmulatorMapping, options: Bundle?): Result<Unit> {
+        val pkg = mapping.packageName
+        // romPath is "steam:<appid>" (STEAM) or "steam:<SOURCE>:<appid>" (Epic/GOG/Amazon/custom).
+        val parts = game.romPath.removePrefix("steam:").split(":")
+        val appId = parts.last().toIntOrNull()
+        val source = if (parts.size >= 2) parts.first() else "STEAM"
+        if (pkg == GAMENATIVE_PACKAGE && appId != null) {
+            val intent = Intent(GAMENATIVE_LAUNCH_ACTION).apply {
+                setPackage(pkg)
+                putExtra(GAMENATIVE_EXTRA_APP_ID, appId)
+                putExtra(GAMENATIVE_EXTRA_GAME_SOURCE, source)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            // If GameNative can't handle the direct launch, fall back to opening its library.
+            return tryStartActivity(intent, options)
+                .recoverCatching { context.startActivity(openAppIntent(pkg) ?: throw it, options) }
+        }
+        // No direct-launch recipe for this frontend — open it so the user can start the game.
+        return tryStartActivity(
+            openAppIntent(pkg) ?: return Result.failure(Exception("App not installed: $pkg")),
+            options
+        )
     }
 
     private fun launchStandalone(game: Game, mapping: EmulatorMapping, options: Bundle?): Result<Unit> {
@@ -199,6 +230,13 @@ class EmulatorLauncher @Inject constructor(
 
     /** How the ROM is supplied: its raw file URI, or a FileProvider URI with temporary read access. */
     private enum class RomUriMode { FILE, CONTENT }
+
+    private companion object {
+        const val GAMENATIVE_PACKAGE = "app.gamenative"
+        const val GAMENATIVE_LAUNCH_ACTION = "app.gamenative.LAUNCH_GAME"
+        const val GAMENATIVE_EXTRA_APP_ID = "app_id"
+        const val GAMENATIVE_EXTRA_GAME_SOURCE = "game_source"
+    }
 
     // Platforms whose emulator renders both panels itself (Nintendo DS, 3DS) — never force these
     // onto a single display; they use the whole dual-screen device.

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
@@ -58,7 +58,7 @@ class PackageManagerHelper @Inject constructor(
         "com.explusalpha.Snes9xEmu"          to "Snes9x EX+ (SNES)",
         // PC / Steam launchers
         "com.valvesoftware.steamlink"         to "Steam Link",
-        "com.gamenative.android"              to "GameNative",
+        "app.gamenative"                     to "GameNative",
         "com.saber.gamehub"                  to "GameHub",
         // Other
         "ru.playsoftware.j2meloader"         to "J2ME Loader",
@@ -112,7 +112,7 @@ class PackageManagerHelper @Inject constructor(
         "wii"       to listOf("org.dolphinemu.dolphinemu", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "wiiu"      to listOf("info.cemu.cemu", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "psvita"    to listOf("org.vita3k.emulator"),
-        "steam"     to listOf("com.gamenative.android", "com.saber.gamehub", "com.valvesoftware.steamlink"),
+        "steam"     to listOf("app.gamenative", "com.saber.gamehub", "com.valvesoftware.steamlink"),
         "xbox360"   to listOf("org.adars.xeo")
     )
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -466,6 +466,8 @@ fun SettingsScreen(
                             Spacer(Modifier.height(4.dp))
                             AndroidGamesSection(state, viewModel)
                             Spacer(Modifier.height(4.dp))
+                            SteamLibrarySection(state, viewModel)
+                            Spacer(Modifier.height(4.dp))
                             EmulatorsSection(state, viewModel, onEmulatorConfigClick)
                         }
                         SettingsTab.RETRO_ACHIEVEMENTS -> RetroAchievementsSection(state, viewModel)
@@ -1376,6 +1378,82 @@ private fun AndroidGamesSection(state: SettingsUiState, viewModel: SettingsViewM
                 text  = result,
                 color = ElectricBlue
             )
+        }
+    }
+}
+
+// ── Section: Steam / PC Games ─────────────────────────────────────────────
+
+@Composable
+private fun SteamLibrarySection(state: SettingsUiState, viewModel: SettingsViewModel) {
+    val folderPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let {
+            val path = StorageUtils.resolveTreeUriToPath(it) ?: it.toString()
+            viewModel.setSteamLibraryPath(path)
+        }
+    }
+
+    SettingsSectionHeader("Steam / PC Games")
+    SettingsCard {
+        Text(
+            "Add PC games run through GameNative, GameHub or Winlator. In GameNative, turn on " +
+            "\"Export for ES-DE\" and point it at a folder on shared storage, then choose that same " +
+            "folder here — eOr reads the exported games and launches them back through GameNative. " +
+            "A raw Steam \"steamapps\" folder works too.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Default.FolderOpen,
+                contentDescription = null,
+                tint = ElectricBlue,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text  = state.steamLibraryPath.ifBlank { "No folder selected" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            GradientFillButton(
+                text     = if (state.steamLibraryPath.isBlank()) "Choose Folder" else "Change Folder",
+                onClick  = { folderPicker.launch(null) },
+                modifier = Modifier.weight(1f)
+            )
+            if (state.steamLibraryPath.isNotBlank()) {
+                GradientOutlineButton(
+                    text     = "Clear",
+                    onClick  = { viewModel.clearSteamLibraryPath() },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+        if (state.steamLibraryPath.isNotBlank()) {
+            Spacer(Modifier.height(8.dp))
+            GradientFillButton(
+                text     = "Scan Steam Library",
+                onClick  = { viewModel.scanSteamLibrary() },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        when {
+            state.steamScanning -> {
+                Spacer(Modifier.height(8.dp))
+                LoadingStatusRow("Scanning Steam library…", MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            state.steamScanResult != null -> {
+                Spacer(Modifier.height(6.dp))
+                StatusRow(Icons.Default.Check, state.steamScanResult, ElectricBlue)
+            }
         }
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.gamelaunch.frontend.domain.usecase.EsdeImportStatus
 import com.gamelaunch.frontend.domain.usecase.ImportEsdeMediaUseCase
 import com.gamelaunch.frontend.domain.usecase.LbSyncStatus
 import com.gamelaunch.frontend.domain.usecase.ScanAndroidGamesUseCase
+import com.gamelaunch.frontend.domain.usecase.ScanSteamLibraryUseCase
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.usecase.SyncLaunchBoxUseCase
 import com.gamelaunch.frontend.ui.theme.LayoutMode
@@ -33,6 +34,9 @@ import javax.inject.Inject
 data class SettingsUiState(
     val androidScanResult: String? = null,
     val romRootPath: String = "",
+    val steamLibraryPath: String = "",
+    val steamScanResult: String? = null,
+    val steamScanning: Boolean = false,
     val ssId: String = "",
     val ssPassword: String = "",
     val raUsername: String = "",
@@ -93,6 +97,7 @@ class SettingsViewModel @Inject constructor(
     private val syncLaunchBoxUseCase: SyncLaunchBoxUseCase,
     private val importEsdeMediaUseCase: ImportEsdeMediaUseCase,
     private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
+    private val scanSteamLibraryUseCase: ScanSteamLibraryUseCase,
     private val convertBackgroundImageUseCase: ConvertBackgroundImageUseCase,
     private val raRepository: RetroAchievementsRepository,
     private val gameRepository: GameRepository,
@@ -161,6 +166,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.mediaStoragePath.collect { path ->
                 _uiState.update { it.copy(mediaStoragePath = path) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.steamLibraryPath.collect { path ->
+                _uiState.update { it.copy(steamLibraryPath = path) }
             }
         }
         viewModelScope.launch {
@@ -555,6 +565,37 @@ class SettingsViewModel @Inject constructor(
 
     fun clearAndroidScanResult() {
         _uiState.update { it.copy(androidScanResult = null) }
+    }
+
+    fun setSteamLibraryPath(path: String) {
+        viewModelScope.launch { settingsRepository.setSteamLibraryPath(path) }
+    }
+
+    fun clearSteamLibraryPath() {
+        viewModelScope.launch { settingsRepository.setSteamLibraryPath("") }
+        _uiState.update { it.copy(steamScanResult = null) }
+    }
+
+    fun scanSteamLibrary() {
+        if (_uiState.value.steamScanning) return
+        _uiState.update { it.copy(steamScanning = true, steamScanResult = null) }
+        viewModelScope.launch {
+            scanSteamLibraryUseCase().collect { progress ->
+                if (progress.scanned == progress.total) {
+                    val n = progress.added
+                    _uiState.update {
+                        it.copy(
+                            steamScanning = false,
+                            steamScanResult = "Found $n new PC game${if (n != 1) "s" else ""}"
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearSteamScanResult() {
+        _uiState.update { it.copy(steamScanResult = null) }
     }
 
     fun finishSetup() {


### PR DESCRIPTION
## What

Adds a **Steam / PC Games** section under **Settings → Games**. Point it at a folder; eOr adds the PC games it finds to the `steam` platform and launches them back through the configured frontend.

## How it scans

In priority order:

1. **A GameNative "Export for ES-DE" directory** (preferred). GameNative writes one file per installed game named `<title>.<store-ext>` (`.steam` / `.epic` / `.gog` / `.amazon` / `.pcgame`) whose text is the numeric app id. Filename → title, contents → app id, extension → source. This lives on shared storage, unlike GameNative's private `steamapps` tree.
2. **A raw Steam `steamapps` tree** — parses `appmanifest_<appid>.acf` (all treated as the STEAM source). Steamworks redistributables / runtimes are filtered out.

Games are stored as `romPath` `steam:<appid>` (STEAM) or `steam:<SOURCE>:<appid>` (other stores). Rescans only count genuinely new games.

## How it launches

- **GameNative** → direct-launch intent `app.gamenative.LAUNCH_GAME` with `app_id` + `game_source` (verified against the app's manifest and source).
- **GameHub / Winlator / Steam Link** → no known per-game intent, so open the app as a best-effort fallback.

## Also fixes

GameNative's package id, which was wrong everywhere it appeared: `com.gamenative.android` → **`app.gamenative`**.

## Files

- `ScanSteamLibraryUseCase.kt` (new) — the scanner
- `EmulatorLauncher.kt` — `steam:` launch handling
- `SettingsScreen.kt` / `SettingsViewModel.kt` — the Steam Library UI (folder picker, scan, status)
- `AppDataStore.kt` / `SettingsRepository(.kt/Impl)` — persist the library folder
- `PackageManagerHelper.kt` / `PlatformDefinitions.kt` — package-id fix

Both `full` and `lite` flavors compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)