### PR TITLE
fix(grid): load box art in one batch instead of trickling in one-at-a-time

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/GameLauncherApp.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/GameLauncherApp.kt
@@ -8,6 +8,7 @@ import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import coil.request.CachePolicy
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.Dispatchers
 
 @HiltAndroidApp
 class GameLauncherApp : Application(), ImageLoaderFactory {
@@ -44,6 +45,13 @@ class GameLauncherApp : Application(), ImageLoaderFactory {
             .respectCacheHeaders(false)
             .memoryCachePolicy(CachePolicy.ENABLED)
             .diskCachePolicy(CachePolicy.ENABLED)
+            // Run the request pipeline (memory-cache lookup, size resolution, dispatch, result apply)
+            // off the main thread. Coil defaults this to Dispatchers.Main.immediate, which means every
+            // tile's load competes for main-thread time — and the full build always has a focused-card
+            // idle animation cycling the main thread at ~60fps. That throttling made covers trickle in
+            // one-at-a-time on full while the lite build (no idle animation) applied them all at once.
+            // Off-main, image loading is decoupled from the animation and covers land together on both.
+            .interceptorDispatcher(Dispatchers.Default)
             .crossfade(120)
             .build()
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridGameCard.kt
@@ -1,8 +1,5 @@
 package com.gamelaunch.frontend.ui.theme.grid
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -16,8 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,15 +35,12 @@ import com.gamelaunch.frontend.ui.perf.rememberIdleMotion
 import com.gamelaunch.frontend.ui.perf.rememberSelectionScale
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
 import com.gamelaunch.frontend.ui.theme.NeonPurple
-import kotlinx.coroutines.delay
 
 @Composable
 fun GridGameCard(
     game: Game,
-    index: Int = 0,
     media: GameMedia? = null,
     isFocused: Boolean = false,
-    animateOnEntry: Boolean = true,
     // Container shape. Defaults to the system's real box proportions; callers showing a mixed-system
     // list (e.g. Recently played) pass a fixed value to keep every tile the same rectangle.
     aspectRatio: Float = boxArtAspectRatio(game.platformId),
@@ -59,18 +51,11 @@ fun GridGameCard(
 ) {
     val shape = RoundedCornerShape(12.dp)
 
-    // Entrance: rise up from the bottom with a slight spring bounce, staggered by position.
-    // Only the cards present when the system loads should animate — capture that decision at
-    // first composition so cards recycled into view while scrolling appear instantly instead
-    // of re-playing the rise.
-    val shouldAnimate = remember { animateOnEntry }
-    val enter = remember { Animatable(if (shouldAnimate) 0f else 1f) }
-    LaunchedEffect(Unit) {
-        if (shouldAnimate) {
-            delay(index.coerceAtMost(18) * 28L)
-            enter.animateTo(1f, spring(dampingRatio = 0.58f, stiffness = Spring.StiffnessMediumLow))
-        }
-    }
+    // No staggered entrance: the per-card rise gated each tile's alpha behind an index-based delay
+    // (delay(index * 28)), so covers faded in one-at-a-time top-to-bottom — which on the full build
+    // read as the grid "loading in slowly", tile by tile. Cards (and their art) now appear together
+    // as soon as they compose, matching how the lite build already behaves. The focus pop and idle
+    // motion below are untouched.
 
     // Focused card pops with the same bounce-scale as the console cards — but snaps instantly under
     // reduced (lite build / performance mode) instead of animating every d-pad step.
@@ -90,9 +75,7 @@ fun GridGameCard(
             .zIndex(if (isFocused) 1f else 0f)
             .graphicsLayer {
                 val pulse = if (isFocused) idle.breath * 0.012f else 0f
-                translationY = (1f - enter.value) * 72.dp.toPx() +
-                    (if (isFocused) idle.bob * 1.8.dp.toPx() else 0f)
-                alpha = enter.value.coerceIn(0f, 1f)
+                translationY = if (isFocused) idle.bob * 1.8.dp.toPx() else 0f
                 scaleX = scale + pulse
                 scaleY = scale + pulse
                 rotationZ = if (isFocused) idle.tilt * 0.9f else 0f

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -16,9 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,7 +30,6 @@ import com.gamelaunch.frontend.ui.component.ScrollSectionIndicator
 import com.gamelaunch.frontend.ui.component.boxArtAspectRatio
 import com.gamelaunch.frontend.ui.component.rememberSectionIndicatorState
 import com.gamelaunch.frontend.ui.perf.LocalReduceMotion
-import kotlinx.coroutines.delay
 
 @Composable
 fun GridHomeContent(
@@ -108,16 +104,6 @@ fun GridHomeContent(
         label = "gridScrollBlur"
     )
 
-    // The entrance animation should fire once, when we load into a system — not every time a
-    // card is recycled into view on scroll. Keep a short window open right after the games list
-    // changes; cards composed during it animate, cards composed later appear instantly.
-    var entranceWindowOpen by remember(games) { mutableStateOf(true) }
-    LaunchedEffect(games) {
-        entranceWindowOpen = true
-        delay(900L)   // long enough for the staggered rise of the initially-visible cards
-        entranceWindowOpen = false
-    }
-
     Box(modifier.fillMaxSize()) {
         LazyVerticalGrid(
             columns               = GridCells.Fixed(columns),
@@ -135,10 +121,8 @@ fun GridHomeContent(
             itemsIndexed(games, key = { _, g -> g.id }) { index, game ->
                 GridGameCard(
                     game           = game,
-                    index          = index,
                     media          = mediaForGames[game.id],
                     isFocused      = index == focusedGameIndex,
-                    animateOnEntry = entranceWindowOpen,
                     aspectRatio    = uniformAspectRatio ?: boxArtAspectRatio(game.platformId),
                     // Pass the stable callback straight through — the card builds its own click
                     // lambda internally, so no per-item allocation happens here.


### PR DESCRIPTION
## Problem

On the **full** build, game covers painted in one at a time (top to bottom) when entering a system, while the **lite** build showed them all at once. Verified on a Retroid Pocket 4 (Unisoc T618): the trickle reproduced on the full build, and toggling Performance mode on the same device (which flips the build to the reduced/lite code path) made it batch — so it was the code path, not the hardware.

## Root cause

Two things, both only on the full path:

1. **Coil resolved every image request on the main thread.** Coil 2's default `interceptorDispatcher` is `Dispatchers.Main.immediate`, and the full build always runs a focused-card idle animation cycling the main thread at ~60fps (measured: 124 frames in 2s at rest). That throttled per-image dispatch/apply to roughly one cover per frame → the visible trickle. The lite build has no idle animation, so its main thread was free and all ready covers applied together.
2. **The per-card staggered entrance** gated each tile's `alpha` behind an index-based `delay(index * 28ms)`, so covers faded in one-by-one on entry.

## Fix

- Run Coil's request pipeline off the main thread (`interceptorDispatcher = Dispatchers.Default`) so image loading is decoupled from main-thread animation load.
- Remove the staggered per-card entrance. **The focus pop and idle motion animations are untouched** — only the entrance stagger is gone.

Net result: covers land together on both flavors. Confirmed on-device — the grid goes from empty to fully-loaded in a single frame instead of trickling.

## Scope note

An earlier iteration also added a scroll-ahead prefetch to warm art beyond the visible screen; it was removed because a two-screen window decoded too many full-size, variable-aspect covers on entry and added a noticeable delay. This PR is just the two fixes above.

## Testing

- Built `fullRelease` (R8 minified) and installed on a Retroid Pocket 4.
- Before/after burst-screenshot comparison: before grew gradually over ~2.5s (trickle); after jumps empty → full in one frame (batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)