### PR TITLE
release: 2.5.0 — Steam library, Locked Mode & Home-launcher mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 38
-        versionName = "2.4.2"
+        versionCode = 39
+        versionName = "2.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Version bump to 2.5.0 (versionCode 39) for the 2.5.0 release.

Release build verified on-device (RG DS): full + lite APKs debug-key-signed, and a real game launched into RetroArch without an R8 crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)