### PR TITLE
feat(grid): master grid-size setting + top-row pinning on short viewports

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -247,6 +247,12 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         if (columns > 0) current[platformId] = columns else current.remove(platformId)
         prefs[Keys.GAME_GRID_COLUMNS_BY_PLATFORM] = current.entries.joinToString(",") { "${it.key}:${it.value}" }
     }
+    // Master (default) grid size for every system's game grid. Stored in the legacy single-value key,
+    // which [gameGridColumnsByPlatform] already surfaces under the "" key as the per-system fallback —
+    // so a system with its own override keeps it, and everyone else follows this. 0 = auto-fit.
+    suspend fun setMasterGameGridColumns(columns: Int) = context.dataStore.edit { prefs ->
+        if (columns > 0) prefs[Keys.GAME_GRID_COLUMNS] = columns else prefs.remove(Keys.GAME_GRID_COLUMNS)
+    }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
         it[Keys.RA_API_KEY] = apiKey
     }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -72,6 +72,7 @@ class SettingsRepositoryImpl @Inject constructor(
         dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
     override val gameSort: Flow<GameSort> = dataStore.gameSort.map { GameSort.fromName(it) }
     override val gameGridColumnsByPlatform: Flow<Map<String, Int>> = dataStore.gameGridColumnsByPlatform
+    override val masterGameGridColumns: Flow<Int> = dataStore.gameGridColumns
     override val raUsername: Flow<String> = dataStore.raUsername
     override val raApiKey: Flow<String> = dataStore.raApiKey
     override val raToken: Flow<String> = dataStore.raToken
@@ -133,6 +134,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
     override suspend fun setGameSort(sort: GameSort) { dataStore.setGameSort(sort.name) }
     override suspend fun setGameGridColumns(platformId: String, columns: Int) { dataStore.setGameGridColumns(platformId, columns) }
+    override suspend fun setMasterGameGridColumns(columns: Int) { dataStore.setMasterGameGridColumns(columns) }
     override suspend fun setRaApiKey(apiKey: String) { dataStore.setRaApiKey(apiKey) }
     override suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) {
         dataStore.setRaSession(username, token, points, softcorePoints)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -37,6 +37,8 @@ interface SettingsRepository {
     val gameSort: Flow<GameSort>
     /** Per-system grid column overrides, keyed by platform id (0/absent = auto-fit). */
     val gameGridColumnsByPlatform: Flow<Map<String, Int>>
+    /** Master (default) game-grid column count applied to any system without its own override (0 = auto-fit). */
+    val masterGameGridColumns: Flow<Int>
     val raUsername: Flow<String>
     val raApiKey: Flow<String>
     val raToken: Flow<String>
@@ -86,6 +88,7 @@ interface SettingsRepository {
     suspend fun setSystemSort(keys: List<SystemSort>)
     suspend fun setGameSort(sort: GameSort)
     suspend fun setGameGridColumns(platformId: String, columns: Int)
+    suspend fun setMasterGameGridColumns(columns: Int)
     suspend fun setRaApiKey(apiKey: String)
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int)
     suspend fun clearRaCredentials()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -104,6 +104,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
@@ -784,6 +785,15 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
                 modifier = Modifier.weight(1f)
             )
         }
