### PR TITLE
fix(perf): tie reduced-motion to chipset, not dual-screen

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -364,14 +364,13 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             settingsRepository.darkMode.collect { artworkBus.setDarkMode(it) }
         }
-        // "Run lighter" signal: the lite build (LOW_POWER) is always reduced; the full build reduces
-        // when the user enables Performance mode or when a second screen is present.
+        // "Run lighter" signal: the lite build (LOW_POWER) targets low-power chipsets (RK3568/RK3566
+        // and similar) and is always reduced; the full build reduces only when the user enables
+        // Performance mode. Deliberately NOT tied to dual-screen presence — a dual-screen device is
+        // not necessarily low-powered (e.g. AYN Thor), and the RG DS already runs the lite build.
         lifecycleScope.launch {
-            combine(
-                settingsRepository.performanceMode,
-                dualScreenManager.active
-            ) { pref, dualScreen -> BuildConfig.LOW_POWER || pref || dualScreen }
-                .collect { performanceState.set(it) }
+            settingsRepository.performanceMode
+                .collect { pref -> performanceState.set(BuildConfig.LOW_POWER || pref) }
         }
         // Hide the top artwork overlay while a game is running on the top panel so it doesn't cover
         // the game; it's restored when the user returns (see onWindowFocusChanged).

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -806,7 +806,7 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
                 onCheckedChange = viewModel::setPerformanceMode
             )
             Text(
-                "Reduces animations and delays video previews — recommended on low-power handhelds. (Auto-on with dual screens.)",
+                "Reduces animations and delays video previews — recommended on low-power handhelds.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )


### PR DESCRIPTION
Performance/reduced-motion mode is meant for low-power chipsets (RK3568, RK3566 and similar), which eOr targets via the `lite` build flavor (BuildConfig.LOW_POWER). The runtime signal also OR'd in dualScreenManager.active, which force-enabled reduced mode on every active dual-screen device regardless of chipset — throttling capable hardware (e.g. AYN Thor) for no reason. The RG DS already gets reduced mode from the lite build, so the dual-screen term was redundant for it.

Drop the dual-screen term so the signal is `LOW_POWER || performanceMode`, and remove the "(Auto-on with dual screens.)" note from the settings description.