### PR TITLE
Dark-mode contrast, per-system scrape, launch scan, ES-DE-aware scraping, dual-screen tab icons

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -93,6 +93,7 @@ class MainActivity : ComponentActivity() {
     @Inject lateinit var mediaRepository: MediaRepository
     @Inject lateinit var lockedModeRepository: LockedModeRepository
     @Inject lateinit var checkForUpdateUseCase: CheckForUpdateUseCase
+    @Inject lateinit var launchLibraryScanner: com.gamelaunch.frontend.domain.usecase.LaunchLibraryScanner
     @Inject lateinit var syncthingController: com.gamelaunch.frontend.data.sync.SyncthingController
     @Inject lateinit var syncEngineManager: com.gamelaunch.frontend.data.sync.SyncEngineManager
     @Inject lateinit var friendRepository: com.gamelaunch.frontend.domain.repository.FriendRepository
@@ -164,6 +165,10 @@ class MainActivity : ComponentActivity() {
         // cold start — otherwise an update that lands while the app is open is only noticed after a
         // force-close and reopen.
         startSaveSyncIfEnabled()
+        // Quietly pick up games added since last launch (new ROMs/Android/Steam). Runs on its own
+        // app scope so it never blocks the cold-start path; a launch with nothing new does no heavy
+        // work. First-run is skipped inside the scanner (onboarding owns the initial scan).
+        launchLibraryScanner.scanOnLaunch()
         handleFriendDeepLink(intent)
 
         setContent {

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
@@ -36,10 +36,21 @@ interface GameDao {
     @Query("SELECT * FROM games WHERE is_scraped = 0 ORDER BY title ASC")
     suspend fun getUnscrapedGames(): List<GameEntity>
 
+    /** Just the rom paths of non-Android games — a cheap set for the launch "any new ROMs?" check. */
+    @Query("SELECT rom_path FROM games WHERE platform_id != 'android'")
+    suspend fun getNonAndroidRomPaths(): List<String>
+
     /**
-     * Games that still need scraping for the enabled options: never scraped, or scraped but
-     * missing any artwork/metadata the user has turned on. Games that already have everything
-     * enabled are skipped. Flags are passed as 1/0.
+     * Games that still need scraping: missing any enabled artwork (box art / screenshots / wheel
+     * logos / videos) or, when metadata is enabled, a description. A game is judged purely on what it
+     * actually has — art and descriptions imported from ES-DE, an embedded ROM cover, or a previous
+     * scrape all count — so a game that already has everything enabled is skipped even if it never
+     * went through the network scraper. Flags are passed as 1/0.
+     *
+     * Deliberately NOT gated on `is_scraped`: that flag is only set by the network scraper, so gating
+     * on it re-queued every ES-DE-/embedded-imported game (which already has art) — a big cause of an
+     * implausibly huge "needs scraping" count. Descriptions from ES-DE's gamelist.xml are imported so
+     * the metadata clause below doesn't flag games that already have a local description.
      */
     @Query(
         """
@@ -47,8 +58,7 @@ interface GameDao {
         LEFT JOIN game_media m ON m.game_id = g.id
         WHERE g.rom_filename NOT LIKE '.%'
           AND (
-            g.is_scraped = 0
-            OR (:needMeta = 1 AND g.description IS NULL)
+            (:needMeta = 1 AND g.description IS NULL)
             OR (:needBox = 1 AND m.box_art_local IS NULL AND m.box_art_remote IS NULL)
             OR (:needShot = 1 AND m.screenshot_local IS NULL AND m.screenshot_remote IS NULL)
             OR (:needWheel = 1 AND m.wheel_logo_local IS NULL AND m.wheel_logo_remote IS NULL)
@@ -137,6 +147,10 @@ interface GameDao {
 
     @Query("UPDATE games SET title = :title, is_scraped = 1 WHERE id = :gameId")
     suspend fun updateTitle(gameId: Long, title: String)
+
+    /** Fill a game's description only if it doesn't already have one (ES-DE gamelist.xml import). */
+    @Query("UPDATE games SET description = :description WHERE id = :gameId AND (description IS NULL OR description = '')")
+    suspend fun fillDescriptionIfMissing(gameId: Long, description: String)
 
     @Query("UPDATE games SET is_favorite = :isFavorite WHERE id = :gameId")
     suspend fun setFavorite(gameId: Long, isFavorite: Boolean)

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/GameRepositoryImpl.kt
@@ -29,6 +29,9 @@ class GameRepositoryImpl @Inject constructor(
     override suspend fun getUnscrapedGames(): List<Game> =
         gameDao.getUnscrapedGames().map(GameEntity::toDomain)
 
+    override suspend fun getNonAndroidRomPaths(): List<String> =
+        gameDao.getNonAndroidRomPaths()
+
     override suspend fun getGamesNeedingScrape(
         needMeta: Boolean,
         needBox: Boolean,
@@ -82,6 +85,10 @@ class GameRepositoryImpl @Inject constructor(
 
     override suspend fun markScraped(gameId: Long, title: String) {
         gameDao.updateTitle(gameId, title)
+    }
+
+    override suspend fun fillDescriptionIfMissing(gameId: Long, description: String) {
+        gameDao.fillDescriptionIfMissing(gameId, description)
     }
 
     override suspend fun setFavorite(gameId: Long, isFavorite: Boolean) {

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/GameRepository.kt
@@ -9,7 +9,9 @@ interface GameRepository {
     suspend fun getGameById(id: Long): Game?
     suspend fun getGameByRomPath(romPath: String): Game?
     suspend fun getUnscrapedGames(): List<Game>
-    /** Games missing any of the enabled scrape outputs (skips ones that already have everything). */
+    /** Rom paths of all non-Android games — a cheap set for the launch "any new ROMs?" check. */
+    suspend fun getNonAndroidRomPaths(): List<String>
+    /** Games missing any enabled scrape output (artwork types + description when metadata is on). */
     suspend fun getGamesNeedingScrape(
         needMeta: Boolean,
         needBox: Boolean,
@@ -27,6 +29,8 @@ interface GameRepository {
     suspend fun updateScrapedMetadata(gameId: Long, scraperGameId: Long?, title: String, description: String?, genre: String?, releaseYear: Int?, rating: Float?)
     /** Mark a game as scraped and keep its title without touching description/genre/year/rating. */
     suspend fun markScraped(gameId: Long, title: String)
+    /** Fill a game's description only if it's currently empty (used by ES-DE gamelist.xml import). */
+    suspend fun fillDescriptionIfMissing(gameId: Long, description: String)
     suspend fun setFavorite(gameId: Long, isFavorite: Boolean)
     suspend fun setAvailableInLockedMode(gameId: Long, available: Boolean)
     suspend fun recordPlay(gameId: Long)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/BatchScrapeUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/BatchScrapeUseCase.kt
@@ -1,11 +1,14 @@
 package com.gamelaunch.frontend.domain.usecase
 
 import android.database.sqlite.SQLiteFullException
+import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import java.io.IOException
 import javax.inject.Inject
@@ -36,18 +39,46 @@ private fun Throwable.isOutOfSpace(): Boolean {
 
 class BatchScrapeUseCase @Inject constructor(
     private val gameRepository: GameRepository,
-    private val scrapeGameUseCase: ScrapeGameUseCase
+    private val scrapeGameUseCase: ScrapeGameUseCase,
+    private val importEsdeMediaUseCase: ImportEsdeMediaUseCase,
+    private val settingsRepository: SettingsRepository
 ) {
-    operator fun invoke(config: ScraperConfig): Flow<BatchScrapeState> = flow {
-        // Only scrape games missing something the user has enabled — fully-complete games are
-        // skipped so re-running the scrape doesn't re-fetch everything.
-        val games = gameRepository.getGamesNeedingScrape(
+    /** Games still missing enabled artwork/metadata, optionally scoped to one [platformId]. */
+    private suspend fun candidates(config: ScraperConfig, platformId: String?): List<Game> {
+        val all = gameRepository.getGamesNeedingScrape(
             needMeta  = config.scrapeMetadata,
             needBox   = config.scrapeBoxArt,
             needShot  = config.scrapeScreenshots,
             needWheel = config.scrapeWheelLogos,
             needVideo = config.scrapeVideos
         )
+        return if (platformId == null) all else all.filter { it.platformId == platformId }
+    }
+
+    /**
+     * @param platformId when non-null, only that system's games are scraped (the game grid's
+     *   Select-menu "Scrape artwork" action); null scrapes the whole library.
+     */
+    operator fun invoke(config: ScraperConfig, platformId: String? = null): Flow<BatchScrapeState> = flow {
+        // Only scrape games missing something the user has enabled — fully-complete games are
+        // skipped so re-running the scrape doesn't re-fetch everything.
+        var games = candidates(config, platformId)
+
+        // Before hitting the network, satisfy artwork that already exists in the user's ES-DE media
+        // library (either configured folder). Anything ES-DE fills in is then dropped from the scrape
+        // list, so a game that already has art on the ES-DE filesystem is never needlessly re-scraped.
+        if (games.isNotEmpty()) {
+            val esdeFolders = listOf(
+                settingsRepository.mediaFolderPath.first(),
+                settingsRepository.mediaStoragePath.first()
+            ).filter { it.isNotBlank() }.distinct()
+            var importedAny = false
+            for (folder in esdeFolders) {
+                if (importEsdeMediaUseCase.importForGames(folder, games).isNotEmpty()) importedAny = true
+            }
+            if (importedAny) games = candidates(config, platformId)
+        }
+
         val total = games.size
         val results = mutableListOf<ScrapeResult>()
         var succeeded = 0

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportEsdeMediaUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportEsdeMediaUseCase.kt
@@ -1,13 +1,21 @@
 package com.gamelaunch.frontend.domain.usecase
 
+import android.util.Xml
+import androidx.room.withTransaction
+import com.gamelaunch.frontend.data.db.AppDatabase
 import com.gamelaunch.frontend.data.db.dao.GameMediaDao
 import com.gamelaunch.frontend.data.db.entity.GameMediaEntity
+import com.gamelaunch.frontend.domain.model.Game
 import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.util.StorageUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import org.xmlpull.v1.XmlPullParser
 import java.io.File
 import javax.inject.Inject
 
@@ -17,10 +25,29 @@ sealed class EsdeImportStatus {
     data class Error(val message: String) : EsdeImportStatus()
 }
 
+// Index built once per folder: (platformDir_lc, typeDir_lc, nameWithoutExt) → absolutePath.
+private typealias MediaIndex = HashMap<Triple<String, String, String>, String>
+
 class ImportEsdeMediaUseCase @Inject constructor(
     private val gameRepository: GameRepository,
-    private val gameMediaDao: GameMediaDao
+    private val gameMediaDao: GameMediaDao,
+    private val settingsRepository: SettingsRepository,
+    private val appDatabase: AppDatabase
 ) {
+
+    /** The media files ES-DE holds for one game (any subset may be present). */
+    private data class ResolvedEsdeMedia(
+        val boxArt: String?,
+        val screenshot: String?,
+        val video: String?,
+        val background: String?,
+        val wheelLogo: String?,
+        val miximage: String?
+    ) {
+        val hasAny: Boolean
+            get() = boxArt != null || screenshot != null || video != null ||
+                    background != null || wheelLogo != null || miximage != null
+    }
 
     // Maps our internal platformId → the directory names ES-DE uses (try in order)
     private val platformDirMap = mapOf(
@@ -52,23 +79,23 @@ class ImportEsdeMediaUseCase @Inject constructor(
         "pico8"     to listOf("pico8"),
     )
 
-    operator fun invoke(mediaFolderPath: String): Flow<EsdeImportStatus> = flow {
-        emit(EsdeImportStatus.Scanning)
-
+    /** Resolve the ES-DE `downloaded_media` root under [mediaFolderPath], or null if inaccessible. */
+    private fun resolveRoot(mediaFolderPath: String): File? {
+        if (mediaFolderPath.isBlank()) return null
         val picked = File(mediaFolderPath)
-        // Accept ES-DE root (contains downloaded_media/) or the folder itself
-        val root = when {
+        return when {
             File(picked, "downloaded_media").isDirectory -> File(picked, "downloaded_media")
             picked.isDirectory -> picked
-            else -> {
-                emit(EsdeImportStatus.Error("Folder not accessible: $mediaFolderPath"))
-                return@flow
-            }
+            else -> null
         }
+    }
 
-        // Build index: (platformDir_lc, typeDir_lc, nameWithoutExt) → absolutePath
-        // This avoids per-game filesystem traversal (O(files) once vs O(games*files))
-        val index = HashMap<Triple<String, String, String>, String>()
+    /**
+     * Build the (platformDir, typeDir, name) → path index once for the whole folder, avoiding
+     * per-game filesystem traversal (O(files) once vs O(games*files)).
+     */
+    private fun buildIndex(root: File): MediaIndex {
+        val index = MediaIndex()
         root.listFiles()?.forEach { platformDir ->
             if (!platformDir.isDirectory) return@forEach
             val pKey = platformDir.name.lowercase()
@@ -80,66 +107,203 @@ class ImportEsdeMediaUseCase @Inject constructor(
                 }
             }
         }
+        return index
+    }
 
-        if (index.isEmpty()) {
-            // No existing media in the folder — not an error; it's just empty (e.g. picked for
-            // future storage). Report nothing matched.
+    /** Look a game's media up in [index] across the platform's candidate ES-DE directory names. */
+    private fun resolve(game: Game, index: MediaIndex): ResolvedEsdeMedia {
+        val dirs = (platformDirMap[game.platformId] ?: listOf(game.platformId)).map { it.lowercase() }
+        val nameKey = game.romFilename.substringBeforeLast(".")
+
+        var boxArt:     String? = null
+        var screenshot: String? = null
+        var video:      String? = null
+        var background: String? = null
+        var wheelLogo:  String? = null
+        var miximage:   String? = null
+
+        for (dir in dirs) {
+            boxArt     = boxArt     ?: index[Triple(dir, "box2dfront",   nameKey)]
+                                    ?: index[Triple(dir, "covers",       nameKey)]
+            screenshot = screenshot ?: index[Triple(dir, "screenshots",  nameKey)]
+                                    ?: index[Triple(dir, "titlescreens", nameKey)]
+            video      = video      ?: index[Triple(dir, "videos",       nameKey)]
+            background = background ?: index[Triple(dir, "fanart",       nameKey)]
+                                    ?: index[Triple(dir, "backgrounds",  nameKey)]
+            // ES-DE stores the wheel/logo art in `marquees` (plural). Older ES-DE builds and
+            // other frontends use `marquee`/`wheel`/`logos`, so try those too.
+            wheelLogo  = wheelLogo  ?: index[Triple(dir, "marquees",     nameKey)]
+                                    ?: index[Triple(dir, "marquee",      nameKey)]
+                                    ?: index[Triple(dir, "wheel",        nameKey)]
+                                    ?: index[Triple(dir, "logos",        nameKey)]
+            // ES-DE composites live in `miximages`.
+            miximage   = miximage   ?: index[Triple(dir, "miximages",    nameKey)]
+                                    ?: index[Triple(dir, "miximage",      nameKey)]
+            if (boxArt != null && screenshot != null && video != null &&
+                background != null && wheelLogo != null && miximage != null) break
+        }
+        return ResolvedEsdeMedia(boxArt, screenshot, video, background, wheelLogo, miximage)
+    }
+
+    /** Merge resolved ES-DE paths into the game's media row, keeping anything already stored. */
+    private suspend fun upsert(gameId: Long, media: ResolvedEsdeMedia) {
+        val existing = gameMediaDao.getMediaForGame(gameId)
+        val updated  = (existing ?: GameMediaEntity(gameId = gameId)).copy(
+            boxArtLocalPath     = media.boxArt     ?: existing?.boxArtLocalPath,
+            screenshotLocalPath = media.screenshot ?: existing?.screenshotLocalPath,
+            videoLocalPath      = media.video      ?: existing?.videoLocalPath,
+            backgroundLocalPath = media.background ?: existing?.backgroundLocalPath,
+            wheelLogoLocalPath  = media.wheelLogo  ?: existing?.wheelLogoLocalPath,
+            miximageLocalPath   = media.miximage   ?: existing?.miximageLocalPath,
+        )
+        gameMediaDao.upsertMedia(updated)
+    }
+
+    /**
+     * Apply resolved ES-DE media and gamelist descriptions to [games]; returns ids that got either.
+     * All writes run inside a single transaction — without it, a large library was thousands of
+     * individually-committed UPDATE/UPSERTs, each fsync'ing, which made the scrape's prep phase crawl.
+     */
+    private suspend fun applyToGames(
+        games: List<Game>,
+        index: MediaIndex,
+        descIndex: Map<String, String>
+    ): Set<Long> = appDatabase.withTransaction {
+        val matched = mutableSetOf<Long>()
+        games.forEach { game ->
+            var got = false
+            if (index.isNotEmpty()) {
+                val media = resolve(game, index)
+                if (media.hasAny) {
+                    upsert(game.id, media)
+                    got = true
+                }
+            }
+            if (descIndex.isNotEmpty()) {
+                val desc = descIndex[game.romFilename.substringBeforeLast(".")]
+                if (!desc.isNullOrBlank()) {
+                    gameRepository.fillDescriptionIfMissing(game.id, desc)
+                    got = true
+                }
+            }
+            if (got) matched += game.id
+        }
+        matched
+    }
+
+    /**
+     * Import ES-DE media (and gamelist descriptions) for just [games] from [mediaFolderPath],
+     * returning the ids that matched something. Used by the scraper to satisfy artwork/metadata from
+     * an existing ES-DE library before making any network request. A no-op (empty set) when the
+     * folder is unset/missing and no gamelist descriptions are found.
+     */
+    suspend fun importForGames(mediaFolderPath: String, games: List<Game>): Set<Long> =
+        withContext(Dispatchers.IO) {
+            val root = resolveRoot(mediaFolderPath)
+            val index = root?.let { buildIndex(it) } ?: MediaIndex()
+            val descIndex = buildDescriptionIndex(mediaFolderPath)
+            if (index.isEmpty() && descIndex.isEmpty()) return@withContext emptySet()
+            applyToGames(games, index, descIndex)
+        }
+
+    operator fun invoke(mediaFolderPath: String): Flow<EsdeImportStatus> = flow {
+        emit(EsdeImportStatus.Scanning)
+
+        val root = resolveRoot(mediaFolderPath)
+        if (root == null) {
+            emit(EsdeImportStatus.Error("Folder not accessible: $mediaFolderPath"))
+            return@flow
+        }
+
+        val index = buildIndex(root)
+        val descIndex = buildDescriptionIndex(mediaFolderPath)
+        if (index.isEmpty() && descIndex.isEmpty()) {
+            // No existing media or descriptions — not an error; the folder is just empty (e.g. picked
+            // for future storage). Report nothing matched.
             emit(EsdeImportStatus.Complete(matched = 0, total = 0))
             return@flow
         }
 
         val games = gameRepository.getAllGames().first()
-        var matched = 0
+        val matched = applyToGames(games, index, descIndex)
+        emit(EsdeImportStatus.Complete(matched = matched.size, total = games.size))
+    }.flowOn(Dispatchers.IO)
 
-        games.forEach { game ->
-            val dirs = (platformDirMap[game.platformId] ?: listOf(game.platformId))
-                .map { it.lowercase() }
-            val nameKey = game.romFilename.substringBeforeLast(".")
-
-            var boxArt:     String? = null
-            var screenshot: String? = null
-            var video:      String? = null
-            var background: String? = null
-            var wheelLogo:  String? = null
-            var miximage:   String? = null
-
-            for (dir in dirs) {
-                boxArt     = boxArt     ?: index[Triple(dir, "box2dfront",   nameKey)]
-                                        ?: index[Triple(dir, "covers",       nameKey)]
-                screenshot = screenshot ?: index[Triple(dir, "screenshots",  nameKey)]
-                                        ?: index[Triple(dir, "titlescreens", nameKey)]
-                video      = video      ?: index[Triple(dir, "videos",       nameKey)]
-                background = background ?: index[Triple(dir, "fanart",       nameKey)]
-                                        ?: index[Triple(dir, "backgrounds",  nameKey)]
-                // ES-DE stores the wheel/logo art in `marquees` (plural). Older ES-DE builds and
-                // other frontends use `marquee`/`wheel`/`logos`, so try those too.
-                wheelLogo  = wheelLogo  ?: index[Triple(dir, "marquees",     nameKey)]
-                                        ?: index[Triple(dir, "marquee",      nameKey)]
-                                        ?: index[Triple(dir, "wheel",        nameKey)]
-                                        ?: index[Triple(dir, "logos",        nameKey)]
-                // ES-DE composites live in `miximages`.
-                miximage   = miximage   ?: index[Triple(dir, "miximages",    nameKey)]
-                                        ?: index[Triple(dir, "miximage",      nameKey)]
-                if (boxArt != null && screenshot != null && video != null &&
-                    background != null && wheelLogo != null && miximage != null) break
+    /**
+     * Build a `romNameWithoutExtension → description` map from every ES-DE gamelist.xml reachable
+     * from the media folder: the standard `<ES-DE root>/gamelists/<system>/gamelist.xml`, plus any
+     * gamelist.xml inside the ROM tree (legacy / in-place layout). Empty when none are found.
+     */
+    private suspend fun buildDescriptionIndex(mediaFolderPath: String): Map<String, String> {
+        val roots = LinkedHashSet<File>()
+        if (mediaFolderPath.isNotBlank()) {
+            val picked = File(mediaFolderPath)
+            // The ES-DE root is the folder holding downloaded_media (the picked folder, or its parent
+            // when the user pointed straight at downloaded_media).
+            val esdeRoot = when {
+                File(picked, "downloaded_media").isDirectory -> picked
+                picked.name.equals("downloaded_media", ignoreCase = true) -> picked.parentFile
+                else -> picked
             }
+            esdeRoot?.let { File(it, "gamelists").takeIf(File::isDirectory)?.let(roots::add) }
+            File(picked, "gamelists").takeIf(File::isDirectory)?.let(roots::add)
+        }
+        // Legacy: gamelist.xml living inside the ROM system folders.
+        val romRoot = settingsRepository.romRootPath.first()
+        if (romRoot.isNotBlank()) {
+            File(StorageUtils.resolveStoredPath(romRoot)).takeIf(File::isDirectory)?.let(roots::add)
+        }
+        if (roots.isEmpty()) return emptyMap()
 
-            if (boxArt != null || screenshot != null || video != null ||
-                background != null || wheelLogo != null || miximage != null) {
-                val existing = gameMediaDao.getMediaForGame(game.id)
-                val updated  = (existing ?: GameMediaEntity(gameId = game.id)).copy(
-                    boxArtLocalPath     = boxArt     ?: existing?.boxArtLocalPath,
-                    screenshotLocalPath = screenshot ?: existing?.screenshotLocalPath,
-                    videoLocalPath      = video      ?: existing?.videoLocalPath,
-                    backgroundLocalPath = background ?: existing?.backgroundLocalPath,
-                    wheelLogoLocalPath  = wheelLogo  ?: existing?.wheelLogoLocalPath,
-                    miximageLocalPath   = miximage   ?: existing?.miximageLocalPath,
-                )
-                gameMediaDao.upsertMedia(updated)
-                matched++
+        // ES-DE keeps exactly one gamelist.xml per system: <root>/<system>/gamelist.xml (and some
+        // setups put one at <root>/gamelist.xml). Look those up directly — a handful of stat calls
+        // per root — instead of walking the whole (potentially enormous) ROM tree to find them.
+        val out = HashMap<String, String>()
+        roots.flatMap(::gamelistFilesIn).distinctBy { it.absolutePath }
+            .forEach { parseGamelistDescriptions(it, out) }
+        return out
+    }
+
+    /** gamelist.xml files directly under [root] and each of its immediate sub-folders. */
+    private fun gamelistFilesIn(root: File): List<File> {
+        val found = ArrayList<File>()
+        File(root, "gamelist.xml").takeIf(File::isFile)?.let(found::add)
+        root.listFiles()?.forEach { child ->
+            if (child.isDirectory) File(child, "gamelist.xml").takeIf(File::isFile)?.let(found::add)
+        }
+        return found
+    }
+
+    /** Read `<game><path>…</path><desc>…</desc></game>` entries into [out], keyed by rom base name. */
+    private fun parseGamelistDescriptions(file: File, out: HashMap<String, String>) {
+        runCatching {
+            file.inputStream().use { stream ->
+                val parser = Xml.newPullParser().apply {
+                    setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, false)
+                    setInput(stream, null)
+                }
+                var event = parser.eventType
+                while (event != XmlPullParser.END_DOCUMENT) {
+                    if (event == XmlPullParser.START_TAG && parser.name == "game") {
+                        var path: String? = null
+                        var desc: String? = null
+                        var e = parser.next()
+                        while (!(e == XmlPullParser.END_TAG && parser.name == "game")) {
+                            if (e == XmlPullParser.START_TAG) {
+                                when (parser.name) {
+                                    "path" -> path = parser.nextText().trim()
+                                    "desc" -> desc = parser.nextText().trim()
+                                    else   -> { /* skip other fields */ }
+                                }
+                            }
+                            e = parser.next()
+                        }
+                        val key = path?.let { File(it).nameWithoutExtension }
+                        if (!key.isNullOrBlank() && !desc.isNullOrBlank()) out.putIfAbsent(key, desc)
+                    }
+                    event = parser.next()
+                }
             }
         }
-
-        emit(EsdeImportStatus.Complete(matched = matched, total = games.size))
-    }.flowOn(Dispatchers.IO)
+    }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
@@ -1,0 +1,71 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * On each app launch (returning users only — the very first run goes through
+ * [FirstRunSetupManager]), quietly pick up games added since the last launch: newly-installed
+ * Android games, new Steam-library entries, and new ROMs. The ROM folder is checked with a fast,
+ * no-hash probe first ([ScanRomsUseCase.hasNewGames]), so the expensive full ROM scan only runs when
+ * there's actually something new on disk — a launch with nothing new does no heavy work and the user
+ * lands straight on Home.
+ *
+ * App-scoped (its own scope, not a viewModelScope) so a scan started at launch keeps running even if
+ * the user navigates around; Home reflects additions live because its lists are Room-backed.
+ */
+@Singleton
+class LaunchLibraryScanner @Inject constructor(
+    private val scanRomsUseCase: ScanRomsUseCase,
+    private val scanAndroidGamesUseCase: ScanAndroidGamesUseCase,
+    private val scanSteamLibraryUseCase: ScanSteamLibraryUseCase,
+    private val settingsRepository: SettingsRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // True only while the (potentially slow) full ROM scan runs, so Home can show a lightweight
+    // "scanning for new games" indicator. The sub-second Android/Steam refreshes don't flip it.
+    private val _isScanning = MutableStateFlow(false)
+    val isScanning: StateFlow<Boolean> = _isScanning
+
+    @Volatile private var started = false
+
+    /** Kick off the launch scan once per process. Safe to call from every onCreate. */
+    fun scanOnLaunch() {
+        if (started) return
+        started = true
+        scope.launch { run() }
+    }
+
+    private suspend fun run() {
+        // Never fight the first-run setup pipeline — onboarding owns the initial full scan.
+        if (settingsRepository.isFirstLaunch.first()) return
+
+        // Android + Steam: cheap and idempotent — refresh quietly to catch new installs / entries.
+        runCatching { scanAndroidGamesUseCase().collect { } }
+        if (settingsRepository.steamLibraryPath.first().isNotBlank()) {
+            runCatching { scanSteamLibraryUseCase().collect { } }
+        }
+
+        // ROMs: only run the hashing full scan when the quick probe finds something new on disk.
+        val romPath = settingsRepository.romRootPath.first()
+        val romsHaveNew = romPath.isNotBlank() &&
+            runCatching { scanRomsUseCase.hasNewGames(romPath) }.getOrDefault(false)
+        if (romsHaveNew) {
+            _isScanning.value = true
+            try {
+                runCatching { scanRomsUseCase(romPath).collect { } }
+            } finally {
+                _isScanning.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.security.MessageDigest
 import java.util.zip.ZipInputStream
@@ -45,18 +46,16 @@ class ScanRomsUseCase @Inject constructor(
         "license", "appmeta", "ppsspp_state", "private"
     )
 
-    operator fun invoke(rootPath: String): Flow<ScanProgress> = flow {
-        // Refresh the prod.keys search once per scan. The locator memoises its (expensive) storage
-        // walk so it runs once for the whole scan rather than once per NSP; invalidating here keeps
-        // that cache from hiding a key file the user added since the previous scan.
-        prodKeysLocator.invalidate()
-
+    /**
+     * The library-eligible ROM files under [rootPath] — the walk + cue/m3u de-duplication +
+     * platform-exclusion filtering, shared by the full [invoke] scan and the quick [hasNewGames]
+     * check so both agree on exactly which files count as games. Returns null when the root folder
+     * doesn't exist.
+     */
+    private suspend fun collectFilteredRomFiles(rootPath: String): List<File>? {
         val resolvedPath = StorageUtils.resolveStoredPath(rootPath)
         val rootDir = File(resolvedPath)
-        if (!rootDir.exists() || !rootDir.isDirectory) {
-            emit(ScanProgress(0, 0, "Root folder not found: $resolvedPath"))
-            return@flow
-        }
+        if (!rootDir.exists() || !rootDir.isDirectory) return null
 
         // Paths the user has manually removed from the library — never re-add them.
         val excludedPaths = settingsRepository.excludedPaths.first()
@@ -83,11 +82,40 @@ class ScanRomsUseCase @Inject constructor(
             }
         }
 
-        val filteredRomFiles = romFiles.filterNot { file ->
+        return romFiles.filterNot { file ->
             getNormalizedPath(file) in referencedPaths
         }.filterNot { file ->
             val platform = platformDetector.detect(file, file.parentFile?.name ?: "")
             shouldExcludeFromLibrary(file, platform?.id)
+        }
+    }
+
+    /**
+     * A fast check — no hashing, no DB writes — for whether the ROM folder holds any game not yet in
+     * the library. Used by the launch auto-scan to decide if the (expensive, hashing) full [invoke]
+     * scan is worth running. Only detects additions; removals are reconciled by a full scan.
+     */
+    suspend fun hasNewGames(rootPath: String): Boolean = withContext(Dispatchers.IO) {
+        val files = collectFilteredRomFiles(rootPath) ?: return@withContext false
+        if (files.isEmpty()) return@withContext false
+        val knownPaths = gameRepository.getNonAndroidRomPaths().toHashSet()
+        files.any { file ->
+            platformDetector.detect(file, file.parentFile?.name ?: "") != null &&
+                file.absolutePath !in knownPaths
+        }
+    }
+
+    operator fun invoke(rootPath: String): Flow<ScanProgress> = flow {
+        // Refresh the prod.keys search once per scan. The locator memoises its (expensive) storage
+        // walk so it runs once for the whole scan rather than once per NSP; invalidating here keeps
+        // that cache from hiding a key file the user added since the previous scan.
+        prodKeysLocator.invalidate()
+
+        val filteredRomFiles = collectFilteredRomFiles(rootPath)
+        if (filteredRomFiles == null) {
+            val resolvedPath = StorageUtils.resolveStoredPath(rootPath)
+            emit(ScanProgress(0, 0, "Root folder not found: $resolvedPath"))
+            return@flow
         }
 
         val validPaths = mutableListOf<String>()

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkBus.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkBus.kt
@@ -9,12 +9,22 @@ import javax.inject.Singleton
 
 /** What the artwork (top) screen is currently showing. */
 enum class ArtworkMode {
-    /** No game context yet (onboarding, splash, non-Games tab) — show branding. */
+    /** No game context yet (onboarding, splash, non-Games tab) — show branding or a section icon. */
     IDLE,
     /** Browsing the system grid — show the focused system's preview art. */
     SYSTEM_GRID,
     /** Inside a system — show the selected game's screenshot / video / box art. */
     GAME
+}
+
+/**
+ * Which home-screen section the bottom screen is on when there's no game art to show (ArtworkMode
+ * .IDLE). The top panel mirrors it with the matching tab icon — the same way the Settings area shows
+ * a gear — so a dual-screen user always sees what they're browsing on the top panel. [BRANDING] is
+ * the neutral fallback (onboarding, splash, the Games tab before any system is focused).
+ */
+enum class TopScreenSection {
+    BRANDING, FAVORITES, RECENTLY_PLAYED, APPS, RETROACHIEVEMENTS, FRIENDS
 }
 
 /** Immutable snapshot the [ArtworkPresentation] renders on the second screen. */
@@ -28,7 +38,9 @@ data class ArtworkUiState(
     val focusedPlatformId: String? = null,
     val title: String? = null,
     /** Which media the top panel renders in GAME mode (marquee / screenshot / miximage). */
-    val topImageType: TopScreenImage = TopScreenImage.MARQUEE
+    val topImageType: TopScreenImage = TopScreenImage.MARQUEE,
+    /** In IDLE mode, which non-game home section is active, so the top panel shows its icon. */
+    val idleSection: TopScreenSection = TopScreenSection.BRANDING
 )
 
 /**

--- a/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkPresentation.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/dualscreen/ArtworkPresentation.kt
@@ -13,8 +13,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -144,7 +150,19 @@ private fun ArtworkScreen(artworkBus: ArtworkBus) {
                 )
 
                     ArtworkMode.IDLE -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        BrandPlaceholder()
+                        val sectionIcon = sectionIcon(state.idleSection)
+                        if (sectionIcon != null) {
+                            // Mirror the bottom screen's active tab with its icon, themed like the
+                            // Settings gear: solid white on dark, solid black on light.
+                            Icon(
+                                imageVector = sectionIcon,
+                                contentDescription = null,
+                                tint = if (darkMode) Color.White else Color.Black,
+                                modifier = Modifier.fillMaxSize(0.34f)
+                            )
+                        } else {
+                            BrandPlaceholder()
+                        }
                     }
                 }
             }
@@ -298,6 +316,20 @@ private fun marqueeImage(media: GameMedia?): String? {
     val local = m.wheelLogoLocalPath
         ?.takeIf { it.isNotBlank() && File(it).let { f -> f.exists() && f.length() > 0 } }
     return local ?: m.wheelLogoRemoteUrl?.takeIf { it.isNotBlank() }
+}
+
+/**
+ * The icon mirroring a non-game home tab on the top panel — matched to the bottom screen's tab bar
+ * (see HomeScreen's tabSpecs). [TopScreenSection.BRANDING] returns null so the neutral brand
+ * placeholder is shown instead.
+ */
+private fun sectionIcon(section: TopScreenSection): ImageVector? = when (section) {
+    TopScreenSection.FAVORITES        -> Icons.Default.Favorite
+    TopScreenSection.RECENTLY_PLAYED  -> Icons.Default.History
+    TopScreenSection.APPS             -> Icons.Default.Apps
+    TopScreenSection.RETROACHIEVEMENTS -> Icons.Default.EmojiEvents
+    TopScreenSection.FRIENDS          -> Icons.Default.Group
+    TopScreenSection.BRANDING         -> null
 }
 
 @Composable

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
@@ -83,6 +83,9 @@ fun AppNavGraph(
                 onSettingsClick = {
                     if (canAccessProtectedRoutes) navController.navigate(Screen.Settings.route)
                 },
+                onScrapeSystem = { platformId ->
+                    navController.navigate(Screen.ScrapeProgress.route(platformId))
+                },
                 lockedModeViewModel = lockedModeViewModel
             )
         }
@@ -110,7 +113,7 @@ fun AppNavGraph(
                     onEmulatorConfigClick = { navController.navigate(Screen.EmulatorConfig.route) },
                     onManageAllowedGames = { navController.navigate(Screen.LockedModeGames.route) },
                     onManageAllowedApps = { navController.navigate(Screen.LockedModeApps.route) },
-                    onScrapeAllClick = { navController.navigate(Screen.ScrapeProgress.route) },
+                    onScrapeAllClick = { navController.navigate(Screen.ScrapeProgress.route()) },
                     onRescanClick = { navController.navigate(Screen.Scan.route) }
                 )
             }
@@ -134,7 +137,14 @@ fun AppNavGraph(
             }
         }
 
-        composable(Screen.ScrapeProgress.route) {
+        composable(
+            route = Screen.ScrapeProgress.route,
+            arguments = listOf(navArgument(Screen.ScrapeProgress.ARG_PLATFORM_ID) {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            })
+        ) {
             ProtectedRoute(lockedModeState, navController) {
                 ScrapeProgressScreen(onBack = { navController.backOrHome() })
             }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/Screen.kt
@@ -8,8 +8,14 @@ sealed class Screen(val route: String) {
     object LockedModeGames : Screen("locked_mode_games")
     object LockedModeApps : Screen("locked_mode_apps")
     object EmulatorConfig : Screen("emulator_config")
-    object ScrapeProgress : Screen("scrape_progress")
     object About : Screen("about")
+
+    object ScrapeProgress : Screen("scrape_progress?platformId={platformId}") {
+        const val ARG_PLATFORM_ID = "platformId"
+        /** No platformId scrapes the whole library; a platformId scrapes just that system. */
+        fun route(platformId: String? = null) =
+            if (platformId == null) "scrape_progress" else "scrape_progress?platformId=$platformId"
+    }
 
     object GameDetail : Screen("game_detail/{gameId}") {
         const val ARG_GAME_ID = "gameId"

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/GameViewOptions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/GameViewOptions.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -33,17 +34,17 @@ import androidx.compose.ui.zIndex
 import com.gamelaunch.frontend.domain.model.GameSort
 import com.gamelaunch.frontend.ui.theme.BrandBlue
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
-import com.gamelaunch.frontend.ui.theme.IceWhite
-import com.gamelaunch.frontend.ui.theme.LocalDarkMode
-import com.gamelaunch.frontend.ui.theme.SteelGray
-import com.gamelaunch.frontend.ui.theme.TileSub
-import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassTile
+import com.gamelaunch.frontend.ui.theme.tileTextPrimary
+import com.gamelaunch.frontend.ui.theme.tileTextSecondary
 import kotlin.math.roundToInt
 
 /** Rows in the quick menu: index 0 is the grid-size slider, then one row per [GameSort]. */
 val gameSortOptions: List<GameSort> = GameSort.entries.toList()
-const val GAME_OPTIONS_ROWS: Int = 1 + 4   // size + four sort choices
+// size slider + one row per sort choice + the "Scrape artwork" action row (always last).
+val GAME_OPTIONS_ROWS: Int = 1 + gameSortOptions.size + 1
+/** Focus index of the "Scrape artwork" action row (the last row). */
+val GAME_OPTIONS_SCRAPE_ROW: Int = GAME_OPTIONS_ROWS - 1
 
 /**
  * A small controller-first quick menu shown over the game grid (opened with Select). Row focus and
@@ -63,11 +64,13 @@ fun GameViewOptions(
     focusIndex: Int,
     onSetColumns: (Int) -> Unit,
     onPickSort: (GameSort) -> Unit,
+    onScrapeArtwork: () -> Unit,
     onClose: () -> Unit
 ) {
-    val darkMode = LocalDarkMode.current
-    val textPrimary = if (darkMode) IceWhite else TileText
-    val textSecondary = if (darkMode) SteelGray else TileSub
+    // The panel is a coloured glass tile, so use the tile-aware text colours for readable contrast
+    // in dark mode instead of the on-background greys.
+    val textPrimary = tileTextPrimary()
+    val textSecondary = tileTextSecondary()
 
     // Rendered inside HomeScreen's root Box so its focusable keeps receiving controller keys.
     Box(
@@ -138,6 +141,33 @@ fun GameViewOptions(
                         }
                     }
                     Spacer(Modifier.height(4.dp))
+                }
+
+                // ── Scrape artwork for just this system ─────────────────────
+                Spacer(Modifier.height(6.dp))
+                OptionRow(focused = focusIndex == GAME_OPTIONS_SCRAPE_ROW, onClick = onScrapeArtwork) {
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.Image,
+                            contentDescription = null,
+                            tint = ElectricBlue,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                "Scrape artwork",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.SemiBold,
+                                color = textPrimary
+                            )
+                            Text(
+                                "Fetch missing box art & media for this system",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = textSecondary
+                            )
+                        }
+                    }
                 }
 
                 Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -113,6 +114,7 @@ private const val CAROUSEL_PAGE = 10
 fun HomeScreen(
     onGameClick: (Long) -> Unit,
     onSettingsClick: () -> Unit,
+    onScrapeSystem: (String) -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel(),
     appsViewModel: AppsViewModel = hiltViewModel(),
     lockedModeViewModel: LockedModeViewModel = hiltViewModel()
@@ -416,8 +418,17 @@ fun HomeScreen(
                                 viewModel.setGameGridColumns((gameGridColumns + 1).coerceAtMost(maxGameCols))
                             Key.DirectionRight -> if (optionsFocusIndex == 0)
                                 viewModel.setGameGridColumns((gameGridColumns - 1).coerceAtLeast(minGameCols))
-                            GamepadA, Key.DirectionCenter, Key.Enter ->
-                                if (optionsFocusIndex >= 1) viewModel.setGameSort(gameSortOptions[optionsFocusIndex - 1])
+                            GamepadA, Key.DirectionCenter, Key.Enter -> {
+                                val sortIdx = optionsFocusIndex - 1
+                                when {
+                                    sortIdx in gameSortOptions.indices ->
+                                        viewModel.setGameSort(gameSortOptions[sortIdx])
+                                    optionsFocusIndex == GAME_OPTIONS_SCRAPE_ROW -> {
+                                        showGameOptions = false
+                                        state.selectedPlatform?.let(onScrapeSystem)
+                                    }
+                                }
+                            }
                             GamepadB, Key.Back, GamepadSelect -> showGameOptions = false
                             else -> {}
                         }
@@ -544,6 +555,25 @@ fun HomeScreen(
                         )
                         Text("e",  fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = BrandBlue, letterSpacing = 2.sp)
                         Text("Or", fontSize = 22.sp, fontWeight = FontWeight.ExtraBold, color = textPrimary, letterSpacing = 2.sp)
+
+                        // Launch auto-scan found new ROMs and is adding them — small live indicator.
+                        // Shown only on the system grid / non-game views so it never crowds the
+                        // in-system breadcrumb.
+                        if (state.isScanningLibrary && !(state.topTab == TopTab.GAMES && state.gameViewActive)) {
+                            Spacer(Modifier.width(12.dp))
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(14.dp),
+                                strokeWidth = 2.dp,
+                                color = BrandBlue
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(
+                                "Scanning for new games…",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = textSecondary,
+                                maxLines = 1
+                            )
+                        }
 
                         // Inside a system, breadcrumb: eOr · <Console> → <hovered game>
                         if (state.topTab == TopTab.GAMES && state.gameViewActive) {
@@ -767,6 +797,10 @@ fun HomeScreen(
                     focusIndex   = optionsFocusIndex,
                     onSetColumns = viewModel::setGameGridColumns,
                     onPickSort   = viewModel::setGameSort,
+                    onScrapeArtwork = {
+                        showGameOptions = false
+                        state.selectedPlatform?.let(onScrapeSystem)
+                    },
                     onClose      = { showGameOptions = false }
                 )
             }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeViewModel.kt
@@ -19,6 +19,7 @@ import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
 import com.gamelaunch.frontend.ui.dualscreen.ArtworkBus
 import com.gamelaunch.frontend.ui.dualscreen.ArtworkMode
 import com.gamelaunch.frontend.ui.dualscreen.ArtworkUiState
+import com.gamelaunch.frontend.ui.dualscreen.TopScreenSection
 import com.gamelaunch.frontend.ui.perf.PerformanceState
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -67,7 +68,9 @@ data class HomeUiState(
     val videoDelayMs: Long = 1500L,
     val topScreenImage: com.gamelaunch.frontend.ui.dualscreen.TopScreenImage =
         com.gamelaunch.frontend.ui.dualscreen.TopScreenImage.MARQUEE,
-    val isLoading: Boolean = true
+    val isLoading: Boolean = true,
+    // True while the launch auto-scan is adding newly-found ROMs, for a small Home indicator.
+    val isScanningLibrary: Boolean = false
 )
 
 @HiltViewModel
@@ -79,7 +82,8 @@ class HomeViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val lockedModeRepository: LockedModeRepository,
     private val artworkBus: ArtworkBus,
-    private val performanceState: PerformanceState
+    private val performanceState: PerformanceState,
+    private val launchLibraryScanner: com.gamelaunch.frontend.domain.usecase.LaunchLibraryScanner
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -128,6 +132,16 @@ class HomeViewModel @Inject constructor(
                     !state.gameViewActive -> ArtworkMode.SYSTEM_GRID
                     else -> ArtworkMode.GAME
                 }
+                // On a non-Games tab (mode IDLE) tell the top panel which section it is, so it shows
+                // that tab's icon — mirroring the bottom screen the way the Settings gear does.
+                val idleSection = when (state.topTab) {
+                    TopTab.FAVORITES        -> TopScreenSection.FAVORITES
+                    TopTab.RECENTLY_PLAYED  -> TopScreenSection.RECENTLY_PLAYED
+                    TopTab.APPS             -> TopScreenSection.APPS
+                    TopTab.RETROACHIEVEMENTS -> TopScreenSection.RETROACHIEVEMENTS
+                    TopTab.FRIENDS          -> TopScreenSection.FRIENDS
+                    TopTab.GAMES            -> TopScreenSection.BRANDING
+                }
                 artworkBus.publish(
                     ArtworkUiState(
                         mode = mode,
@@ -137,7 +151,8 @@ class HomeViewModel @Inject constructor(
                         systemPreviewArt = state.systemPreviewArt,
                         focusedPlatformId = state.previewPlatformId,
                         title = selectedGame?.title,
-                        topImageType = state.topScreenImage
+                        topImageType = state.topScreenImage,
+                        idleSection = idleSection
                     )
                 )
             }
@@ -474,6 +489,16 @@ class HomeViewModel @Inject constructor(
         observeFavorites()
         publishArtwork()
         observeLockedModeTransitions()
+        observeLibraryScan()
+    }
+
+    /** Reflect the launch auto-scan's activity so Home can show a small "scanning" indicator. */
+    private fun observeLibraryScan() {
+        viewModelScope.launch {
+            launchLibraryScanner.isScanning.collect { scanning ->
+                _uiState.update { it.copy(isScanningLibrary = scanning) }
+            }
+        }
     }
 
     private companion object {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/SystemSelectionContent.kt
@@ -52,13 +52,13 @@ import com.gamelaunch.frontend.ui.perf.rememberIdleMotion
 import com.gamelaunch.frontend.ui.perf.rememberSelectionScale
 import com.gamelaunch.frontend.ui.theme.BounceDurationMs
 import com.gamelaunch.frontend.ui.theme.BounceEasing
-import com.gamelaunch.frontend.ui.theme.IceWhite
 import com.gamelaunch.frontend.ui.theme.LocalDarkMode
 import com.gamelaunch.frontend.ui.theme.SteelGray
 import com.gamelaunch.frontend.ui.theme.TileSub
-import com.gamelaunch.frontend.ui.theme.TileText
 import com.gamelaunch.frontend.ui.theme.glassTile
 import com.gamelaunch.frontend.ui.theme.tileColor
+import com.gamelaunch.frontend.ui.theme.tileTextPrimary
+import com.gamelaunch.frontend.ui.theme.tileTextSecondary
 
 @Composable
 fun SystemSelectionContent(
@@ -272,9 +272,10 @@ private fun SystemCard(
     // kept its own animation clock ticking; now at most one runs.
     val reduceMotion = LocalReduceMotion.current
     val idle = if (isFocused && !reduceMotion) rememberIdleMotion() else IdleMotion.None
-    val darkMode = LocalDarkMode.current
-    val textPrimary = if (darkMode) IceWhite else TileText
-    val textSecondary = if (darkMode) SteelGray else TileSub
+    // On a coloured tile, use the tile-aware text colours so the counter/label keep enough contrast
+    // in dark mode (SteelGray on the darkened dark-mode tile was nearly unreadable).
+    val textPrimary = tileTextPrimary()
+    val textSecondary = tileTextSecondary()
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeProgressScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
@@ -115,6 +116,27 @@ fun ScrapeProgressScreen(
             }
 
             val batch = state.batchState
+            // Preparing phase: before the first batch tick we check the ES-DE library and work out
+            // which games actually need scraping. On a big library that takes a moment, so show a
+            // clear loading state instead of an empty screen that looks broken.
+            if (batch == null && state.isRunning) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        CircularProgressIndicator()
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            "One moment please…",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "Checking your library for artwork it already has and working out what still needs scraping.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
             if (batch != null) {
                 val progress = if (batch.total > 0) batch.completed.toFloat() / batch.total else 0f
                 LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/scrape/ScrapeViewModel.kt
@@ -1,11 +1,13 @@
 package com.gamelaunch.frontend.ui.screen.scrape
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.domain.usecase.BatchScrapeState
 import com.gamelaunch.frontend.domain.usecase.BatchScrapeUseCase
 import com.gamelaunch.frontend.domain.usecase.ScrapeResult
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.ui.navigation.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,11 +29,16 @@ data class ScrapeUiState(
 @HiltViewModel
 class ScrapeViewModel @Inject constructor(
     private val batchScrapeUseCase: BatchScrapeUseCase,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ScrapeUiState())
     val uiState: StateFlow<ScrapeUiState> = _uiState
+
+    // Non-null when the screen was opened from a system's Select menu ("Scrape artwork" for just
+    // that system); null for the whole-library scrape (Settings → Scrape all).
+    private val platformId: String? = savedStateHandle[Screen.ScrapeProgress.ARG_PLATFORM_ID]
 
     private var scrapeJob: Job? = null
 
@@ -56,7 +63,7 @@ class ScrapeViewModel @Inject constructor(
             _uiState.update { it.copy(isRunning = true) }
             scrapeJob = launch {
                 try {
-                    batchScrapeUseCase(config).collect { state ->
+                    batchScrapeUseCase(config, platformId).collect { state ->
                         _uiState.update { it.copy(batchState = state) }
                     }
                 } catch (e: kotlinx.coroutines.CancellationException) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
@@ -68,6 +68,22 @@ val TilePalette = listOf(
 )
 fun tileColor(index: Int): Color = TilePalette[index % TilePalette.size]
 
+// ── Text drawn on top of a coloured glass tile ──────────────────────────────
+// On a [glassTile] the background is a shade of the tile's colour, not the ambient background, so
+// on-background greys (SteelGray / TileSub) don't have enough contrast in dark mode — in particular
+// the muted SteelGray subtitle nearly vanished on the darker dark-mode tiles. Text on a tile should
+// derive from the tile's own light/dark treatment: near-opaque IceWhite in dark mode (readable on
+// both the darkened unselected tiles and the bright focused one), the existing slate in light mode.
+
+/** Primary (title) colour for text drawn on a coloured glass tile. */
+@Composable
+fun tileTextPrimary(): Color = if (LocalDarkMode.current) IceWhite else TileText
+
+/** Secondary (subtitle/label) colour for text drawn on a coloured glass tile. */
+@Composable
+fun tileTextSecondary(): Color =
+    if (LocalDarkMode.current) IceWhite.copy(alpha = 0.78f) else TileSub
+
 // "Back-ease" bezier — overshoots past the target then settles, for a natural little bounce.
 val BounceEasing = CubicBezierEasing(0.34f, 1.8f, 0.45f, 1f)
 const val BounceDurationMs = 420


### PR DESCRIPTION
Batch of home-screen and scraping improvements.

## 1. Dark-mode contrast
Text on coloured glass tiles (the per-system **game counter**, the Select-menu "View options" panel) used `SteelGray`, which nearly vanished on dark-mode tiles. Added `tileTextPrimary()` / `tileTextSecondary()` theme helpers; on-tile secondary text now uses near-opaque `IceWhite` in dark mode. On-background greys are unchanged.

## 2. Per-system "Scrape artwork" (Select menu)
New action row in the game grid's Select menu scrapes just the current system. `BatchScrapeUseCase` takes an optional `platformId`; the `ScrapeProgress` route carries it via `SavedStateHandle`.

## 3. ES-DE-aware scraping (+ fixes the huge "needs scraping" count)
- Before any network request, the scraper satisfies artwork/metadata from an existing ES-DE library. `ImportEsdeMediaUseCase` gains `importForGames()` and now also imports **descriptions from `gamelist.xml`**.
- **Root-cause fix for the implausible count:** the "needs scraping" gate keyed off `is_scraped`, which is only ever set by the online scraper — so every ES-DE-/embedded-imported game (already having art) tripped it. The gate now judges games purely on the art/description they actually have.
- Added a **"One moment please…"** loading state for the scrape prep phase.
- Perf: ES-DE import writes run in a single transaction, and `gamelist.xml` is located via per-system lookups instead of walking the whole ROM tree.

## 4. Quick scan for new games on launch
`LaunchLibraryScanner` picks up games added since last launch on every launch: cheap Android/Steam refresh always; ROMs full-scanned only when a fast, no-hash probe (`ScanRomsUseCase.hasNewGames`) finds something new. Home shows a small "Scanning for new games…" indicator while the ROM scan runs. First-run (onboarding) is skipped.

## 5. Dual-screen top-panel tab icons
Non-game Home tabs (Favorites / Recent / Apps / RetroAchievements / Friends) now mirror their icon on the top panel, matching the bottom-screen tab bar, the same way the Settings area shows a gear. Themed for light/dark.

## Testing
- `:app:testFullDebugUnitTest` green; both `full` and `lite` debug assemble.
- Installed and launched clean on RP4 Pro (full) and RG DS (lite) — no crashes.
- ⚠️ Verified on **debug** builds only; a minified-release + real-game-launch check is still advisable before tagging. The launch auto-scan does background I/O at startup, which is worth a look on the RK3568 (lite) for responsiveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)