+        // Master grid size — only meaningful (and only shown) when the grid layout is active. Sets the
+        // default tile size for every system's game grid; a system sized from its own grid overrides it.
+        if (state.layoutMode == LayoutMode.GRID) {
+            Spacer(Modifier.height(12.dp))
+            MasterGridSizeControl(
+                columns = state.masterGridColumns,
+                onSet   = viewModel::setMasterGridColumns
+            )
+        }
         Spacer(Modifier.height(12.dp))
         Text(
             "Appearance",
@@ -813,6 +823,62 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+    }
+}
+
+/**
+ * Master (default) game-grid size, shown in the Display section only while the grid layout is active.
+ * The slider reads small → large (fewer columns = bigger tiles) to match the in-grid quick menu, with
+ * an "Auto" stop at the far left that lets the grid fit the screen. Recents/Favorites keep their own
+ * fixed sizing, and any system sized from its own grid overrides this default.
+ */
+@Composable
+private fun MasterGridSizeControl(columns: Int, onSet: (Int) -> Unit) {
+    val screenWidthDp = LocalConfiguration.current.screenWidthDp
+    // Same column maths as the home grid so the steps line up with what the library actually shows.
+    val minCols = 3
+    val maxCols = maxOf(1, (screenWidthDp - 2 * 8 + 8) / (92 + 8)).coerceIn(minCols + 1, 12)
+
+    // Fold "Auto" (columns == 0) into the far-left slot; explicit sizes run smallest-tiles (maxCols)
+    // up to largest-tiles (minCols) rightward.
+    val sliderMax = (maxCols - minCols) + 1
+    val sliderValue = if (columns <= 0) 0 else (maxCols - columns.coerceIn(minCols, maxCols) + 1)
+
+    Column(Modifier.fillMaxWidth()) {
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(
+                "Grid size",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                if (columns <= 0) "Auto" else "$columns per row",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Slider(
+            value = sliderValue.toFloat(),
+            onValueChange = { v ->
+                val iv = v.roundToInt()
+                onSet(if (iv <= 0) 0 else maxCols - (iv - 1))
+            },
+            valueRange = 0f..sliderMax.toFloat(),
+            steps = (sliderMax - 1).coerceAtLeast(0),
+            colors = SliderDefaults.colors(
+                thumbColor = ElectricBlue,
+                activeTrackColor = ElectricBlue,
+            )
+        )
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text("Auto", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("Larger", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Text(
+            "Default size for every system's game grid. Resize a single system from its grid to override it.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -46,6 +46,7 @@ data class SettingsUiState(
     val raLoginResult: String? = null,   // success or error message to surface
     val raLoggedIn: Boolean = false,     // a token is stored
     val layoutMode: LayoutMode = LayoutMode.CAROUSEL,
+    val masterGridColumns: Int = 0,      // default game-grid size for all systems (0 = auto-fit)
     val scrapeMetadata: Boolean = true,
     val scrapeBoxArt: Boolean = true,
     val scrapeScreenshots: Boolean = true,
@@ -201,6 +202,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.darkMode.collect { dark ->
                 _uiState.update { it.copy(darkMode = dark) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.masterGameGridColumns.collect { cols ->
+                _uiState.update { it.copy(masterGridColumns = cols) }
             }
         }
         viewModelScope.launch {
@@ -494,6 +500,11 @@ class SettingsViewModel @Inject constructor(
 
     fun setLayoutMode(mode: LayoutMode) {
         viewModelScope.launch { settingsRepository.setLayoutMode(mode) }
+    }
+
+    /** Set the master (default) game-grid size; per-system overrides still win. 0 = auto-fit. */
+    fun setMasterGridColumns(columns: Int) {
+        viewModelScope.launch { settingsRepository.setMasterGameGridColumns(columns) }
     }
 
     fun setScrapeMetadata(v: Boolean) = _uiState.update { it.copy(scrapeMetadata = v) }.also { saveOptions() }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/grid/GridHomeContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.GameMedia
@@ -59,6 +60,11 @@ fun GridHomeContent(
 
     val gridState = rememberLazyGridState()
 
+    // Row/column gap. Kept in one place because the scroll-anchor math below needs the same value to
+    // work out how many whole rows fit in the viewport.
+    val gridSpacing = 8.dp
+    val gridSpacingPx = with(LocalDensity.current) { gridSpacing.roundToPx() }
+
     // Report a "page" (whole rows currently on screen × columns) up to the caller so L2/R2 can jump
     // the selection by a screenful at a time.
     LaunchedEffect(gridState, columns) {
@@ -69,12 +75,30 @@ fun GridHomeContent(
             }
     }
 
-    // Scroll so the controller-focused card is always visible. Anchor the focused card to the
-    // second visible row (one row of context above it) instead of pinning it to the top row —
-    // scrolling only kicks in once focus moves past the second row.
+    // Scroll so the controller-focused card is always visible. When at least 2 WHOLE rows fit in the
+    // viewport we anchor the focused card to the SECOND row (one row of context above it), so
+    // scrolling only kicks in once focus moves past the second row. But a short viewport that can't
+    // fit 2 whole rows has no room to spare a context row — anchoring to the second row pushes the
+    // focused card off the bottom edge (e.g. tall arcade art at a large grid size shows barely one
+    // full row) — so there we pin the focused card's row to the TOP instead, keeping it fully on
+    // screen. Note this is viewport CAPACITY (how many whole rows fit), not how many rows happen to
+    // be peeking through right now — a partially-clipped row does not count toward the 2.
     LaunchedEffect(focusedGameIndex, columns) {
         if (focusedGameIndex in games.indices) {
-            gridState.animateScrollToItem((focusedGameIndex - columns).coerceAtLeast(0))
+            val info = gridState.layoutInfo
+            val rowHeightPx = info.visibleItemsInfo.firstOrNull()?.size?.height ?: 0
+            val rowPitchPx = rowHeightPx + gridSpacingPx
+            // Space available to lay out rows, inside the content padding.
+            val contentHeightPx = info.viewportSize.height - info.beforeContentPadding - info.afterContentPadding
+            // n whole rows occupy n*rowHeight + (n-1)*spacing, i.e. n*rowPitch - spacing.
+            val wholeRowsThatFit =
+                if (rowPitchPx > 0) (contentHeightPx + gridSpacingPx) / rowPitchPx else 0
+            val target = if (wholeRowsThatFit >= 2) {
+                (focusedGameIndex - columns).coerceAtLeast(0)   // second-row anchor (context above)
+            } else {
+                (focusedGameIndex / columns) * columns          // top-row anchor (focused row first)
+            }
+            gridState.animateScrollToItem(target)
         }
     }
 
@@ -111,8 +135,8 @@ fun GridHomeContent(
             // Extra top padding so a focused top-row card (which scales 1.16× and bobs upward) clears
             // the header instead of being clipped under it.
             contentPadding        = PaddingValues(start = 8.dp, end = 8.dp, top = 30.dp, bottom = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement   = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(gridSpacing),
+            verticalArrangement   = Arrangement.spacedBy(gridSpacing),
             modifier              = Modifier
                 .fillMaxSize()
                 // Modifier.blur no-ops on API < 31; the effect only runs where RenderEffect exists.


### PR DESCRIPTION
Two grid-layout improvements.

## Master grid size (Settings → Display → Library Layout)
Adds an overall grid-size control, shown **only when the grid layout is selected**. It sets the default tile size for every system's game grid:
- **Per-system sizes still override it** — resize a system from its own grid and that wins.
- **Recents/Favorites are unaffected** — they keep their own fixed sizing.
- Small→large slider with an **Auto** stop (fits the screen).

Implementation reuses the existing legacy `GAME_GRID_COLUMNS` pref, which the per-platform resolver already consumes as the `""` fallback, so per-system overrides work for free. Adds a datastore setter, a repository flow + setter, view-model wiring, and the UI.

## Top-row pinning on short viewports
The controller-focus scroll anchored the selected card to the *second* visible row (one row of context above). On a short viewport — e.g. tall arcade art at a large grid size where barely one full row fits — that pushed the selected card off the bottom edge. Now it measures how many **whole** rows fit and, when fewer than two do, pins the focused card's row to the top so it stays fully on screen.

## Testing
- Compiles clean (`assembleFullDebug`).
- Sideloaded on the RG DS: verified the short-viewport case (FinalBurn Neo at a large grid size) now keeps the selection on screen, and the new Grid size control appears under Library Layout only in grid mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)