### PR TITLE
feat(grid): remember game-grid size per system

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -71,6 +71,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val SYSTEM_SORT = stringPreferencesKey("system_sort")
         val GAME_SORT = stringPreferencesKey("game_sort")
         val GAME_GRID_COLUMNS = intPreferencesKey("game_grid_columns")
+        // Per-system grid column overrides, encoded as "platformId:cols,platformId:cols".
+        // A platform absent from the map falls back to the legacy GAME_GRID_COLUMNS value (0 = auto).
+        val GAME_GRID_COLUMNS_BY_PLATFORM = stringPreferencesKey("game_grid_columns_by_platform")
         val RA_USERNAME = stringPreferencesKey("ra_username")
         val RA_API_KEY = stringPreferencesKey("ra_api_key")
         val RA_TOKEN = stringPreferencesKey("ra_token")
@@ -141,6 +144,24 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val gameSort: Flow<String> = context.dataStore.data.map { it[Keys.GAME_SORT] ?: "ALPHABETICAL" }
     // 0 = auto-fit columns to screen; > 0 = user-chosen fixed column count.
     val gameGridColumns: Flow<Int> = context.dataStore.data.map { it[Keys.GAME_GRID_COLUMNS] ?: 0 }
+    // Per-system column overrides. A legacy single GAME_GRID_COLUMNS value (from before per-system
+    // sizing existed) is folded in under the "" key so existing users keep their chosen size as a
+    // default for any system they haven't resized individually yet.
+    val gameGridColumnsByPlatform: Flow<Map<String, Int>> = context.dataStore.data.map { prefs ->
+        val map = prefs[Keys.GAME_GRID_COLUMNS_BY_PLATFORM]
+            ?.split(",")
+            ?.mapNotNull { entry ->
+                val i = entry.lastIndexOf(':')
+                if (i <= 0) return@mapNotNull null
+                val platform = entry.substring(0, i)
+                val cols = entry.substring(i + 1).toIntOrNull() ?: return@mapNotNull null
+                platform to cols
+            }
+            ?.toMap()
+            ?: emptyMap()
+        val legacy = prefs[Keys.GAME_GRID_COLUMNS] ?: 0
+        if (legacy > 0 && "" !in map) map + ("" to legacy) else map
+    }
     val raUsername: Flow<String> = context.dataStore.data.map { it[Keys.RA_USERNAME] ?: "" }
     val raApiKey: Flow<String> = context.dataStore.data.map { it[Keys.RA_API_KEY] ?: "" }
     val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
@@ -209,7 +230,23 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     }
     suspend fun setSystemSort(keys: List<String>) = context.dataStore.edit { it[Keys.SYSTEM_SORT] = keys.joinToString(",") }
     suspend fun setGameSort(sort: String) = context.dataStore.edit { it[Keys.GAME_SORT] = sort }
-    suspend fun setGameGridColumns(columns: Int) = context.dataStore.edit { it[Keys.GAME_GRID_COLUMNS] = columns }
+    // Set (or clear, when columns == 0) the column override for a single system, leaving every other
+    // system's choice untouched. Encoded back into the "platformId:cols,..." string.
+    suspend fun setGameGridColumns(platformId: String, columns: Int) = context.dataStore.edit { prefs ->
+        val current = prefs[Keys.GAME_GRID_COLUMNS_BY_PLATFORM]
+            ?.split(",")
+            ?.mapNotNull { entry ->
+                val i = entry.lastIndexOf(':')
+                if (i <= 0) return@mapNotNull null
+                val cols = entry.substring(i + 1).toIntOrNull() ?: return@mapNotNull null
+                entry.substring(0, i) to cols
+            }
+            ?.toMap()
+            ?.toMutableMap()
+            ?: mutableMapOf()
+        if (columns > 0) current[platformId] = columns else current.remove(platformId)
+        prefs[Keys.GAME_GRID_COLUMNS_BY_PLATFORM] = current.entries.joinToString(",") { "${it.key}:${it.value}" }
+    }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
         it[Keys.RA_API_KEY] = apiKey
     }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -71,7 +71,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override val systemSort: Flow<List<SystemSort>> =
         dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
     override val gameSort: Flow<GameSort> = dataStore.gameSort.map { GameSort.fromName(it) }
-    override val gameGridColumns: Flow<Int> = dataStore.gameGridColumns
+    override val gameGridColumnsByPlatform: Flow<Map<String, Int>> = dataStore.gameGridColumnsByPlatform
     override val raUsername: Flow<String> = dataStore.raUsername
     override val raApiKey: Flow<String> = dataStore.raApiKey
     override val raToken: Flow<String> = dataStore.raToken
@@ -132,7 +132,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun clearBackgroundImage() { dataStore.clearBackgroundImage() }
     override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
     override suspend fun setGameSort(sort: GameSort) { dataStore.setGameSort(sort.name) }
-    override suspend fun setGameGridColumns(columns: Int) { dataStore.setGameGridColumns(columns) }
+    override suspend fun setGameGridColumns(platformId: String, columns: Int) { dataStore.setGameGridColumns(platformId, columns) }
     override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }
     override suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) {
         dataStore.setRaSession(username, token, points, softcorePoints)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -35,7 +35,8 @@ interface SettingsRepository {
     val syncChargingOnly: Flow<Boolean>
     val systemSort: Flow<List<SystemSort>>
     val gameSort: Flow<GameSort>
-    val gameGridColumns: Flow<Int>
+    /** Per-system grid column overrides, keyed by platform id (0/absent = auto-fit). */
+    val gameGridColumnsByPlatform: Flow<Map<String, Int>>
     val raUsername: Flow<String>
     val raApiKey: Flow<String>
     val raToken: Flow<String>
@@ -84,7 +85,7 @@ interface SettingsRepository {
     suspend fun clearBackgroundImage()
     suspend fun setSystemSort(keys: List<SystemSort>)
     suspend fun setGameSort(sort: GameSort)
-    suspend fun setGameGridColumns(columns: Int)
+    suspend fun setGameGridColumns(platformId: String, columns: Int)
     suspend fun setRaApiKey(apiKey: String)
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)
     suspend fun clearRaCredentials()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -144,15 +144,28 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /** The Select-menu options (game sort + fixed column count) for the game grid. */
+    // Latest per-system column overrides from settings. Held here (not just in ui state) so the
+    // effective count can be re-resolved whenever the selected system changes, not only when the
+    // stored map changes. A "" key holds the legacy single-value setting, used as a fallback for any
+    // system the user hasn't sized individually yet.
+    private var gridColumnsByPlatform: Map<String, Int> = emptyMap()
+
+    /** Resolve the fixed column count for [platformId] (0 = auto-fit) from the stored overrides. */
+    private fun resolveGridColumns(platformId: String?): Int =
+        gridColumnsByPlatform[platformId] ?: gridColumnsByPlatform[""] ?: 0
+
+    /** The Select-menu options (game sort + per-system column count) for the game grid. */
     private fun observeGameViewPrefs() {
         viewModelScope.launch {
             combine(
                 settingsRepository.gameSort,
-                settingsRepository.gameGridColumns
+                settingsRepository.gameGridColumnsByPlatform
             ) { sort, cols -> sort to cols }
                 .collect { (sort, cols) ->
-                    _uiState.update { it.copy(gameSort = sort, gameGridColumns = cols) }
+                    gridColumnsByPlatform = cols
+                    _uiState.update {
+                        it.copy(gameSort = sort, gameGridColumns = resolveGridColumns(it.selectedPlatform))
+                    }
                 }
         }
     }
@@ -204,6 +217,7 @@ class HomeViewModel @Inject constructor(
                             platforms = sorted,
                             platformCounts = counts,
                             selectedPlatform = selected,
+                            gameGridColumns = resolveGridColumns(selected),
                             isLoading = false
                         )
                     }
@@ -411,13 +425,21 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch { settingsRepository.setGameSort(sort) }
     }
 
+    /** Persist the grid size for the system currently being viewed, so each system keeps its own. */
     fun setGameGridColumns(columns: Int) {
-        viewModelScope.launch { settingsRepository.setGameGridColumns(columns) }
+        val platformId = _uiState.value.selectedPlatform ?: return
+        viewModelScope.launch { settingsRepository.setGameGridColumns(platformId, columns) }
     }
 
     fun selectPlatform(platformId: String) {
         videoDelayJob?.cancel()
-        _uiState.update { it.copy(selectedPlatform = platformId, shouldPlayVideo = false) }
+        _uiState.update {
+            it.copy(
+                selectedPlatform = platformId,
+                gameGridColumns = resolveGridColumns(platformId),
+                shouldPlayVideo = false
+            )
+        }
         loadGamesForPlatform(platformId)
     }
 


### PR DESCRIPTION
## What

On the game grid, the Select-menu size slider previously stored a **single global** column count — resizing the grid while browsing one system changed it for every system. This makes the grid size **per system**: resize SNES and it stays that way for SNES; PSX keeps its own size.

## How

- **AppDataStore** — new `GAME_GRID_COLUMNS_BY_PLATFORM` pref encoding overrides as `"platformId:cols,…"`; a per-platform read flow and a `setGameGridColumns(platformId, columns)` that updates just one system's entry (`0` clears it back to auto-fit).
- **SettingsRepository / Impl** — swapped the single `Flow<Int>` / `setGameGridColumns(Int)` for the per-platform map + setter.
- **HomeViewModel** — holds the override map, resolves the effective column count for the currently-selected system, and re-resolves it on selection changes (`selectPlatform`, platform-list load) and when the stored map changes. The slider writes to the system currently on screen.

No UI changes needed — `HomeScreen` still reads `state.gameGridColumns` (now the resolved value for the current system) and still calls `viewModel.setGameGridColumns(columns)`.

## Migration

An existing user's old global value is folded in under a `""` fallback key, so it keeps applying to any system they haven't resized individually yet, then ages out as per-system sizes get set. No regression for current users.

## Testing

- `./gradlew :app:compileFullDebugKotlin` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)