### PR TITLE
feat(locked-mode): block system navigation via embedded wireless ADB

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,11 +41,17 @@ android {
         versionName = "2.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        ndk { abiFilters += listOf("arm64-v8a", "armeabi-v7a") }
+        externalNativeBuild { cmake { cppFlags += "-std=c++17" } }
 
         // ScreenScraper dev credentials — set in local.properties, obfuscated into the APK (see
         // obfuscateSecret above) and decoded at runtime by Secrets.reveal().
         buildConfigField("String", "SS_DEV_ID",       "\"${obfuscateSecret((localProperties["SS_DEV_ID"] as String?) ?: "")}\"")
         buildConfigField("String", "SS_DEV_PASSWORD",  "\"${obfuscateSecret((localProperties["SS_DEV_PASSWORD"] as String?) ?: "")}\"")
+    }
+
+    externalNativeBuild {
+        cmake { path = file("src/main/cpp/CMakeLists.txt") }
     }
 
     buildTypes {
@@ -81,8 +87,10 @@ android {
     }
 
     buildFeatures {
+        aidl = true
         compose = true
         buildConfig = true
+        prefab = true
     }
 
     // The bundled Syncthing daemon (jniLibs/*/libsyncthing.so) must be extracted to a real file in
@@ -91,6 +99,8 @@ android {
         jniLibs {
             useLegacyPackaging = true
         }
+        // Bouncy Castle JARs contain duplicate Java 9 OSGi metadata unused by Android.
+        resources.excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
     }
 
     // The Syncthing daemon is fetched at build time (see the fetchSyncthing task) into this generated
@@ -154,6 +164,10 @@ dependencies {
 
     // Coroutines
     implementation(libs.kotlinx.coroutines.android)
+    // Embedded Wireless ADB. These are bundled in eOr
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.80.2")
+    implementation("org.conscrypt:conscrypt-android:2.5.2")
+    implementation("io.github.vvb2060.ndk:boringssl:20250114")
 
     // Testing
     testImplementation(libs.junit)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -10,3 +10,5 @@
 # needed by the TypeToken<Map<String,String>>(){} usages in EmulatorRepositoryImpl and Converters.
 -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
 -keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+-keep class com.gamelaunch.frontend.systemui.EmbeddedBrokerMain { public static void main(java.lang.String[]); }
+-keep class com.gamelaunch.frontend.systemui.IEorPrivilegeBroker$Stub { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,21 @@
         android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
 
+        <!-- A normal app cannot control system navigation due to platform permission restrictions,
+             the broker runs under Android's privileged shell UID to perform those operations. -->
+        <provider
+            android:name=".systemui.EmbeddedBrokerBootstrapProvider"
+            android:authorities="${applicationId}.privilege.bootstrap"
+            android:enabled="true"
+            android:exported="true"
+            android:multiprocess="false" />
+
+        <!-- Keeps wireless-debugging pairing alive with a foreground notification. -->
+        <service
+            android:name=".systemui.EmbeddedPairingService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/aidl/com/gamelaunch/frontend/systemui/IEorPrivilegeBroker.aidl
+++ b/app/src/main/aidl/com/gamelaunch/frontend/systemui/IEorPrivilegeBroker.aidl
@@ -1,0 +1,8 @@
+package com.gamelaunch.frontend.systemui;
+
+interface IEorPrivilegeBroker {
+    int setNavigationLocked(boolean locked);
+    int getNavigationLockState();
+    int getProtocolVersion();
+    void shutdown();
+}

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(eor_embedded_broker)
+find_package(boringssl REQUIRED CONFIG)
+add_library(eor_adb SHARED eor_adb.cpp)
+add_executable(eor_starter eor_starter.cpp)
+set_target_properties(eor_starter PROPERTIES PREFIX "lib" SUFFIX ".so")
+target_link_libraries(eor_adb log boringssl::crypto_static)
+target_link_libraries(eor_starter log)

--- a/app/src/main/cpp/eor_adb.cpp
+++ b/app/src/main/cpp/eor_adb.cpp
@@ -1,0 +1,145 @@
+/* Copyright 2017-2025 Rikka contributors; 2026 eOr contributors. Apache-2.0. */
+#include <jni.h>
+#include <openssl/aead.h>
+#include <openssl/evp.h>
+#include <openssl/hkdf.h>
+#include <openssl/curve25519.h>
+#include <android/log.h>
+#include <sys/system_properties.h>
+#include <cstdlib>
+#include <cstring>
+
+struct PairingContext {
+    SPAKE2_CTX *spake = nullptr;
+    EVP_AEAD_CTX *aead = nullptr;
+    uint8_t msg[SPAKE2_MAX_MSG_SIZE]{};
+    size_t msg_size = 0;
+    uint64_t enc = 0, dec = 0;
+};
+#define EOR_LOGE(msg) __android_log_write(ANDROID_LOG_ERROR, "EorBroker", msg)
+
+static jlong create(JNIEnv *env, jclass, jboolean client, jbyteArray password) {
+    auto *ctx = new PairingContext();
+    const uint8_t client_name[] = "adb pair client";
+    const uint8_t server_name[] = "adb pair server";
+    ctx->spake = SPAKE2_CTX_new(client ? spake2_role_alice : spake2_role_bob,
+                                client_name, sizeof(client_name), server_name, sizeof(server_name));
+    if (!ctx->spake) {
+        EOR_LOGE("pairing/native/create-context");
+        delete ctx;
+        return 0;
+    }
+    jsize n = env->GetArrayLength(password);
+    jbyte *p = env->GetByteArrayElements(password, nullptr);
+    int ok = SPAKE2_generate_msg(ctx->spake, ctx->msg, &ctx->msg_size,
+                                 sizeof(ctx->msg), reinterpret_cast<uint8_t *>(p), n);
+    env->ReleaseByteArrayElements(password, p, JNI_ABORT);
+    if (!ok || ctx->msg_size == 0) {
+        EOR_LOGE("pairing/native/generate-message");
+        SPAKE2_CTX_free(ctx->spake);
+        delete ctx;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(ctx);
+}
+
+static jbyteArray message(JNIEnv *env, jobject, jlong ptr) {
+    auto *ctx = reinterpret_cast<PairingContext *>(ptr);
+    auto out = env->NewByteArray(ctx->msg_size);
+    env->SetByteArrayRegion(out, 0, ctx->msg_size, reinterpret_cast<jbyte *>(ctx->msg));
+    return out;
+}
+
+static jboolean init(JNIEnv *env, jobject, jlong ptr, jbyteArray peer) {
+    auto *ctx = reinterpret_cast<PairingContext *>(ptr);
+    jsize n = env->GetArrayLength(peer);
+    if (n > SPAKE2_MAX_MSG_SIZE) return JNI_FALSE;
+    jbyte *p = env->GetByteArrayElements(peer, nullptr);
+    uint8_t material[SPAKE2_MAX_KEY_SIZE];
+    size_t material_size = 0;
+    int ok = SPAKE2_process_msg(ctx->spake, material, &material_size, sizeof(material),
+                                reinterpret_cast<uint8_t *>(p), n);
+    env->ReleaseByteArrayElements(peer, p, JNI_ABORT);
+    if (!ok) {
+        EOR_LOGE("pairing/native/process-peer");
+        return JNI_FALSE;
+    }
+    uint8_t key[16];
+    const uint8_t info[] = "adb pairing_auth aes-128-gcm key";
+    if (!HKDF(key, sizeof(key), EVP_sha256(), material, material_size, nullptr, 0, info,
+              sizeof(info) - 1)) {
+        EOR_LOGE("pairing/native/hkdf");
+        return JNI_FALSE;
+    }
+    ctx->aead = EVP_AEAD_CTX_new(EVP_aead_aes_128_gcm(), key, sizeof(key),
+                                 EVP_AEAD_DEFAULT_TAG_LENGTH);
+    if (!ctx->aead) EOR_LOGE("pairing/native/aead");
+    return ctx->aead ? JNI_TRUE : JNI_FALSE;
+}
+
+static jbyteArray crypt(JNIEnv *env, PairingContext *ctx, jbyteArray input, bool encrypt) {
+    jsize n = env->GetArrayLength(input);
+    if (n <= 0 || n > 16384) return nullptr;
+    jbyte *p = env->GetByteArrayElements(input, nullptr);
+    size_t cap = encrypt ? n + EVP_AEAD_max_overhead(EVP_AEAD_CTX_aead(ctx->aead)) : n;
+    auto *buf = new uint8_t[cap];
+    uint8_t nonce[12]{};
+    uint64_t &seq = encrypt ? ctx->enc : ctx->dec;
+    memcpy(nonce, &seq, sizeof(seq));
+    size_t written = 0;
+    int ok = encrypt
+             ? EVP_AEAD_CTX_seal(ctx->aead, buf, &written, cap, nonce, sizeof(nonce),
+                                 reinterpret_cast<uint8_t *>(p), n, nullptr, 0)
+             : EVP_AEAD_CTX_open(ctx->aead, buf, &written, cap, nonce, sizeof(nonce),
+                                 reinterpret_cast<uint8_t *>(p), n, nullptr, 0);
+    env->ReleaseByteArrayElements(input, p, JNI_ABORT);
+    if (!ok) {
+        EOR_LOGE(encrypt ? "pairing/native/encrypt" : "pairing/native/decrypt");
+        delete[] buf;
+        return nullptr;
+    }
+    ++seq;
+    auto out = env->NewByteArray(written);
+    env->SetByteArrayRegion(out, 0, written, reinterpret_cast<jbyte *>(buf));
+    delete[] buf;
+    return out;
+}
+
+static jbyteArray encrypt(JNIEnv *e, jobject, jlong p, jbyteArray b) {
+    return crypt(e, reinterpret_cast<PairingContext *>(p), b, true);
+}
+
+static jbyteArray decrypt(JNIEnv *e, jobject, jlong p, jbyteArray b) {
+    return crypt(e, reinterpret_cast<PairingContext *>(p), b, false);
+}
+
+static void destroy(JNIEnv *, jobject, jlong p) {
+    auto *c = reinterpret_cast<PairingContext *>(p);
+    if (!c)return;
+    if (c->spake)SPAKE2_CTX_free(c->spake);
+    if (c->aead)EVP_AEAD_CTX_free(c->aead);
+    delete c;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_gamelaunch_frontend_systemui_EorAdbNative_tlsPort(JNIEnv *, jobject) {
+    char value[PROP_VALUE_MAX]{};
+    if (__system_property_get("service.adb.tls.port", value) <= 0) return 0;
+    char *end = nullptr;
+    const long port = strtol(value, &end, 10);
+    return end != value && *end == '\0' && port > 0 && port <= 65535
+           ? static_cast<jint>(port) : 0;
+}
+
+JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *) {
+    JNIEnv *e = nullptr;
+    if (vm->GetEnv(reinterpret_cast<void **>(&e), JNI_VERSION_1_6) != JNI_OK)return -1;
+    JNINativeMethod m[] = {{const_cast<char *>("nativeCreate"),  const_cast<char *>("(Z[B)J"),  (void *) create},
+                           {const_cast<char *>("nativeMessage"), const_cast<char *>("(J)[B"),   (void *) message},
+                           {const_cast<char *>("nativeInit"),    const_cast<char *>("(J[B)Z"),  (void *) init},
+                           {const_cast<char *>("nativeEncrypt"), const_cast<char *>("(J[B)[B"), (void *) encrypt},
+                           {const_cast<char *>("nativeDecrypt"), const_cast<char *>("(J[B)[B"), (void *) decrypt},
+                           {const_cast<char *>("nativeDestroy"), const_cast<char *>("(J)V"),    (void *) destroy}};
+    return e->RegisterNatives(e->FindClass("com/gamelaunch/frontend/systemui/AdbPairingContext"), m,
+                              6) == 0 ? JNI_VERSION_1_6 : -1;
+}

--- a/app/src/main/cpp/eor_starter.cpp
+++ b/app/src/main/cpp/eor_starter.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2017-2025 Rikka contributors; 2026 eOr contributors. Apache-2.0. */
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+
+// Executed by adb shell. Arguments are validated again by EmbeddedBrokerMain.
+int main(int argc, char **argv) {
+    if (getuid() != 2000 || argc != 6) return 2;
+    if (strncmp(argv[1], "/data/app/", 10) || !strstr(argv[1], ".apk")) return 3;
+    pid_t pid = fork();
+    if (pid < 0) return 4;
+    if (pid > 0) return 0;
+    setsid();
+    int fd = open("/dev/null", O_RDWR);
+    if (fd >= 0) {
+        dup2(fd, 0);
+        dup2(fd, 1);
+        dup2(fd, 2);
+        if (fd > 2) close(fd);
+    }
+    setenv("CLASSPATH", argv[1], 1);
+    execl("/system/bin/app_process", "app_process", "/system/bin",
+          "--nice-name=eor_privilege_broker",
+          "com.gamelaunch.frontend.systemui.EmbeddedBrokerMain",
+          argv[1], argv[2], argv[3], argv[4], argv[5], nullptr);
+    return 5;
+}

--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -68,6 +68,7 @@ import com.gamelaunch.frontend.ui.perf.PerformanceState
 import com.gamelaunch.frontend.ui.navigation.AppNavGraph
 import com.gamelaunch.frontend.ui.navigation.Screen
 import com.gamelaunch.frontend.ui.navigation.backOrHome
+import com.gamelaunch.frontend.ui.systemui.SystemNavigationLockHost
 import com.gamelaunch.frontend.ui.theme.AppTheme
 import com.gamelaunch.frontend.ui.theme.BackgroundBranding
 import com.gamelaunch.frontend.ui.theme.BackgroundImageMode
@@ -286,6 +287,7 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.align(Alignment.TopCenter)
                     )
                 }
+                SystemNavigationLockHost()
                 }
               }
             }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -11,6 +11,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.gamelaunch.frontend.domain.lockedmode.UNKNOWN_BOOT_COUNT
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -25,7 +26,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     data class LockedModeRecord(
         val enabled: Boolean,
         val active: Boolean,
+        // After reboot, this count differs and locked mode returns to READY
+        val activeBootCount: Int,
         val pin: String,
+        val blockSystemNavigation: Boolean,
     )
 
     private object Keys {
@@ -94,7 +98,11 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         // If stronger security is ever needed, harden it here.
         val LOCKED_MODE_ENABLED = booleanPreferencesKey("locked_mode_enabled")
         val LOCKED_MODE_ACTIVE = booleanPreferencesKey("locked_mode_active")
+        val LOCKED_MODE_ACTIVE_BOOT_COUNT = intPreferencesKey("locked_mode_active_boot_count")
         val LOCKED_MODE_PIN = stringPreferencesKey("locked_mode_pin")
+        // Whether the embedded broker should block Android system navigation in Locked Mode.
+        val LOCKED_MODE_BLOCK_SYSTEM_NAVIGATION =
+            booleanPreferencesKey("locked_mode_block_system_navigation")
         // Small allowlist, if more info about apps is needed, move to database
         val LOCKED_MODE_ALLOWED_APP_PACKAGES = stringSetPreferencesKey("locked_mode_allowed_app_packages")
     }
@@ -178,17 +186,20 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val lockedMode: Flow<LockedModeRecord> = context.dataStore.data.map {
         val enabled = it[Keys.LOCKED_MODE_ENABLED] ?: false
         val active = it[Keys.LOCKED_MODE_ACTIVE] ?: false
+        val activeBootCount = it[Keys.LOCKED_MODE_ACTIVE_BOOT_COUNT] ?: UNKNOWN_BOOT_COUNT
         val pin = it[Keys.LOCKED_MODE_PIN] ?: ""
+        val blockSystemNavigation = it[Keys.LOCKED_MODE_BLOCK_SYSTEM_NAVIGATION] ?: false
         LockedModeRecord(
             enabled = enabled,
             active = active,
+            activeBootCount = activeBootCount,
             pin = pin,
+            blockSystemNavigation = blockSystemNavigation,
         )
     }
     val lockedModeAllowedAppPackages: Flow<Set<String>> = context.dataStore.data.map {
         it[Keys.LOCKED_MODE_ALLOWED_APP_PACKAGES] ?: emptySet()
     }
-
     suspend fun setRomRootPath(path: String) = context.dataStore.edit { it[Keys.ROM_ROOT_PATH] = path }
     suspend fun setMediaFolderPath(path: String) = context.dataStore.edit { it[Keys.MEDIA_FOLDER_PATH] = path }
     suspend fun setMediaStoragePath(path: String) = context.dataStore.edit { it[Keys.MEDIA_STORAGE_PATH] = path }
@@ -289,9 +300,11 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         if (!enabled) it[Keys.LOCKED_MODE_ACTIVE] = false
     }
 
-    suspend fun setLockedModeActive(active: Boolean) = context.dataStore.edit {
+    suspend fun setLockedModeActive(active: Boolean, bootCount: Int) = context.dataStore.edit {
         val enabled = it[Keys.LOCKED_MODE_ENABLED] ?: false
         it[Keys.LOCKED_MODE_ACTIVE] = active && enabled
+        if (active && enabled) it[Keys.LOCKED_MODE_ACTIVE_BOOT_COUNT] = bootCount
+        else it.remove(Keys.LOCKED_MODE_ACTIVE_BOOT_COUNT)
     }
 
     suspend fun configureLockedMode(pin: String) = context.dataStore.edit {
@@ -300,6 +313,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
 
     suspend fun removeLockedModePin() = context.dataStore.edit {
         it.remove(Keys.LOCKED_MODE_PIN)
+    }
+
+    suspend fun setLockedModeBlockSystemNavigation(enabled: Boolean) = context.dataStore.edit {
+        it[Keys.LOCKED_MODE_BLOCK_SYSTEM_NAVIGATION] = enabled
     }
 
     suspend fun setLockedModeAppAllowed(packageName: String, allowed: Boolean) = context.dataStore.edit {

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/LockedModeRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/LockedModeRepositoryImpl.kt
@@ -4,6 +4,8 @@ import com.gamelaunch.frontend.data.preferences.AppDataStore
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeRepository
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
 import com.gamelaunch.frontend.domain.lockedmode.PinResult
+import com.gamelaunch.frontend.domain.lockedmode.UNKNOWN_BOOT_COUNT
+import com.gamelaunch.frontend.domain.system.BootCountProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -14,10 +16,16 @@ private const val PIN_LENGTH = 4
 
 @Singleton
 class LockedModeRepositoryImpl @Inject constructor(
-    private val dataStore: AppDataStore
+    private val dataStore: AppDataStore,
+    private val bootCountProvider: BootCountProvider,
 ) : LockedModeRepository {
     override val state: Flow<LockedModeState> = dataStore.lockedMode.map { record ->
-        deriveLockedModeState(record.enabled, record.active)
+        deriveLockedModeState(
+            record.enabled,
+            record.active,
+            record.activeBootCount,
+            bootCountProvider.currentBootCount(),
+        )
     }
     override suspend fun setEnabled(enabled: Boolean) {
         dataStore.setLockedModeEnabled(enabled)
@@ -25,12 +33,14 @@ class LockedModeRepositoryImpl @Inject constructor(
 
     override suspend fun activate() {
         if (state.first() == LockedModeState.DISABLED) return
-        dataStore.setLockedModeActive(true)
+        dataStore.setLockedModeActive(true, bootCountProvider.currentBootCount())
     }
 
     override suspend fun isLocked(): Boolean = state.first() == LockedModeState.LOCKED
 
     override val hasPin: Flow<Boolean> = dataStore.lockedMode.map { it.pin.isNotBlank() }
+    override val blockSystemNavigation: Flow<Boolean> =
+        dataStore.lockedMode.map { it.blockSystemNavigation }
 
     override suspend fun configure(pin: String): PinResult {
         if (!isValidLockedModePin(pin)) return PinResult.InvalidPin
@@ -41,12 +51,18 @@ class LockedModeRepositoryImpl @Inject constructor(
     override suspend fun unlock(pin: String?): PinResult {
         val record = dataStore.lockedMode.first()
         val result = if (record.pin.isBlank()) PinResult.Success else verify(pin.orEmpty())
-        if (result == PinResult.Success) dataStore.setLockedModeActive(false)
+        if (result == PinResult.Success) {
+            dataStore.setLockedModeActive(false, bootCountProvider.currentBootCount())
+        }
         return result
     }
 
     override suspend fun removePin() {
         dataStore.removeLockedModePin()
+    }
+
+    override suspend fun setBlockSystemNavigation(enabled: Boolean) {
+        dataStore.setLockedModeBlockSystemNavigation(enabled)
     }
 
     override suspend fun verify(pin: String): PinResult {
@@ -58,10 +74,19 @@ class LockedModeRepositoryImpl @Inject constructor(
     }
 }
 
-internal fun deriveLockedModeState(enabled: Boolean, active: Boolean): LockedModeState {
+internal fun deriveLockedModeState(
+    enabled: Boolean,
+    active: Boolean,
+    activeBootCount: Int,
+    currentBootCount: Int,
+): LockedModeState {
     return when {
         !enabled -> LockedModeState.DISABLED
-        active -> LockedModeState.LOCKED
+        // Only really lock when activation was at this boot count
+        active &&
+            activeBootCount != UNKNOWN_BOOT_COUNT &&
+            currentBootCount != UNKNOWN_BOOT_COUNT &&
+            activeBootCount == currentBootCount -> LockedModeState.LOCKED
         else -> LockedModeState.READY
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/system/AndroidBootCountProvider.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/system/AndroidBootCountProvider.kt
@@ -1,0 +1,18 @@
+package com.gamelaunch.frontend.data.system
+
+import android.content.Context
+import android.provider.Settings
+import com.gamelaunch.frontend.domain.lockedmode.UNKNOWN_BOOT_COUNT
+import com.gamelaunch.frontend.domain.system.BootCountProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AndroidBootCountProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : BootCountProvider {
+    override fun currentBootCount(): Int = runCatching {
+        Settings.Global.getInt(context.contentResolver, Settings.Global.BOOT_COUNT)
+    }.getOrDefault(UNKNOWN_BOOT_COUNT)
+}

--- a/app/src/main/java/com/gamelaunch/frontend/di/SystemModule.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/di/SystemModule.kt
@@ -1,0 +1,17 @@
+package com.gamelaunch.frontend.di
+
+import com.gamelaunch.frontend.data.system.AndroidBootCountProvider
+import com.gamelaunch.frontend.domain.system.BootCountProvider
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SystemModule {
+    @Binds
+    @Singleton
+    abstract fun bindBootCountProvider(impl: AndroidBootCountProvider): BootCountProvider
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/lockedmode/LockedMode.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/lockedmode/LockedMode.kt
@@ -2,6 +2,8 @@ package com.gamelaunch.frontend.domain.lockedmode
 
 import kotlinx.coroutines.flow.Flow
 
+const val UNKNOWN_BOOT_COUNT = -1
+
 enum class LockedModeState { DISABLED, READY, LOCKED }
 
 sealed interface PinResult {
@@ -19,6 +21,7 @@ fun PinResult.message(): String? = when (this) {
 interface LockedModeRepository {
     val state: Flow<LockedModeState>
     val hasPin: Flow<Boolean>
+    val blockSystemNavigation: Flow<Boolean>
 
     suspend fun setEnabled(enabled: Boolean)
     suspend fun activate()
@@ -27,4 +30,5 @@ interface LockedModeRepository {
     suspend fun verify(pin: String): PinResult
     suspend fun unlock(pin: String? = null): PinResult
     suspend fun removePin()
+    suspend fun setBlockSystemNavigation(enabled: Boolean)
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/system/BootCountProvider.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/system/BootCountProvider.kt
@@ -1,0 +1,5 @@
+package com.gamelaunch.frontend.domain.system
+
+interface BootCountProvider {
+    fun currentBootCount(): Int
+}

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedAdb.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedAdb.kt
@@ -1,0 +1,477 @@
+/*
+ * Adapted from Shizuku, Copyright 2017-2025 Rikka contributors.
+ * Copyright 2026 eOr contributors. Licensed under Apache-2.0.
+ */
+package com.gamelaunch.frontend.systemui
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.util.Base64
+import android.util.Log
+import java.io.Closeable
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.math.BigInteger
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.Socket
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.RSAKeyGenParameterSpec
+import java.security.spec.RSAPublicKeySpec
+import java.util.Date
+import java.util.Locale
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509ExtendedTrustManager
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.cert.X509v3CertificateBuilder
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.conscrypt.Conscrypt
+import kotlin.coroutines.resume
+
+internal object EorAdbProtocol {
+    const val CNXN = 0x4e584e43;
+    const val AUTH = 0x48545541;
+    const val OPEN = 0x4e45504f
+    const val OKAY = 0x59414b4f;
+    const val CLSE = 0x45534c43;
+    const val WRTE = 0x45545257;
+    const val STLS = 0x534c5453
+    const val VERSION = 0x01000000;
+    const val MAX_DATA = 4096;
+    const val TOKEN = 1;
+    const val SIGNATURE = 2;
+    const val PUBLIC_KEY = 3
+}
+
+internal data class EorAdbMessage(
+    val command: Int,
+    val arg0: Int,
+    val arg1: Int,
+    val data: ByteArray = byteArrayOf()
+) {
+    fun bytes(): ByteArray =
+        ByteBuffer.allocate(24 + data.size).order(ByteOrder.LITTLE_ENDIAN).apply {
+            putInt(command); putInt(arg0); putInt(arg1); putInt(data.size); putInt(data.sumOf { it.toInt() and 255 }); putInt(
+            command xor -1
+        ); put(data)
+        }.array()
+
+    companion object {
+        const val MAX_PAYLOAD = 1024 * 1024
+        fun read(input: DataInputStream): EorAdbMessage {
+            val h = ByteArray(24); input.readFully(h);
+            val b = ByteBuffer.wrap(h).order(ByteOrder.LITTLE_ENDIAN)
+            val command = b.int;
+            val a0 = b.int;
+            val a1 = b.int;
+            val size = b.int;
+            val checksum = b.int;
+            val magic = b.int
+            require(size in 0..MAX_PAYLOAD && magic == (command xor -1)) { "Malformed ADB header" }
+            val data =
+                ByteArray(size); input.readFully(data); require(data.sumOf { it.toInt() and 255 } == checksum) { "Malformed ADB payload" }
+            return EorAdbMessage(command, a0, a1, data)
+        }
+    }
+}
+
+internal class EorAdbKey(context: Context) {
+    private val privateKey: RSAPrivateKey
+    private val publicKey: RSAPublicKey
+    private val certificate: X509Certificate
+
+    init {
+        val storage = EncryptedAdbIdentity(context)
+        privateKey = if (storage.exists()) KeyFactory.getInstance("RSA")
+            .generatePrivate(PKCS8EncodedKeySpec(storage.load())) as RSAPrivateKey else {
+            (KeyPairGenerator.getInstance("RSA")
+                .apply { initialize(RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)) }
+                .generateKeyPair().private as RSAPrivateKey).also { storage.store(it.encoded) }
+        }
+        publicKey = KeyFactory.getInstance("RSA").generatePublic(
+            RSAPublicKeySpec(
+                privateKey.modulus,
+                RSAKeyGenParameterSpec.F4
+            )
+        ) as RSAPublicKey
+        val built = X509v3CertificateBuilder(
+            X500Name("CN=eOr"),
+            BigInteger.ONE,
+            Date(0),
+            Date(4102444800000L),
+            Locale.ROOT,
+            X500Name("CN=eOr"),
+            SubjectPublicKeyInfo.getInstance(publicKey.encoded)
+        ).build(JcaContentSignerBuilder("SHA256withRSA").build(privateKey))
+        certificate = CertificateFactory.getInstance("X.509")
+            .generateCertificate(built.encoded.inputStream()) as X509Certificate
+    }
+
+    val adbPublicKey: ByteArray get() = publicKey.adbEncoded("eor@localhost")
+    fun sign(token: ByteArray): ByteArray {
+        require(token.size == 20);
+        val padding = byteArrayOf(0, 1) + ByteArray(218) { -1 } + byteArrayOf(
+            0,
+            0x30,
+            0x21,
+            0x30,
+            9,
+            6,
+            5,
+            0x2b,
+            0x0e,
+            3,
+            2,
+            0x1a,
+            5,
+            0,
+            4,
+            0x14
+        )
+        return javax.crypto.Cipher.getInstance("RSA/ECB/NoPadding")
+            .run { init(javax.crypto.Cipher.ENCRYPT_MODE, privateKey); doFinal(padding + token) }
+    }
+
+    val sslContext: SSLContext by lazy {
+        val km = object : X509ExtendedKeyManager() {
+            override fun chooseClientAlias(
+                k: Array<out String>,
+                i: Array<out Principal>?,
+                s: Socket?
+            ) = "eor";
+
+            override fun getCertificateChain(a: String?) =
+                if (a == "eor") arrayOf(certificate) else null;
+
+            override fun getPrivateKey(a: String?) = if (a == "eor") privateKey else null;
+            override fun getClientAliases(k: String?, i: Array<out Principal>?) = arrayOf("eor");
+            override fun getServerAliases(k: String?, i: Array<out Principal>?) = null;
+            override fun chooseServerAlias(k: String?, i: Array<out Principal>?, s: Socket?) = null
+        }
+        val tm = object : X509ExtendedTrustManager() {
+            override fun getAcceptedIssuers() = emptyArray<X509Certificate>();
+            override fun checkClientTrusted(c: Array<out X509Certificate>?, a: String?) {};
+            override fun checkServerTrusted(c: Array<out X509Certificate>?, a: String?) {};
+            override fun checkClientTrusted(
+                c: Array<out X509Certificate>?,
+                a: String?,
+                s: Socket?
+            ) {
+            };
+            override fun checkServerTrusted(
+                c: Array<out X509Certificate>?,
+                a: String?,
+                s: Socket?
+            ) {
+            };
+            override fun checkClientTrusted(
+                c: Array<out X509Certificate>?,
+                a: String?,
+                e: SSLEngine?
+            ) {
+            };
+            override fun checkServerTrusted(
+                c: Array<out X509Certificate>?,
+                a: String?,
+                e: SSLEngine?
+            ) {
+            }
+        }
+        SSLContext.getInstance("TLS", Conscrypt.newProvider())
+            .apply { init(arrayOf(km), arrayOf(tm), SecureRandom()) }
+    }
+}
+
+private fun RSAPublicKey.adbEncoded(name: String): ByteArray {
+    fun BigInteger.words(): IntArray {
+        val out = IntArray(64);
+        var n = this;
+        val r = BigInteger.ONE.shiftLeft(32); for (i in out.indices) {
+            val q = n.divideAndRemainder(r); n = q[0]; out[i] = q[1].toInt()
+        }; return out
+    }
+
+    val r32 = BigInteger.ONE.shiftLeft(32);
+    val n0 = modulus.mod(r32).modInverse(r32).negate();
+    val rr = BigInteger.ONE.shiftLeft(2048).pow(2).mod(modulus)
+    val raw = ByteBuffer.allocate(524).order(ByteOrder.LITTLE_ENDIAN).apply {
+        putInt(64); putInt(n0.toInt()); modulus.words().forEach(::putInt); rr.words()
+        .forEach(::putInt); putInt(publicExponent.toInt())
+    }.array()
+    return Base64.encode(raw, Base64.NO_WRAP) + " $name\u0000".toByteArray()
+}
+
+internal data class LocalAdbEndpoint(val address: InetAddress, val port: Int)
+internal class AdbAuthenticationException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)
+
+internal fun Throwable.isAdbAuthenticationFailure(): Boolean = generateSequence(this) { it.cause }
+    .any { it is AdbAuthenticationException || it is SSLException }
+
+internal object EorAdbEndpointCache {
+    @Volatile
+    var pairing: LocalAdbEndpoint? = null
+}
+
+internal object EorAdbNative {
+    init {
+        System.loadLibrary("eor_adb")
+    }
+
+    external fun tlsPort(): Int
+}
+
+internal fun localTlsEndpointOrNull(): LocalAdbEndpoint? = EorAdbNative.tlsPort()
+    .takeIf { it in 1..65535 }
+    ?.let { LocalAdbEndpoint(preferredLocalAddress(), it) }
+
+internal fun preferredLocalAddress(): InetAddress =
+    NetworkInterface.getNetworkInterfaces().asSequence()
+        .filter { it.isUp && !it.isLoopback }.flatMap { it.inetAddresses.asSequence() }
+        .firstOrNull { !it.isLoopbackAddress && it.address.size == 4 && it.isSiteLocalAddress }
+        ?: InetAddress.getLoopbackAddress()
+
+internal suspend fun discoverLocalAdb(
+    context: Context,
+    type: String,
+    timeoutMs: Long = 15_000
+): LocalAdbEndpoint = withTimeout(timeoutMs) {
+    suspendCancellableCoroutine { continuation ->
+        Log.i(
+            EOR_BROKER_TAG,
+            "discovery/start/${if (type.contains("pairing")) "pairing" else "connect"}"
+        )
+        val nsd = context.getSystemService(NsdManager::class.java);
+        var started = false
+        lateinit var listener: NsdManager.DiscoveryListener
+        fun local(address: InetAddress) = NetworkInterface.getNetworkInterfaces().asSequence()
+            .flatMap { it.inetAddresses.asSequence() }.any { it == address }
+
+        fun finish(endpoint: LocalAdbEndpoint?) {
+            if (continuation.isActive) {
+                Log.i(
+                    EOR_BROKER_TAG,
+                    if (endpoint != null) "discovery/resolved" else "discovery/failed"
+                ); if (started) runCatching { nsd.stopServiceDiscovery(listener) }; if (endpoint != null) continuation.resume(
+                    endpoint
+                ) else continuation.cancel(IllegalStateException("Discovery failed"))
+            }
+        }
+        listener = object : NsdManager.DiscoveryListener {
+            override fun onDiscoveryStarted(t: String) {
+                started = true
+            };
+            override fun onDiscoveryStopped(t: String) {};
+            override fun onStartDiscoveryFailed(t: String, e: Int) = finish(null);
+            override fun onStopDiscoveryFailed(t: String, e: Int) {}
+            override fun onServiceLost(s: NsdServiceInfo) {};
+            override fun onServiceFound(s: NsdServiceInfo) {
+                if (s.serviceType.trimEnd('.') != type.trimEnd('.')) return; nsd.resolveService(s,
+                    object : NsdManager.ResolveListener {
+                        override fun onResolveFailed(s: NsdServiceInfo, e: Int) {};
+                        override fun onServiceResolved(s: NsdServiceInfo) {
+                            if (s.port in 1..65535 && local(s.host)) finish(
+                                LocalAdbEndpoint(
+                                    s.host,
+                                    s.port
+                                )
+                            )
+                        }
+                    })
+            }
+        }
+        continuation.invokeOnCancellation {
+            if (started) runCatching {
+                nsd.stopServiceDiscovery(
+                    listener
+                )
+            }
+        }
+        nsd.discoverServices(type, NsdManager.PROTOCOL_DNS_SD, listener)
+    }
+}
+
+internal class AdbPairingContext private constructor(private val ptr: Long) : Closeable {
+    val message get() = nativeMessage(ptr);
+    fun init(peer: ByteArray) = nativeInit(ptr, peer);
+    fun encrypt(v: ByteArray) = nativeEncrypt(ptr, v);
+    fun decrypt(v: ByteArray) = nativeDecrypt(ptr, v)
+    override fun close() = nativeDestroy(ptr)
+    private external fun nativeMessage(p: Long): ByteArray;
+    private external fun nativeInit(p: Long, v: ByteArray): Boolean;
+    private external fun nativeEncrypt(p: Long, v: ByteArray): ByteArray?;
+    private external fun nativeDecrypt(p: Long, v: ByteArray): ByteArray?;
+    private external fun nativeDestroy(p: Long)
+
+    companion object { init {
+        System.loadLibrary("eor_adb")
+    };
+        @JvmStatic
+        private external fun nativeCreate(client: Boolean, password: ByteArray): Long;
+        fun create(password: ByteArray) =
+            nativeCreate(true, password).takeIf { it != 0L }?.let(::AdbPairingContext)
+    }
+}
+
+internal class EorAdbPairingClient(
+    private val endpoint: LocalAdbEndpoint,
+    private val code: String,
+    private val key: EorAdbKey
+) : Closeable {
+    private var socket: Socket? = null
+    fun pair(): Boolean {
+        require(code.matches(Regex("[0-9]{6}")) && endpoint.port in 1..65535)
+        Log.i(EOR_BROKER_TAG, "pairing/socket-connect")
+        val plain = Socket().apply {
+            connect(
+                InetSocketAddress(endpoint.address, endpoint.port),
+                5000
+            ); soTimeout = 5000; tcpNoDelay = true
+        }; socket = plain
+        val tls = key.sslContext.socketFactory.createSocket(
+            plain,
+            endpoint.address.hostAddress,
+            endpoint.port,
+            true
+        ) as SSLSocket; tls.startHandshake()
+        Log.i(EOR_BROKER_TAG, "pairing/tls-ready")
+        val material = Conscrypt.exportKeyingMaterial(tls, "adb-label\u0000", null, 64);
+        val context = AdbPairingContext.create(code.toByteArray() + material) ?: return false
+        context.use { p ->
+            val input = DataInputStream(tls.inputStream);
+            val output = DataOutputStream(tls.outputStream)
+            fun send(type: Int, data: ByteArray) {
+                output.write(
+                    byteArrayOf(1, type.toByte()) + ByteBuffer.allocate(4).putInt(data.size)
+                        .array() + data
+                ); output.flush()
+            }
+
+            fun receive(expected: Int): ByteArray {
+                val h = ByteArray(6); input.readFully(h);
+                val b = ByteBuffer.wrap(h).order(ByteOrder.BIG_ENDIAN); require(
+                    b.get().toInt() == 1 && b.get().toInt() == expected
+                );
+                val n = b.int; require(n in 1..16384); return ByteArray(n).also(input::readFully)
+            }
+            send(0, p.message); if (!p.init(receive(0))) return false
+            Log.i(EOR_BROKER_TAG, "pairing/spake-ready")
+            val peer = ByteArray(8192).also {
+                it[0] = 0; key.adbPublicKey.copyInto(
+                it,
+                1,
+                0,
+                minOf(key.adbPublicKey.size, 8191)
+            )
+            }; send(1, p.encrypt(peer) ?: return false)
+            val accepted = (p.decrypt(receive(1)) ?: return false).size == 8192
+            Log.i(EOR_BROKER_TAG, if (accepted) "pairing/accepted" else "pairing/peer-invalid")
+            return accepted
+        }
+    }
+
+    override fun close() {
+        runCatching { socket?.close() }
+    }
+}
+
+internal class EorAdbClient(private val endpoint: LocalAdbEndpoint, private val key: EorAdbKey) :
+    Closeable {
+    private var socket: Socket? = null;
+    private lateinit var input: DataInputStream;
+    private lateinit var output: DataOutputStream
+    fun connect() {
+        Log.i(EOR_BROKER_TAG, "connection/socket-connect");
+        val plain = Socket().apply {
+            connect(
+                InetSocketAddress(endpoint.address, endpoint.port),
+                5000
+            ); soTimeout = 10_000; tcpNoDelay = true
+        }; socket = plain; input = DataInputStream(plain.inputStream); output =
+            DataOutputStream(plain.outputStream); write(
+            EorAdbProtocol.CNXN,
+            EorAdbProtocol.VERSION,
+            EorAdbProtocol.MAX_DATA,
+            "host::\u0000".toByteArray()
+        );
+        var m = read(); if (m.command == EorAdbProtocol.STLS) {
+            write(EorAdbProtocol.STLS, EorAdbProtocol.VERSION, 0);
+            val tls = key.sslContext.socketFactory.createSocket(
+                plain,
+                endpoint.address.hostAddress,
+                endpoint.port,
+                true
+            ) as SSLSocket; try {
+                tls.startHandshake()
+            } catch (failure: SSLException) {
+                throw AdbAuthenticationException("ADB TLS authentication failed", failure)
+            }; input = DataInputStream(tls.inputStream); output =
+                DataOutputStream(tls.outputStream); m = read()
+        } else if (m.command == EorAdbProtocol.AUTH && m.arg0 == EorAdbProtocol.TOKEN) {
+            write(EorAdbProtocol.AUTH, EorAdbProtocol.SIGNATURE, 0, key.sign(m.data)); m =
+                read(); if (m.command != EorAdbProtocol.CNXN) {
+                write(EorAdbProtocol.AUTH, EorAdbProtocol.PUBLIC_KEY, 0, key.adbPublicKey); m =
+                    read()
+            }
+        }; if (m.command != EorAdbProtocol.CNXN) throw AdbAuthenticationException("ADB authentication failed"); Log.i(
+            EOR_BROKER_TAG,
+            "connection/authenticated"
+        )
+    }
+
+    fun shell(command: String): String {
+        require(command.length <= 4096); write(
+            EorAdbProtocol.OPEN,
+            1,
+            0,
+            "shell:$command\u0000".toByteArray()
+        );
+        val result = java.io.ByteArrayOutputStream(); while (true) {
+            val m = read(); when (m.command) {
+                EorAdbProtocol.OKAY -> Unit; EorAdbProtocol.WRTE -> {
+                    require(result.size() + m.data.size <= 1024 * 1024); result.write(m.data); write(
+                        EorAdbProtocol.OKAY,
+                        1,
+                        m.arg0
+                    )
+                }; EorAdbProtocol.CLSE -> {
+                    write(
+                        EorAdbProtocol.CLSE,
+                        1,
+                        m.arg0
+                    ); return result.toString(Charsets.UTF_8.name())
+                }; else -> error("Unexpected ADB response")
+            }
+        }
+    }
+
+    private fun write(c: Int, a0: Int, a1: Int, d: ByteArray = byteArrayOf()) {
+        output.write(EorAdbMessage(c, a0, a1, d).bytes()); output.flush()
+    };
+    private fun read() = EorAdbMessage.read(input)
+    override fun close() {
+        runCatching { socket?.close() }
+    }
+}
+
+internal const val EOR_BROKER_TAG = "EorBroker"

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedBrokerBootstrapProvider.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedBrokerBootstrapProvider.kt
@@ -1,0 +1,132 @@
+package com.gamelaunch.frontend.systemui
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.Bundle
+import android.os.Process
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Bridges the shell-owned broker into the app process because the broker is launched through
+ * `app_process` and therefore has no component binding through which it can return its Binder.
+ * This provider is exported only for that bootstrap handoff; the shell UID check and single-use,
+ * version-bound token prevent other processes or stale broker instances from publishing a Binder.
+ */
+class EmbeddedBrokerBootstrapProvider : ContentProvider() {
+    override fun onCreate() = true
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        if (Binder.getCallingUid() != Process.SHELL_UID || method != METHOD) return null
+        val token = extras?.getString(KEY_TOKEN) ?: return null
+        val version = extras.getLong(KEY_VERSION, -1)
+        val broker = extras.getBinder(KEY_BINDER) ?: return null
+        if (!BootstrapTokens.consume(token, version)) return null
+        EmbeddedPrivilegeBrokerManager.accept(broker, version)
+        return Bundle().apply {
+            putBoolean(KEY_ACCEPTED, true); putBinder(
+            KEY_DEATH_TOKEN,
+            APP_DEATH_TOKEN
+        )
+        }
+    }
+
+    override fun query(
+        a: Uri,
+        b: Array<out String>?,
+        c: String?,
+        d: Array<out String>?,
+        e: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+
+    companion object {
+        const val METHOD = "publish_broker";
+        const val KEY_TOKEN = "token";
+        const val KEY_VERSION = "version"
+        const val KEY_BINDER = "binder";
+        const val KEY_ACCEPTED = "accepted";
+        const val KEY_DEATH_TOKEN = "death_token"
+        private val APP_DEATH_TOKEN = Binder()
+        fun deliverFromShell(
+            authority: String,
+            token: String,
+            version: Long,
+            broker: Binder
+        ): Boolean = runCatching {
+            val amClass = Class.forName("android.app.ActivityManager")
+            val am = amClass.getDeclaredMethod("getService").invoke(null)
+            val acquire =
+                am.javaClass.methods.first { it.name == "getContentProviderExternal" && it.parameterTypes.size == 4 }
+            val holder = acquire.invoke(am, authority, 0, null, "eor_privilege_broker")
+                ?: return@runCatching false
+            val provider = holder.javaClass.getField("provider").get(holder)
+            val extras = Bundle().apply {
+                putString(KEY_TOKEN, token); putLong(
+                KEY_VERSION,
+                version
+            ); putBinder(KEY_BINDER, broker)
+            }
+            val call =
+                provider.javaClass.methods.first { it.name == "call" && it.parameterTypes.size in 5..6 }
+            val result = when {
+                call.parameterTypes.first().name == "android.content.AttributionSource" -> call.invoke(
+                    provider,
+                    android.content.AttributionSource.Builder(Process.SHELL_UID).build(),
+                    authority,
+                    METHOD,
+                    null,
+                    extras
+                ) as? Bundle
+
+                call.parameterTypes.size == 6 -> call.invoke(
+                    provider,
+                    null,
+                    null,
+                    authority,
+                    METHOD,
+                    null,
+                    extras
+                ) as? Bundle
+
+                else -> call.invoke(provider, null, authority, METHOD, null, extras) as? Bundle
+            }
+            val death = result?.getBinder(KEY_DEATH_TOKEN) ?: return@runCatching false
+            death.linkToDeath({ Process.killProcess(Process.myPid()) }, 0)
+            result.getBoolean(KEY_ACCEPTED)
+        }.getOrDefault(false)
+    }
+}
+
+internal object BootstrapTokens {
+    private data class Expected(val hash: ByteArray, val version: Long)
+
+    private val expected = AtomicReference<Expected?>()
+    fun issue(token: String, version: Long) {
+        expected.set(Expected(hash(token), version))
+    }
+
+    fun consume(token: String, version: Long): Boolean {
+        val value = expected.get() ?: return false
+        if (value.version != version || !MessageDigest.isEqual(
+                value.hash,
+                hash(token)
+            )
+        ) return false
+        return expected.compareAndSet(value, null)
+    }
+
+    private fun hash(value: String) =
+        MessageDigest.getInstance("SHA-256").digest(value.toByteArray())
+}

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedBrokerMain.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedBrokerMain.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Rikka contributors
+ * Copyright 2026 eOr contributors
+ * Licensed under the Apache License, Version 2.0.
+ */
+package com.gamelaunch.frontend.systemui
+
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.os.Process
+import android.util.Log
+import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Entry point loaded by /system/bin/app_process under Android's shell UID. */
+object EmbeddedBrokerMain {
+    const val PROTOCOL_VERSION = 1
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        Log.i(EOR_BROKER_TAG, "broker-process/started")
+        val parsed = BrokerLaunchArguments.parse(args) ?: run {
+            Log.e(EOR_BROKER_TAG, "broker-process/invalid-arguments")
+            return
+        }
+        if (Process.myUid() != Process.SHELL_UID) {
+            Log.e(EOR_BROKER_TAG, "broker-process/invalid-uid")
+            return
+        }
+        val broker = EorPrivilegeBroker(parsed.applicationUid)
+        val delivered = EmbeddedBrokerBootstrapProvider.deliverFromShell(
+            parsed.authority, parsed.token, parsed.versionCode, broker,
+        )
+        if (!delivered) {
+            Log.e(EOR_BROKER_TAG, "broker-process/delivery-rejected")
+            return
+        }
+        Log.i(EOR_BROKER_TAG, "broker-process/delivered")
+        Binder.joinThreadPool()
+    }
+}
+
+internal data class BrokerLaunchArguments(
+    val apkPath: String, val applicationUid: Int, val versionCode: Long,
+    val authority: String, val token: String,
+) {
+    companion object {
+        fun parse(args: Array<String>): BrokerLaunchArguments? {
+            if (args.size != 5) return null
+            val path = args[0]
+            val uid = args[1].toIntOrNull() ?: return null
+            val version = args[2].toLongOrNull() ?: return null
+            val authority = args[3]
+            val token = args[4]
+            if (!path.startsWith("/data/app/") || !path.endsWith(".apk") || uid < 10_000 ||
+                version < 1 || !authority.matches(Regex("[a-zA-Z0-9._]+")) ||
+                !token.matches(Regex("[A-Za-z0-9_-]{43}"))
+            ) return null
+            return BrokerLaunchArguments(path, uid, version, authority, token)
+        }
+    }
+}
+
+internal class EorPrivilegeBroker(private val expectedUid: Int) : IEorPrivilegeBroker.Stub() {
+    private val stopped = AtomicBoolean(false)
+    private var state = 0
+
+    override fun setNavigationLocked(locked: Boolean): Int = authenticated {
+        val flags = if (locked) arrayOf(
+            "home",
+            "recents",
+            "statusbar-expansion",
+            "notification-peek"
+        ) else arrayOf("none")
+        repeat(3) {
+            if (runCommand("/system/bin/cmd", "statusbar", "send-disable-flag", *flags) == 0 &&
+                navigationState() == if (locked) 1 else 0
+            ) {
+                state = if (locked) 1 else 0
+                return@authenticated 0
+            }
+            Thread.sleep(100)
+        }
+        -1
+    }
+
+    override fun getNavigationLockState(): Int = authenticated { navigationState() }
+    override fun getProtocolVersion(): Int = authenticated { EmbeddedBrokerMain.PROTOCOL_VERSION }
+    override fun shutdown() =
+        authenticated<Unit> { stopped.set(true); Process.killProcess(Process.myPid()) }
+
+    private fun navigationState(): Int {
+        val dump = output("/system/bin/dumpsys", "statusbar") ?: return -1
+        return shellDisableFlags(dump)?.let { if (it == 0L) 0 else 1 } ?: -1
+    }
+
+    private inline fun <T> authenticated(block: () -> T): T {
+        check(!stopped.get() && Binder.getCallingUid() == expectedUid) { "unauthorized broker caller" }
+        return block()
+    }
+
+    private fun runCommand(vararg command: String) = runCatching {
+        ProcessBuilder(*command).redirectErrorStream(true).start().let { p ->
+            p.inputStream.use { input ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    input.transferTo(OutputStream.nullOutputStream())
+                } else {
+                    // TODO: not tested this path (no old device)
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (input.read(buffer) != -1) {
+                        // Drain output so the child process cannot block on a full pipe.
+                    }
+                }
+            }
+            p.waitFor()
+        }
+    }.getOrDefault(-1)
+
+    private fun output(vararg command: String) = runCatching {
+        ProcessBuilder(*command).redirectErrorStream(true).start().let { p ->
+            // limit the returned command to 1 mb
+            val value = p.inputStream.bufferedReader().use { it.readText().take(1_048_576) }
+            if (p.waitFor() == 0) value else null
+        }
+    }.getOrNull()
+}
+
+internal fun shellDisableFlags(statusBarDump: String): Long? {
+    val record = statusBarDump.lineSequence().firstOrNull {
+        "pkg=android" in it && "StatusBarShellCommandToken" in it
+    } ?: return null
+    return Regex("what1=0x([0-9a-fA-F]+)").find(record)?.groupValues?.get(1)?.toLongOrNull(16)
+}

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedPairingService.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedPairingService.kt
@@ -1,0 +1,150 @@
+package com.gamelaunch.frontend.systemui
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.RemoteInput
+import com.gamelaunch.frontend.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/** Keeps wireless-debugging pairing available through a notification while Settings is open. */
+@AndroidEntryPoint
+class EmbeddedPairingService : Service() {
+    @Inject
+    lateinit var controller: SystemNavigationLockController
+    private var retainResultNotification = false
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.i(EOR_BROKER_TAG, "pairing-helper/started")
+        val nm = getSystemService(NotificationManager::class.java)
+        nm.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL,
+                "eOr pairing",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply { description = "Return to eOr before the Wireless debugging code expires" })
+        val pi = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(
+                this,
+                MainActivity::class.java
+            ).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val replyIntent = Intent(this, EmbeddedPairingService::class.java).setAction(ACTION_PAIR)
+        val replyPendingIntent = PendingIntent.getService(
+            this,
+            1,
+            replyIntent,
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val reply = RemoteInput.Builder(KEY_CODE)
+            .setLabel("6 digits; mistake: space, then retry")
+            .build()
+        val replyAction =
+            NotificationCompat.Action.Builder(0, "Enter pairing code", replyPendingIntent)
+                .addRemoteInput(reply).build()
+        controller.markPairingNotificationSetup()
+        startForeground(
+            PAIRING_NOTIFICATION_ID, NotificationCompat.Builder(this, CHANNEL)
+                .setSmallIcon(com.gamelaunch.frontend.R.drawable.ic_notification)
+                .setContentTitle("Pair eOr with Wireless debugging")
+                .setContentText("Keep Settings open; enter the six-digit code here")
+                .setContentIntent(pi).setOngoing(true).setOnlyAlertOnce(true)
+                .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                .addAction(replyAction).build()
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_PAIR) {
+            val code = pairingCodeFrom(
+                RemoteInput.getResultsFromIntent(intent)?.getCharSequence(KEY_CODE)
+            )
+            if (code != null) {
+                Log.i(EOR_BROKER_TAG, "pairing-helper/code-received")
+                controller.markPairingNotificationPairing()
+                showPairingProgress()
+                controller.pair(code, EorAdbEndpointCache.pairing?.port, ::showPairingResult)
+            } else Log.i(EOR_BROKER_TAG, "pairing-helper/code-invalid")
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        Log.i(
+            EOR_BROKER_TAG,
+            "pairing-helper/stopped"
+        )
+        if (!retainResultNotification) stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    private fun showPairingProgress() {
+        val progressNotification = NotificationCompat.Builder(this, CHANNEL)
+            .setSmallIcon(com.gamelaunch.frontend.R.drawable.ic_notification)
+            .setContentTitle("Pairing eOr…")
+            .setContentText("Keep Wireless debugging open")
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setProgress(0, 0, true)
+            .build()
+
+        getSystemService(NotificationManager::class.java)
+            .notify(PAIRING_NOTIFICATION_ID, progressNotification)
+    }
+
+    private fun showPairingResult(status: SystemNavigationLockStatus) {
+        val paired = status in setOf(
+            SystemNavigationLockStatus.READY,
+            SystemNavigationLockStatus.ACTIVE,
+        )
+        val notificationBuilder = NotificationCompat.Builder(this, CHANNEL)
+            .setSmallIcon(com.gamelaunch.frontend.R.drawable.ic_notification)
+            .setContentTitle(if (paired) "Pairing complete" else "Pairing failed")
+            .setContentText(if (paired) "Tap to return to eOr" else "Tap to return and try again")
+            .setContentIntent(returnToEorIntent())
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(false)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+        if (paired) notificationBuilder.setTimeoutAfter(PAIRING_SUCCESS_TIMEOUT_MS)
+
+        retainResultNotification = true
+        controller.markPairingNotificationResult(resetAfterTimeout = paired)
+        getSystemService(NotificationManager::class.java)
+            .notify(PAIRING_NOTIFICATION_ID, notificationBuilder.build())
+        stopForeground(STOP_FOREGROUND_DETACH)
+    }
+
+    private fun returnToEorIntent() = PendingIntent.getActivity(
+        this,
+        0,
+        Intent(this, MainActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+    )
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        const val CHANNEL = "eor_pairing";
+        const val PAIRING_NOTIFICATION_ID = 7103
+        // limit how long the notification stays visible after successful pairing
+        const val PAIRING_SUCCESS_TIMEOUT_MS = 30_000L
+        const val ACTION_PAIR = "com.gamelaunch.frontend.action.PAIR_EMBEDDED_ADB";
+        const val KEY_CODE = "eor_pairing_code"
+    }
+}
+
+internal fun pairingCodeFrom(input: CharSequence?): String? = input?.toString()
+    ?.let { text -> Regex("(?:^|[^0-9])([0-9]{6})(?=[^0-9]|$)").findAll(text).lastOrNull() }
+    ?.groupValues?.get(1)

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedPrivilegeBrokerManager.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/EmbeddedPrivilegeBrokerManager.kt
@@ -1,0 +1,194 @@
+package com.gamelaunch.frontend.systemui
+
+import android.content.Context
+import android.os.Build
+import android.os.IBinder
+import android.util.Base64
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.security.SecureRandom
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Gives the app a small amount of privileged, shell-level functionality without requiring root or
+ * keeping a broadly privileged service permanently exposed.
+ */
+@Singleton
+class EmbeddedPrivilegeBrokerManager @Inject constructor(@ApplicationContext private val context: Context) {
+    private val startMutex = Mutex()
+    fun currentBroker(): IEorPrivilegeBroker? {
+        val value = broker ?: return null
+        if (!value.asBinder().isBinderAlive ||
+            runCatching { value.protocolVersion }.getOrDefault(-1) != EmbeddedBrokerMain.PROTOCOL_VERSION
+        ) {
+            broker = null; return null
+        }
+        return value
+    }
+
+    fun readiness(): SystemNavigationLockStatus = when {
+        Build.VERSION.SDK_INT < 30 -> SystemNavigationLockStatus.UNSUPPORTED
+        !EncryptedAdbIdentity(context).isPaired() -> SystemNavigationLockStatus.PAIRING_REQUIRED
+        else -> SystemNavigationLockStatus.START_REQUIRED
+    }
+
+    suspend fun verifyPairing(): Boolean? {
+        if (!EncryptedAdbIdentity(context).isPaired()) return false
+        return runCatching {
+            val endpoint = localTlsEndpointOrNull()
+                ?: discoverLocalAdb(context, "_adb-tls-connect._tcp", 5_000)
+            withContext(Dispatchers.IO) {
+                EorAdbClient(
+                    endpoint,
+                    EorAdbKey(context)
+                ).use { it.connect() }
+            }
+            true
+        }.getOrElse { failure ->
+            if (failure.isAdbAuthenticationFailure()) {
+                EncryptedAdbIdentity(context).clearPaired()
+                Log.i(EOR_BROKER_TAG, "pairing/revoked")
+                false
+            } else null
+        }
+    }
+
+    fun invalidateCurrentBroker() {
+        val value = broker
+        broker = null
+        runCatching { value?.shutdown() }
+    }
+
+    suspend fun connectOrStart(): SystemNavigationLockStatus = startMutex.withLock {
+        Log.i(EOR_BROKER_TAG, "broker/connect-or-start")
+        // Wireless debugging requires Android 11+, which also makes longVersionCode safe below.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)
+            return@withLock SystemNavigationLockStatus.UNSUPPORTED
+        currentBroker()?.let { return@withLock SystemNavigationLockStatus.READY }
+        if (!EncryptedAdbIdentity(context).isPaired())
+            return@withLock SystemNavigationLockStatus.PAIRING_REQUIRED
+        return runCatching {
+            val endpoint = discoverConnectionEndpoint()
+            val token = newToken();
+            val app = context.applicationInfo
+            val version = context
+                .packageManager
+                .getPackageInfo(context.packageName, 0)
+                .longVersionCode
+            BootstrapTokens.issue(token, version)
+            val starter = "${app.nativeLibraryDir}/libeor_starter.so"
+            val values = listOf(
+                starter,
+                app.sourceDir,
+                app.uid.toString(),
+                version.toString(),
+                "${context.packageName}.privilege.bootstrap",
+                token
+            )
+            require(values.all { SAFE.matches(it) })
+            withContext(Dispatchers.IO) {
+                EorAdbClient(
+                    endpoint,
+                    EorAdbKey(context)
+                ).use { it.connect(); it.shell(values.joinToString(" ") { value -> "'$value'" }) }
+            }
+            repeat(50) {
+                currentBroker()?.let {
+                    Log.i(EOR_BROKER_TAG, "broker/ready")
+                    return@withLock SystemNavigationLockStatus.READY
+                }; delay(100)
+            }
+            SystemNavigationLockStatus.ERROR
+        }.getOrElse { failure ->
+            Log.e(EOR_BROKER_TAG, "broker/start-failed/${failure.javaClass.simpleName}")
+            if (failure.isAdbAuthenticationFailure()) {
+                EncryptedAdbIdentity(context).clearPaired()
+                Log.i(EOR_BROKER_TAG, "pairing/revoked")
+                SystemNavigationLockStatus.PAIRING_REQUIRED
+            } else {
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED
+            }
+        }
+    }
+
+    suspend fun pair(code: String, manualPort: Int? = null): SystemNavigationLockStatus =
+        runCatching {
+            Log.i(
+                EOR_BROKER_TAG,
+                "pairing/begin/${if (manualPort == null) "discovery" else "manual"}"
+            )
+            val endpoint = manualPort?.let { port ->
+                EorAdbEndpointCache.pairing?.takeIf { it.port == port } ?: LocalAdbEndpoint(
+                    preferredLocalAddress(),
+                    port
+                )
+            }
+                ?: discoverLocalAdb(context, "_adb-tls-pairing._tcp")
+            val ok = withContext(Dispatchers.IO) {
+                EorAdbPairingClient(
+                    endpoint,
+                    code,
+                    EorAdbKey(context)
+                ).use { it.pair() }
+            }
+            if (ok && EncryptedAdbIdentity(context).markPaired()) connectOrStart() else SystemNavigationLockStatus.PAIRING_REQUIRED
+        }.getOrElse {
+            Log.e(
+                EOR_BROKER_TAG,
+                "pairing/failed/${it.javaClass.simpleName}"
+            ); SystemNavigationLockStatus.PAIRING_REQUIRED
+        }
+
+    private fun newToken() = ByteArray(32).also(SecureRandom()::nextBytes)
+        .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+    private suspend fun discoverConnectionEndpoint(): LocalAdbEndpoint {
+        // Some Android 13 OEM builds run TLS ADB but fail to publish the connect service through
+        // Android's NSD API. The read-only system property is local to this device and provides a
+        // safe, narrowly scoped fallback without enabling ADB or requiring an arbitrary shell API.
+        localTlsEndpointOrNull()?.let {
+            Log.i(EOR_BROKER_TAG, "connection/local-port-ready")
+            return it
+        }
+        var last: Throwable? = null
+        repeat(6) { attempt ->
+            try {
+                return discoverLocalAdb(context, "_adb-tls-connect._tcp", 15_000)
+            } catch (failure: Throwable) {
+                // A discovery attempt's own timeout is retryable. Only cancellation from the
+                // owning lifecycle should abort startup recovery.
+                if (failure is kotlinx.coroutines.CancellationException && failure !is TimeoutCancellationException) throw failure
+                last = failure
+                Log.i(EOR_BROKER_TAG, "connection/discovery-retry/${attempt + 1}")
+                localTlsEndpointOrNull()?.let { return it }
+                delay(500)
+            }
+        }
+        throw last ?: IllegalStateException("Connection discovery failed")
+    }
+
+    companion object {
+        private val SAFE = Regex("[A-Za-z0-9_./:=~-]+")
+
+        @Volatile
+        private var broker: IEorPrivilegeBroker? = null
+        internal fun accept(value: IBinder, version: Long) {
+            val candidate = IEorPrivilegeBroker.Stub.asInterface(value)
+            if (version <= 0) return
+            broker = candidate
+            runCatching {
+                value.linkToDeath(
+                    { if (broker?.asBinder() === value) broker = null },
+                    0
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/EncryptedAdbIdentity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/EncryptedAdbIdentity.kt
@@ -1,0 +1,63 @@
+package com.gamelaunch.frontend.systemui
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Securely preserves eOr's ADB identity so Android recognizes the app after it has paired once.
+ * The paired flag is cached state, actual proof happens when eOr successfully authenticates.
+ */
+internal class EncryptedAdbIdentity(private val context: Context) {
+    private val file get() = context.noBackupFilesDir.resolve("eor_adb_identity")
+    fun exists() = file.isFile && runCatching { load().isNotEmpty() }.getOrDefault(false)
+    fun isPaired() = exists() && context.getSharedPreferences("eor_adb", Context.MODE_PRIVATE)
+        .getBoolean("paired", false)
+
+    fun markPaired() = context.getSharedPreferences("eor_adb", Context.MODE_PRIVATE).edit()
+        .putBoolean("paired", true).commit()
+
+    fun clearPaired() = context.getSharedPreferences("eor_adb", Context.MODE_PRIVATE).edit()
+        .putBoolean("paired", false).commit()
+
+    fun store(privateKey: ByteArray) {
+        require(privateKey.size in 256..16_384);
+        val c = Cipher.getInstance("AES/GCM/NoPadding"); c.init(
+            Cipher.ENCRYPT_MODE,
+            key()
+        ); file.writeBytes(c.iv + c.doFinal(privateKey))
+    }
+
+    fun load(): ByteArray {
+        val all = file.readBytes(); require(all.size in 29..16_412);
+        val c = Cipher.getInstance("AES/GCM/NoPadding"); c.init(
+            Cipher.DECRYPT_MODE,
+            key(),
+            GCMParameterSpec(128, all.copyOfRange(0, 12))
+        ); return c.doFinal(all.copyOfRange(12, all.size))
+    }
+
+    private fun key(): java.security.Key {
+        val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }; ks.getKey(
+            ALIAS,
+            null
+        )?.let { return it }
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").apply {
+            init(
+                KeyGenParameterSpec.Builder(
+                    ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE).build()
+            )
+        }.generateKey()
+    }
+
+    companion object {
+        const val ALIAS = "eor.embedded.adb.identity.v1"
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/systemui/SystemNavigationLockController.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/systemui/SystemNavigationLockController.kt
@@ -1,0 +1,430 @@
+package com.gamelaunch.frontend.systemui
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.SystemClock
+import android.provider.Settings
+import android.provider.Settings.Global.BOOT_COUNT
+import com.gamelaunch.frontend.domain.lockedmode.LockedModeRepository
+import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+
+enum class SystemNavigationLockStatus {
+    DISABLED,
+    UNSUPPORTED,
+    DEVELOPER_OPTIONS_REQUIRED,
+    WIRELESS_DEBUGGING_REQUIRED,
+    PAIRING_REQUIRED,
+    DISCOVERING,
+    START_REQUIRED,
+    STARTING,
+    READY,
+    APPLYING,
+    ACTIVE,
+    RESTORE_REQUIRED,
+    ERROR,
+}
+
+internal enum class PairingNotificationPhase {
+    IDLE,
+    SETUP,
+    PAIRING,
+    RESULT,
+}
+
+data class SystemNavigationSetupProgress(
+    val developerOptionsEnabled: Boolean = false,
+    val wirelessDebuggingEnabled: Boolean = false,
+    val paired: Boolean = false,
+)
+
+@Singleton
+class SystemNavigationLockController @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val lockedModeRepository: LockedModeRepository,
+    private val brokerManager: EmbeddedPrivilegeBrokerManager,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val mutex = Mutex()
+    private val prefs = context.getSharedPreferences("system_navigation_lock", Context.MODE_PRIVATE)
+    private val _status = MutableStateFlow(SystemNavigationLockStatus.DISABLED)
+    val status: StateFlow<SystemNavigationLockStatus> = _status.asStateFlow()
+    private val _pairingPort = MutableStateFlow<Int?>(null)
+    val pairingPort: StateFlow<Int?> = _pairingPort.asStateFlow()
+    private val _setupProgress = MutableStateFlow(readSetupProgress())
+    val setupProgress: StateFlow<SystemNavigationSetupProgress> = _setupProgress.asStateFlow()
+    private var pairingDiscoveryJob: Job? = null
+    private var reconciliationJob: Job? = null
+    private var navigationRecoveryJob: Job? = null
+    private var pairingResultResetJob: Job? = null
+    private var pairingNotificationPhase = PairingNotificationPhase.IDLE
+    private var pairingNotificationGeneration = 0L
+    private var lastPairingVerificationAt = Long.MIN_VALUE
+    private var optionEnabled = false
+    private var lockedModeState = LockedModeState.DISABLED
+
+    init {
+        scope.launch { combine(lockedModeRepository.state, lockedModeRepository.blockSystemNavigation) { a,b -> a to b }
+            .collect { (state, enabled) ->
+                lockedModeState = state
+                optionEnabled = enabled
+                if (!enabled) dismissPairingNotification()
+                reconcileNow()
+            } }
+        scope.launch { status.collect {
+            if (shouldDismissPairingNotification(it, pairingNotificationPhase)) {
+                dismissPairingNotification()
+            } else {
+                ensurePairingNotification(it)
+            }
+        } }
+        scope.launch { recoverBrokerOnStartup() }
+    }
+    fun reconcile() {
+        refreshSetupProgress()
+        if (reconciliationJob?.isActive == true) return
+        reconciliationJob = scope.launch {
+            verifyStoredPairingIfDue()
+            reconcileNow()
+            ensurePairingNotification(_status.value)
+        }
+    }
+    suspend fun reconcileFromRepository() { lockedModeState=lockedModeRepository.state.first(); optionEnabled=lockedModeRepository.blockSystemNavigation.first(); reconcileNow() }
+
+    private suspend fun verifyStoredPairingIfDue() {
+        val progress = _setupProgress.value
+        if (!optionEnabled || lockedModeState == LockedModeState.LOCKED || !progress.paired ||
+            !progress.developerOptionsEnabled || !progress.wirelessDebuggingEnabled ||
+            brokerManager.currentBroker() == null
+        ) return
+        val now = SystemClock.elapsedRealtime()
+        if (lastPairingVerificationAt != Long.MIN_VALUE && now - lastPairingVerificationAt < 5_000L) return
+        lastPairingVerificationAt = now
+        if (brokerManager.verifyPairing() == false) {
+            brokerManager.invalidateCurrentBroker()
+            refreshSetupProgress()
+        }
+    }
+    fun openDevelopmentSettings(): Boolean = runCatching {
+        context.startActivity(
+            Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        true
+    }.getOrDefault(false)
+    fun openDeviceInfoSettings(): Boolean {
+        val flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        return runCatching {
+            context.startActivity(Intent(Settings.ACTION_DEVICE_INFO_SETTINGS).addFlags(flags))
+            true
+        }.getOrElse {
+            runCatching {
+                context.startActivity(Intent(Settings.ACTION_SETTINGS).addFlags(flags))
+                true
+            }.getOrDefault(false)
+        }
+    }
+    fun preparePairingNotification() {
+        ContextCompat.startForegroundService(context, Intent(context, EmbeddedPairingService::class.java))
+    }
+    fun dismissPairingNotification() {
+        pairingResultResetJob?.cancel()
+        pairingResultResetJob = null
+        pairingNotificationPhase = PairingNotificationPhase.IDLE
+        pairingNotificationGeneration++
+        context.getSystemService(android.app.NotificationManager::class.java)
+            .cancel(EmbeddedPairingService.PAIRING_NOTIFICATION_ID)
+        context.stopService(Intent(context, EmbeddedPairingService::class.java))
+    }
+
+    internal fun markPairingNotificationSetup() {
+        pairingResultResetJob?.cancel()
+        pairingResultResetJob = null
+        pairingNotificationGeneration++
+        pairingNotificationPhase = PairingNotificationPhase.SETUP
+    }
+
+    internal fun markPairingNotificationPairing() {
+        pairingResultResetJob?.cancel()
+        pairingResultResetJob = null
+        pairingNotificationGeneration++
+        pairingNotificationPhase = PairingNotificationPhase.PAIRING
+    }
+
+    internal fun markPairingNotificationResult(resetAfterTimeout: Boolean) {
+        pairingResultResetJob?.cancel()
+        pairingResultResetJob = null
+        val generation = ++pairingNotificationGeneration
+        pairingNotificationPhase = PairingNotificationPhase.RESULT
+        if (resetAfterTimeout) {
+            pairingResultResetJob = scope.launch {
+                delay(EmbeddedPairingService.PAIRING_SUCCESS_TIMEOUT_MS)
+                if (shouldResetPairingNotificationLifecycle(
+                        pairingNotificationPhase,
+                        pairingNotificationGeneration,
+                        generation,
+                    )
+                ) {
+                    pairingNotificationPhase = PairingNotificationPhase.IDLE
+                }
+                pairingResultResetJob = null
+            }
+        }
+    }
+    private fun ensurePairingNotification(status: SystemNavigationLockStatus) {
+        if (!optionEnabled || _setupProgress.value.paired || status !in setOf(
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+                SystemNavigationLockStatus.PAIRING_REQUIRED,
+            )
+        ) return
+        val notificationsAllowed = Build.VERSION.SDK_INT < 33 || ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (notificationsAllowed) preparePairingNotification()
+    }
+    fun beginPairingSetup() {
+        refreshSetupProgress()
+        ContextCompat.startForegroundService(context, Intent(context, EmbeddedPairingService::class.java))
+        pairingDiscoveryJob?.cancel()
+        _pairingPort.value=null
+        pairingDiscoveryJob=scope.launch {
+            repeat(8) {
+                val discovered=runCatching { discoverLocalAdb(context,"_adb-tls-pairing._tcp",15_000) }.getOrNull()
+                if(discovered != null) {
+                    EorAdbEndpointCache.pairing=discovered
+                    _pairingPort.value=discovered.port
+                    android.util.Log.i(EOR_BROKER_TAG,"pairing/background-discovery-ready")
+                    return@launch
+                }
+                delay(500)
+            }
+            android.util.Log.i(EOR_BROKER_TAG,"pairing/background-discovery-unavailable")
+        }
+        openDevelopmentSettings()
+    }
+    fun startBrokerSetup() { scope.launch {
+        refreshSetupProgress()
+        brokerSetupRequirement(_setupProgress.value)?.let {
+            _status.value = it
+            return@launch
+        }
+        _status.value = SystemNavigationLockStatus.DISCOVERING
+        val result = brokerManager.connectOrStart()
+        if (result == SystemNavigationLockStatus.READY) reconcileNow()
+        else {
+            refreshSetupProgress()
+            val status = setupStatus(result, _setupProgress.value)
+            if (status == SystemNavigationLockStatus.STARTING) scheduleNavigationRecovery()
+            else _status.value = status
+        }
+    } }
+    fun pair(code:String,port:Int?,onComplete:((SystemNavigationLockStatus)->Unit)?=null) { scope.launch {
+        pairingDiscoveryJob?.cancel()
+        refreshSetupProgress()
+        brokerSetupRequirement(_setupProgress.value)?.let {
+            _status.value = it
+            onComplete?.invoke(it)
+            context.stopService(Intent(context,EmbeddedPairingService::class.java))
+            return@launch
+        }
+        ContextCompat.startForegroundService(context,Intent(context,EmbeddedPairingService::class.java))
+        _status.value=SystemNavigationLockStatus.DISCOVERING
+        val result=brokerManager.pair(code,port ?: _pairingPort.value)
+        if (result == SystemNavigationLockStatus.READY) reconcileNow() else _status.value=result
+        onComplete?.invoke(_status.value)
+        context.stopService(Intent(context,EmbeddedPairingService::class.java))
+    } }
+
+    private suspend fun reconcileNow() = mutex.withLock {
+        refreshSetupProgress()
+        val desired = shouldLockSystemNavigation(optionEnabled, lockedModeState)
+        val bootCount = currentBootCount()
+        val applied = prefs.getBoolean("applied", false) &&
+            prefs.getInt("applied_boot_count", -1) == bootCount
+        if (!optionEnabled && !applied) { _status.value=SystemNavigationLockStatus.DISABLED; return }
+        if (Build.VERSION.SDK_INT < 30) { _status.value=SystemNavigationLockStatus.UNSUPPORTED; return }
+        var broker = brokerManager.currentBroker()
+        if (broker == null) {
+            brokerSetupRequirement(_setupProgress.value)?.let {
+                _status.value = if (!desired && applied) SystemNavigationLockStatus.RESTORE_REQUIRED else it
+                return
+            }
+            val readiness = brokerManager.readiness()
+            if (readiness != SystemNavigationLockStatus.START_REQUIRED) {
+                _status.value = if (!desired && applied) SystemNavigationLockStatus.RESTORE_REQUIRED else readiness
+                return
+            }
+            _status.value = SystemNavigationLockStatus.DISCOVERING
+            val result = brokerManager.connectOrStart()
+            if (result != SystemNavigationLockStatus.READY) {
+                refreshSetupProgress()
+                val status = if (!desired && applied) SystemNavigationLockStatus.RESTORE_REQUIRED
+                    else setupStatus(result, _setupProgress.value)
+                if (status == SystemNavigationLockStatus.STARTING) scheduleNavigationRecovery()
+                else _status.value = status
+                return
+            }
+            broker = brokerManager.currentBroker()
+            if (broker == null) { _status.value = SystemNavigationLockStatus.ERROR; return }
+        }
+        // A new boot clears shell-owned SystemUI restrictions. If eOr has not applied anything in
+        // this boot and Locked Mode is inactive, broker availability alone means setup is ready.
+        if (!desired && !applied) {
+            _status.value = if (optionEnabled) SystemNavigationLockStatus.READY
+                else SystemNavigationLockStatus.DISABLED
+            return
+        }
+        _status.value=SystemNavigationLockStatus.APPLYING
+        val ok=runCatching { withTimeout(8_000) {
+            repeat(5) { attempt ->
+                val appliedNow = runCatching {
+                    broker.setNavigationLocked(desired) == 0 &&
+                        broker.getNavigationLockState() == if (desired) 1 else 0
+                }.getOrDefault(false)
+                if (appliedNow) return@withTimeout true
+                if (attempt < 4) delay(250L * (1L shl attempt))
+            }
+            false
+        } }.getOrDefault(false)
+        if(ok) { prefs.edit().putBoolean("applied",desired).putInt("applied_boot_count",bootCount).apply(); _status.value=if(desired) SystemNavigationLockStatus.ACTIVE else if(optionEnabled) SystemNavigationLockStatus.READY else SystemNavigationLockStatus.DISABLED }
+        else if (!desired && applied) _status.value=SystemNavigationLockStatus.RESTORE_REQUIRED
+        else scheduleNavigationRecovery()
+    }
+
+    private fun scheduleNavigationRecovery() {
+        refreshSetupProgress()
+        val recoveryStatus = navigationRecoveryStatus(_setupProgress.value)
+        if (recoveryStatus != SystemNavigationLockStatus.STARTING) {
+            _status.value = recoveryStatus
+            navigationRecoveryJob?.cancel()
+            navigationRecoveryJob = null
+            return
+        }
+        _status.value = SystemNavigationLockStatus.STARTING
+        if (navigationRecoveryJob?.isActive == true) return
+        navigationRecoveryJob = scope.launch {
+            try {
+                for (retryDelay in listOf(2_000L, 4_000L, 8_000L, 15_000L, 30_000L)) {
+                    delay(retryDelay)
+                    if (_status.value != SystemNavigationLockStatus.STARTING) return@launch
+                    reconcileNow()
+                    if (_status.value != SystemNavigationLockStatus.STARTING) return@launch
+                }
+                _status.value = SystemNavigationLockStatus.ERROR
+            } finally {
+                navigationRecoveryJob = null
+            }
+        }
+    }
+
+    private suspend fun recoverBrokerOnStartup() {
+        if (!EncryptedAdbIdentity(context).isPaired()) return
+        for (retryDelay in listOf(0L, 1_000L, 2_000L, 4_000L, 8_000L, 15_000L, 30_000L)) {
+            delay(retryDelay)
+            refreshSetupProgress()
+            if (brokerSetupRequirement(_setupProgress.value) != null) continue
+            android.util.Log.i(EOR_BROKER_TAG, "broker/startup-recovery")
+            // The normal reconciliation path owns broker startup and its retry lifecycle.
+            reconcileNow()
+            return
+        }
+    }
+
+    private fun currentBootCount(): Int = runCatching {
+        Settings.Global.getInt(context.contentResolver, BOOT_COUNT)
+    }.getOrDefault(-1)
+
+    fun refreshSetupProgress() {
+        _setupProgress.value = readSetupProgress()
+    }
+
+    private fun readSetupProgress() = SystemNavigationSetupProgress(
+        developerOptionsEnabled = runCatching {
+            Settings.Global.getInt(
+                context.contentResolver,
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED,
+                0,
+            ) == 1
+        }.getOrDefault(false),
+        // Android has exposed this global setting since Wireless debugging was introduced,
+        // but not as a public SDK constant. Treat an unavailable OEM setting as disabled.
+        wirelessDebuggingEnabled = Build.VERSION.SDK_INT >= 30 && runCatching {
+            Settings.Global.getInt(context.contentResolver, "adb_wifi_enabled", 0) == 1
+        }.getOrDefault(false),
+        paired = EncryptedAdbIdentity(context).isPaired(),
+    )
+}
+
+internal fun shouldLockSystemNavigation(optionEnabled:Boolean, lockedModeState:LockedModeState)=optionEnabled && lockedModeState==LockedModeState.LOCKED
+
+internal fun shouldDismissPairingNotification(
+    status: SystemNavigationLockStatus,
+    phase: PairingNotificationPhase,
+): Boolean = status in setOf(
+    SystemNavigationLockStatus.READY,
+    SystemNavigationLockStatus.ACTIVE,
+) && phase in setOf(
+    PairingNotificationPhase.IDLE,
+    PairingNotificationPhase.SETUP,
+)
+
+internal fun shouldResetPairingNotificationLifecycle(
+    phase: PairingNotificationPhase,
+    currentGeneration: Long,
+    scheduledGeneration: Long,
+): Boolean = phase == PairingNotificationPhase.RESULT &&
+    currentGeneration == scheduledGeneration
+
+internal fun navigationRecoveryStatus(
+    progress: SystemNavigationSetupProgress,
+): SystemNavigationLockStatus = when {
+    !progress.developerOptionsEnabled -> SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED
+    !progress.wirelessDebuggingEnabled -> SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED
+    !progress.paired -> SystemNavigationLockStatus.PAIRING_REQUIRED
+    else -> SystemNavigationLockStatus.STARTING
+}
+
+internal fun brokerSetupRequirement(
+    progress: SystemNavigationSetupProgress,
+): SystemNavigationLockStatus? = when {
+    !progress.developerOptionsEnabled -> SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED
+    !progress.wirelessDebuggingEnabled -> SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED
+    else -> null
+}
+
+internal fun setupStatus(
+    status: SystemNavigationLockStatus,
+    progress: SystemNavigationSetupProgress,
+): SystemNavigationLockStatus {
+    if (status != SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED) {
+        return status
+    }
+
+    return when {
+        !progress.developerOptionsEnabled -> SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED
+        !progress.wirelessDebuggingEnabled -> SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED
+        !progress.paired -> SystemNavigationLockStatus.PAIRING_REQUIRED
+        else -> SystemNavigationLockStatus.STARTING
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/lockedmode/LockedModeSettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/lockedmode/LockedModeSettingsViewModel.kt
@@ -6,6 +6,9 @@ import com.gamelaunch.frontend.domain.lockedmode.LockedModeRepository
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
 import com.gamelaunch.frontend.domain.lockedmode.PinResult
 import com.gamelaunch.frontend.domain.lockedmode.message
+import com.gamelaunch.frontend.systemui.SystemNavigationLockController
+import com.gamelaunch.frontend.systemui.SystemNavigationLockStatus
+import com.gamelaunch.frontend.systemui.SystemNavigationSetupProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,6 +30,9 @@ data class LockedModeSettingsUiState(
     val hasPin: Boolean = false,
     val dialogStep: LockedModeDialogStep? = null,
     val error: String? = null,
+    val blockSystemNavigation: Boolean = false,
+    val systemNavigationStatus: SystemNavigationLockStatus = SystemNavigationLockStatus.DISABLED,
+    val systemNavigationSetupProgress: SystemNavigationSetupProgress = SystemNavigationSetupProgress(),
 )
 
 /**
@@ -36,17 +42,36 @@ data class LockedModeSettingsUiState(
 @HiltViewModel
 class LockedModeSettingsViewModel @Inject constructor(
     private val repository: LockedModeRepository,
+    private val systemNavigationLockController: SystemNavigationLockController,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(LockedModeSettingsUiState())
     val uiState: StateFlow<LockedModeSettingsUiState> = _uiState.asStateFlow()
-
     private var newPin = ""
 
     init {
         viewModelScope.launch {
-            combine(repository.state, repository.hasPin) { state, hasPin -> state to hasPin }
-                .collectLatest { (state, hasPin) ->
-                _uiState.value = _uiState.value.copy(lockedModeState = state, hasPin = hasPin)
+            combine(
+                repository.state,
+                repository.hasPin,
+                repository.blockSystemNavigation,
+                systemNavigationLockController.status,
+                systemNavigationLockController.setupProgress,
+            ) { state, hasPin, blockNavigation, navigationStatus, setupProgress ->
+                LockedModeSettingsUiState(
+                    lockedModeState = state,
+                    hasPin = hasPin,
+                    blockSystemNavigation = blockNavigation,
+                    systemNavigationStatus = navigationStatus,
+                    systemNavigationSetupProgress = setupProgress,
+                )
+            }.collectLatest { owned ->
+                _uiState.value = _uiState.value.copy(
+                    lockedModeState = owned.lockedModeState,
+                    hasPin = owned.hasPin,
+                    blockSystemNavigation = owned.blockSystemNavigation,
+                    systemNavigationStatus = owned.systemNavigationStatus,
+                    systemNavigationSetupProgress = owned.systemNavigationSetupProgress,
+                )
             }
         }
     }
@@ -67,6 +92,24 @@ class LockedModeSettingsViewModel @Inject constructor(
         viewModelScope.launch { repository.removePin() }
     }
 
+    fun setBlockSystemNavigation(enabled: Boolean) {
+        viewModelScope.launch {
+            repository.setBlockSystemNavigation(enabled)
+            if (!enabled) systemNavigationLockController.dismissPairingNotification()
+        }
+    }
+
+    fun openDevelopmentSettings() = systemNavigationLockController.openDevelopmentSettings()
+
+    fun openDeviceInfoSettings() = systemNavigationLockController.openDeviceInfoSettings()
+
+    fun beginEmbeddedPairingSetup() = systemNavigationLockController.beginPairingSetup()
+
+    fun prepareEmbeddedPairingNotification() =
+        systemNavigationLockController.preparePairingNotification()
+
+    fun refreshSystemNavigationSetupProgress() = systemNavigationLockController.reconcile()
+
     fun dismissDialog() = finishWorkflow()
 
     fun submitPin(pin: String) {
@@ -76,11 +119,13 @@ class LockedModeSettingsViewModel @Inject constructor(
                 newPin = pin
                 showStep(LockedModeDialogStep.CONFIRM_PIN)
             }
+
             LockedModeDialogStep.CONFIRM_PIN -> confirmSetup(pin)
             LockedModeDialogStep.NEW_PIN -> {
                 newPin = pin
                 showStep(LockedModeDialogStep.CONFIRM_NEW_PIN)
             }
+
             LockedModeDialogStep.CONFIRM_NEW_PIN -> confirmChange(pin)
             null -> Unit
         }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/lockedmode/LockedModeViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/lockedmode/LockedModeViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeRepository
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
+import com.gamelaunch.frontend.domain.lockedmode.PinResult
+import com.gamelaunch.frontend.systemui.SystemNavigationLockController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,7 +24,8 @@ data class LockedModeUiState(
  */
 @HiltViewModel
 class LockedModeViewModel @Inject constructor(
-    private val repository: LockedModeRepository
+    private val repository: LockedModeRepository,
+    private val systemNavigationLockController: SystemNavigationLockController,
 ) : ViewModel() {
     val uiState: StateFlow<LockedModeUiState> =
         combine(repository.state, repository.hasPin) { state, hasPin ->
@@ -33,6 +36,18 @@ class LockedModeViewModel @Inject constructor(
             initialValue = LockedModeUiState(),
         )
 
-    suspend fun activate() = repository.activate()
-    suspend fun unlock(pin: String? = null) = repository.unlock(pin)
+    suspend fun activate() {
+        repository.activate()
+        systemNavigationLockController.reconcileFromRepository()
+    }
+
+    suspend fun unlock(pin: String? = null): PinResult {
+        val result = repository.unlock(pin)
+        if (result == PinResult.Success) {
+            // Do not rely on the controller's asynchronous collector: unlocking must not complete
+            // until the repository's new state has been read and SystemUI restoration has finished.
+            systemNavigationLockController.reconcileFromRepository()
+        }
+        return result
+    }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -2,6 +2,9 @@ package com.gamelaunch.frontend.ui.screen.settings
 
 import android.content.Context
 import android.content.Intent
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.hardware.display.DisplayManager
 import android.provider.Settings
 import android.view.Display
@@ -45,6 +48,8 @@ import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.EmojiEvents
 import com.gamelaunch.frontend.domain.friends.Friend
 import com.gamelaunch.frontend.domain.friends.FriendStatus
+import com.gamelaunch.frontend.systemui.SystemNavigationLockStatus
+import com.gamelaunch.frontend.systemui.SystemNavigationSetupProgress
 import com.gamelaunch.frontend.ui.screen.friends.FriendsViewModel
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.PermMedia
@@ -106,7 +111,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.window.Dialog
@@ -121,6 +130,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.gamelaunch.frontend.launcher.HomeLauncherHelper
 import com.gamelaunch.frontend.domain.sync.EmulatorSyncStatus
 import com.gamelaunch.frontend.domain.sync.SyncReadiness
@@ -511,11 +521,59 @@ private fun LockedModeSection(
     val state = uiState.lockedModeState
     val enabled = state == LockedModeState.READY || state == LockedModeState.LOCKED
     var showLockConfirm by remember { mutableStateOf(false) }
+    var showNavigationSteps by rememberSaveable { mutableStateOf(true) }
+    var openSettingsAfterNotificationPermission by remember { mutableStateOf(false) }
+    var notificationPermissionRequested by remember { mutableStateOf(false) }
+    val pairingContext = LocalContext.current
+    val notificationPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) viewModel.prepareEmbeddedPairingNotification()
+        if (granted && openSettingsAfterNotificationPermission) {
+            viewModel.beginEmbeddedPairingSetup()
+        }
+        openSettingsAfterNotificationPermission = false
+    }
+    val setupNeedsPairingNotification = !uiState.systemNavigationSetupProgress.paired &&
+        uiState.systemNavigationStatus in setOf(
+            SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+            SystemNavigationLockStatus.PAIRING_REQUIRED,
+        )
+    val showSystemNavigationSetupSteps = showNavigationSteps &&
+        shouldShowSystemNavigationSetupSteps(uiState.systemNavigationStatus)
+    LifecycleResumeEffect(
+        viewModel,
+        uiState.blockSystemNavigation,
+        setupNeedsPairingNotification,
+    ) {
+        if (uiState.blockSystemNavigation && setupNeedsPairingNotification) {
+            val needsPermission = Build.VERSION.SDK_INT >= 33 && ContextCompat.checkSelfPermission(
+                pairingContext,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+            if (needsPermission && !notificationPermissionRequested) {
+                notificationPermissionRequested = true
+                openSettingsAfterNotificationPermission = false
+                notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else if (!needsPermission) {
+                viewModel.prepareEmbeddedPairingNotification()
+            }
+        }
+        onPauseOrDispose { }
+    }
+    LaunchedEffect(uiState.blockSystemNavigation, showSystemNavigationSetupSteps) {
+        while (uiState.blockSystemNavigation && showSystemNavigationSetupSteps) {
+            viewModel.refreshSystemNavigationSetupProgress()
+            kotlinx.coroutines.delay(1_000)
+        }
+    }
 
     SettingsSectionHeader("Locked mode")
     SettingsCard {
         Text(
-            "Locked Mode creates a simplified Home screen that shows only the games and apps you choose. Enabling the feature does not lock eOr immediately—you decide when to enter Locked Mode.",
+            "Locked Mode creates a simplified Home screen that shows only the games and " +
+                "apps you choose. Enabling the feature does not lock eOr immediately—you " +
+                "decide when to enter Locked Mode.",
             style = MaterialTheme.typography.bodyMedium,
         )
         Spacer(Modifier.height(12.dp))
@@ -540,7 +598,8 @@ private fun LockedModeSection(
                         LockedModeState.DISABLED ->
                             "Turn on Locked Mode to restrict eOr to the games and apps you allow."
                         LockedModeState.READY ->
-                            "Locked Mode is ready. Choose Lock Now here or use the lock button on Home."
+                            "Locked Mode is ready. Choose Lock Now here or use the lock button " +
+                                "on Home."
                         LockedModeState.LOCKED ->
                             "Locked Mode is active. Only allowed games and apps are available."
                     },
@@ -565,7 +624,8 @@ private fun LockedModeSection(
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            "Turning Locked Mode off exits it immediately. Your PIN and allowed games and apps are kept for the next time you enable it.",
+            "Turning Locked Mode off exits it immediately. Your PIN and allowed games and " +
+                "apps are kept for the next time you enable it.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -574,15 +634,20 @@ private fun LockedModeSection(
     SettingsSectionHeader("PIN settings")
     SettingsCard {
         Text(
-            "A PIN is optional. Set one if you want to prevent someone from leaving Locked Mode without entering four digits.",
+            "A PIN is optional. Set one if you want to prevent someone from leaving Locked " +
+                "Mode without entering four digits.",
             style = MaterialTheme.typography.bodyMedium,
         )
         Spacer(Modifier.height(6.dp))
         Text(
             when {
                 !enabled -> "Enable Locked Mode to set, change, or remove its PIN."
-                uiState.hasPin -> "PIN protection is active. Changing or removing the PIN does not require the current PIN."
-                else -> "Without a PIN, pressing the unlock button on Home exits Locked Mode immediately."
+                uiState.hasPin ->
+                    "PIN protection is active. Changing or removing the PIN does not " +
+                        "require the current PIN."
+                else ->
+                    "Without a PIN, pressing the unlock button on Home exits Locked Mode " +
+                        "immediately."
             },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -605,6 +670,184 @@ private fun LockedModeSection(
                 enabled = enabled && uiState.hasPin,
                 contentColor = MaterialTheme.colorScheme.error
             )
+        }
+    }
+
+    SettingsSectionHeader("System navigation")
+    SettingsCard {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Lock, contentDescription = null, tint = ElectricBlue)
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    "Block system navigation while locked",
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    "Uses Wireless debugging to block Home, Recents, edge navigation, and " +
+                        "notification shade access while Locked Mode is active.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = uiState.blockSystemNavigation,
+                onCheckedChange = { checked ->
+                    viewModel.setBlockSystemNavigation(checked)
+                },
+                enabled = enabled,
+            )
+        }
+        if (uiState.blockSystemNavigation) {
+            Spacer(Modifier.height(12.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(12.dp))
+            Text(
+                "What to expect:\n" +
+                    "• While Locked Mode is active, the notification shade, Home, Recent " +
+                    "apps, and edge navigation will be unavailable.\n" +
+                    "• Unlocking eOr restores normal system navigation.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (showSystemNavigationSetupSteps) {
+                Spacer(Modifier.height(12.dp))
+                val setupStepCompletion = systemNavigationSetupStepCompletion(
+                    uiState.systemNavigationSetupProgress,
+                )
+                val stepsText = buildAnnotatedString {
+                    append("What to do:")
+                    fun appendStep(number: Int, complete: Boolean, instruction: String) {
+                        append('\n')
+                        if (complete) append("✓")
+                        else withStyle(SpanStyle(color = Color.Transparent)) { append("✓") }
+                        append(" ($number) $instruction")
+                    }
+                    appendStep(
+                        number = 1,
+                        complete = setupStepCompletion[0],
+                        instruction = "Enable Developer options: open About phone or About " +
+                            "device, find Build number, and tap it seven times.",
+                    )
+                    appendStep(
+                        number = 2,
+                        complete = setupStepCompletion[1],
+                        instruction = "Open Developer options and enable Wireless debugging.",
+                    )
+                    if (uiState.systemNavigationSetupProgress.paired) {
+                        appendStep(
+                            number = 3,
+                            complete = setupStepCompletion[2],
+                            instruction = "eOr is paired with Wireless debugging.",
+                        )
+                    } else {
+                        appendStep(
+                            number = 3,
+                            complete = false,
+                            instruction = "Open Wireless debugging and choose ‘Pair device " +
+                                "with pairing code’.",
+                        )
+                        appendStep(
+                            number = 4,
+                            complete = false,
+                            instruction = "Pull down the notification shade and find the eOr " +
+                                "notification, not leaving the pair device screen.",
+                        )
+                        appendStep(
+                            number = 5,
+                            complete = false,
+                            instruction = "Tap ‘Enter pairing code’ and enter the six-digit code.",
+                        )
+                        appendStep(
+                            number = 6,
+                            complete = false,
+                            instruction = "Press send and keep the pairing dialog open until " +
+                                "pairing completes.",
+                        )
+                    }
+                }
+                Text(
+                    stepsText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    Text(
+                        "[hide steps]",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = ElectricBlue,
+                        modifier = Modifier
+                            .dpadFocusable { showNavigationSteps = false }
+                            .padding(6.dp),
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(12.dp))
+            }
+            val statusText = when (uiState.systemNavigationStatus) {
+                SystemNavigationLockStatus.DISABLED -> "Disabled"
+                SystemNavigationLockStatus.UNSUPPORTED -> "Unsupported on Android 8–10"
+                SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED -> "Enable Developer options"
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED ->
+                    "Enable Wireless debugging"
+                SystemNavigationLockStatus.PAIRING_REQUIRED -> "Pair eOr with Wireless debugging"
+                SystemNavigationLockStatus.DISCOVERING -> "Discovering local ADB endpoint…"
+                SystemNavigationLockStatus.START_REQUIRED -> "Navigation blocking needs setup"
+                SystemNavigationLockStatus.STARTING -> "Waiting for Android…"
+                SystemNavigationLockStatus.READY -> "Ready - activates with Locked Mode"
+                SystemNavigationLockStatus.APPLYING -> "Applying navigation blocking…"
+                SystemNavigationLockStatus.ACTIVE -> "System navigation is blocked"
+                SystemNavigationLockStatus.RESTORE_REQUIRED ->
+                    "Restore navigation or reboot Android"
+                SystemNavigationLockStatus.ERROR -> "Could not enable navigation blocking"
+            }
+            Text(statusText, style = MaterialTheme.typography.bodyMedium)
+            val requiresDeveloperOptions = uiState.systemNavigationStatus in setOf(
+                SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+                SystemNavigationLockStatus.PAIRING_REQUIRED,
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+            )
+            if (requiresDeveloperOptions) {
+                Spacer(Modifier.height(10.dp))
+                val developerOptionsRequired =
+                    uiState.systemNavigationStatus ==
+                        SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED
+                GradientOutlineButton(
+                    text = if (developerOptionsRequired) {
+                        "Open About device"
+                    } else {
+                        "Open Developer options"
+                    },
+                    onClick = {
+                        if (developerOptionsRequired) {
+                            viewModel.openDeviceInfoSettings()
+                            return@GradientOutlineButton
+                        }
+                        val needsNotificationPermission =
+                            uiState.systemNavigationStatus ==
+                                SystemNavigationLockStatus.PAIRING_REQUIRED &&
+                                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                ContextCompat.checkSelfPermission(
+                                    pairingContext,
+                                    Manifest.permission.POST_NOTIFICATIONS,
+                                ) != PackageManager.PERMISSION_GRANTED
+
+                        if (needsNotificationPermission) {
+                            notificationPermissionRequested = true
+                            openSettingsAfterNotificationPermission = true
+                            notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        } else {
+                            viewModel.beginEmbeddedPairingSetup()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 
@@ -662,6 +905,22 @@ private fun LockedModeSection(
             onPinComplete = viewModel::submitPin,
         )
     }
+}
+
+internal fun shouldShowSystemNavigationSetupSteps(status: SystemNavigationLockStatus): Boolean =
+    status !in setOf(
+        SystemNavigationLockStatus.READY,
+        SystemNavigationLockStatus.APPLYING,
+        SystemNavigationLockStatus.ACTIVE,
+    )
+
+internal fun systemNavigationSetupStepCompletion(
+    progress: SystemNavigationSetupProgress,
+): List<Boolean> {
+    val developerOptionsComplete = progress.developerOptionsEnabled
+    val wirelessDebuggingComplete = developerOptionsComplete && progress.wirelessDebuggingEnabled
+    val pairingComplete = wirelessDebuggingComplete && progress.paired
+    return listOf(developerOptionsComplete, wirelessDebuggingComplete, pairingComplete)
 }
 
 @Composable

--- a/app/src/main/java/com/gamelaunch/frontend/ui/systemui/SystemNavigationLockHost.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/systemui/SystemNavigationLockHost.kt
@@ -1,0 +1,79 @@
+package com.gamelaunch.frontend.ui.systemui
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun SystemNavigationLockHost(
+    viewModel: SystemNavigationLockViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LifecycleResumeEffect(viewModel) {
+        viewModel.reconcile()
+        onPauseOrDispose { }
+    }
+
+    uiState.prompt?.let { prompt ->
+        SystemNavigationLockDialog(
+            prompt = prompt,
+            onPrimaryAction = { viewModel.performPrimaryAction(prompt) },
+            onDismiss = viewModel::dismissPrompt,
+        )
+    }
+}
+
+@Composable
+private fun SystemNavigationLockDialog(
+    prompt: SystemNavigationPrompt,
+    onPrimaryAction: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                if (prompt == SystemNavigationPrompt.RESTORE_NAVIGATION) {
+                    "System navigation needs restoring"
+                } else {
+                    "System navigation is not blocked"
+                }
+            )
+        },
+        text = { Text(prompt.message) },
+        confirmButton = {
+            TextButton(onClick = onPrimaryAction) {
+                Text(prompt.primaryActionLabel)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Later")
+            }
+        },
+    )
+}
+
+private val SystemNavigationPrompt.message: String
+    get() = when (this) {
+        SystemNavigationPrompt.RESTORE_NAVIGATION ->
+            "eOr has unlocked, but could not restore Android system navigation. Try restoring it again or reboot Android."
+        SystemNavigationPrompt.ENABLE_DEVELOPER_OPTIONS -> "Enable Developer options, then return to eOr. Locked Mode remains usable, but system navigation is not blocked."
+        SystemNavigationPrompt.ENABLE_WIRELESS_DEBUGGING -> "Enable Wireless debugging, then return to eOr. Locked Mode remains usable, but system navigation is not blocked."
+        SystemNavigationPrompt.PAIR_DEVICE -> "Pair eOr with this device from Wireless debugging. No second app is required."
+    }
+
+private val SystemNavigationPrompt.primaryActionLabel: String
+    get() = when (this) {
+        SystemNavigationPrompt.ENABLE_DEVELOPER_OPTIONS,
+        SystemNavigationPrompt.ENABLE_WIRELESS_DEBUGGING,
+        -> "Open Developer options"
+        SystemNavigationPrompt.PAIR_DEVICE -> "Pair device"
+        else -> "Restore navigation"
+    }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/systemui/SystemNavigationLockViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/systemui/SystemNavigationLockViewModel.kt
@@ -1,0 +1,78 @@
+package com.gamelaunch.frontend.ui.systemui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gamelaunch.frontend.domain.lockedmode.LockedModeRepository
+import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
+import com.gamelaunch.frontend.systemui.SystemNavigationLockController
+import com.gamelaunch.frontend.systemui.SystemNavigationLockStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+
+enum class SystemNavigationPrompt {
+    ENABLE_DEVELOPER_OPTIONS,
+    ENABLE_WIRELESS_DEBUGGING,
+    PAIR_DEVICE,
+    RESTORE_NAVIGATION,
+}
+
+data class SystemNavigationLockUiState(
+    val prompt: SystemNavigationPrompt? = null,
+)
+
+@HiltViewModel
+class SystemNavigationLockViewModel @Inject constructor(
+    repository: LockedModeRepository,
+    private val controller: SystemNavigationLockController,
+) : ViewModel() {
+    private val promptDismissed = MutableStateFlow(false)
+
+    val uiState: StateFlow<SystemNavigationLockUiState> = combine(
+        repository.state,
+        repository.blockSystemNavigation,
+        controller.status,
+        promptDismissed,
+    ) { lockedMode, optionEnabled, status, dismissed ->
+        SystemNavigationLockUiState(
+            prompt = if (dismissed) null else status.toPrompt(lockedMode, optionEnabled),
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = SystemNavigationLockUiState(),
+    )
+
+    fun reconcile() = controller.reconcile()
+
+    fun dismissPrompt() {
+        promptDismissed.value = true
+    }
+
+    fun performPrimaryAction(prompt: SystemNavigationPrompt) {
+        when (prompt) {
+            SystemNavigationPrompt.ENABLE_DEVELOPER_OPTIONS,
+            SystemNavigationPrompt.ENABLE_WIRELESS_DEBUGGING,
+            SystemNavigationPrompt.PAIR_DEVICE,
+            -> controller.beginPairingSetup()
+            SystemNavigationPrompt.RESTORE_NAVIGATION -> controller.startBrokerSetup()
+        }
+    }
+}
+
+internal fun SystemNavigationLockStatus.toPrompt(
+    lockedMode: LockedModeState,
+    optionEnabled: Boolean,
+): SystemNavigationPrompt? = when {
+    this == SystemNavigationLockStatus.RESTORE_REQUIRED ->
+        SystemNavigationPrompt.RESTORE_NAVIGATION
+    lockedMode != LockedModeState.LOCKED || !optionEnabled -> null
+    this == SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED -> SystemNavigationPrompt.ENABLE_DEVELOPER_OPTIONS
+    this == SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED -> SystemNavigationPrompt.ENABLE_WIRELESS_DEBUGGING
+    this == SystemNavigationLockStatus.PAIRING_REQUIRED -> SystemNavigationPrompt.PAIR_DEVICE
+    else -> null
+}

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Monochrome eOr mark for Android's small notification slot. The deliberately
+  broad shapes and visor cutout remain legible after the system scales and tints it.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- Otto's ears -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M7.3,8.1 L5.8,2.5 Q7.2,1.5 8.5,2.7 L10,8.4 Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M14,8.4 L15.5,2.7 Q16.8,1.5 18.2,2.5 L16.7,8.1 Z" />
+
+    <!-- Head and muzzle; the transparent visor preserves the cyber-donkey identity. -->
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M12,6.5 C6.7,6.5 3.5,9.5 3.5,14 C3.5,18.8 7.2,21.5 12,21.5 C16.8,21.5 20.5,18.8 20.5,14 C20.5,9.5 17.3,6.5 12,6.5 Z M7,10.5 Q6,10.5 6,11.5 L6,13 Q6,14 7,14 L17,14 Q18,14 18,13 L18,11.5 Q18,10.5 17,10.5 Z" />
+</vector>

--- a/app/src/test/java/com/gamelaunch/frontend/EmbeddedBrokerSecurityTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/EmbeddedBrokerSecurityTest.kt
@@ -1,0 +1,67 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.systemui.BootstrapTokens
+import com.gamelaunch.frontend.systemui.BrokerLaunchArguments
+import com.gamelaunch.frontend.systemui.AdbAuthenticationException
+import com.gamelaunch.frontend.systemui.isAdbAuthenticationFailure
+import javax.net.ssl.SSLProtocolException
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmbeddedBrokerSecurityTest {
+    @Test
+    fun `bootstrap token is consumed exactly once`() {
+        BootstrapTokens.issue("secret", 39)
+        assertFalse(BootstrapTokens.consume("wrong", 39))
+        assertTrue(BootstrapTokens.consume("secret", 39))
+        assertFalse(BootstrapTokens.consume("secret", 39))
+    }
+
+    @Test
+    fun `starter accepts only narrow validated arguments`() {
+        val token = "a".repeat(43)
+        assertNotNull(
+            BrokerLaunchArguments.parse(
+                arrayOf(
+                    "/data/app/eor/base.apk",
+                    "10123",
+                    "39",
+                    "com.gamelaunch.frontend.privilege.bootstrap",
+                    token
+                )
+            )
+        )
+        assertNull(
+            BrokerLaunchArguments.parse(
+                arrayOf(
+                    "/sdcard/eor.apk",
+                    "0",
+                    "39",
+                    "bad authority!",
+                    token
+                )
+            )
+        )
+        assertNull(
+            BrokerLaunchArguments.parse(
+                arrayOf(
+                    "/data/app/eor/base.apk",
+                    "10123",
+                    "39",
+                    "ok",
+                    "pairing-code"
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `only authentication failures invalidate saved pairing`() {
+        assertTrue(AdbAuthenticationException("rejected").isAdbAuthenticationFailure())
+        assertTrue(IllegalStateException(SSLProtocolException("rejected")).isAdbAuthenticationFailure())
+        assertFalse(IllegalStateException("endpoint unavailable").isAdbAuthenticationFailure())
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/LockedModeRulesTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/LockedModeRulesTest.kt
@@ -3,6 +3,7 @@ package com.gamelaunch.frontend
 import com.gamelaunch.frontend.data.repository.deriveLockedModeState
 import com.gamelaunch.frontend.data.repository.isValidLockedModePin
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
+import com.gamelaunch.frontend.domain.lockedmode.UNKNOWN_BOOT_COUNT
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -11,10 +12,95 @@ import org.junit.Test
 class LockedModeRulesTest {
     @Test
     fun `state derives independently from PIN configuration`() {
-        assertEquals(LockedModeState.DISABLED, deriveLockedModeState(enabled = false, active = false))
-        assertEquals(LockedModeState.DISABLED, deriveLockedModeState(enabled = false, active = true))
-        assertEquals(LockedModeState.READY, deriveLockedModeState(enabled = true, active = false))
-        assertEquals(LockedModeState.LOCKED, deriveLockedModeState(enabled = true, active = true))
+        assertEquals(
+            LockedModeState.DISABLED,
+            deriveLockedModeState(
+                enabled = false,
+                active = false,
+                activeBootCount = 42,
+                currentBootCount = 42,
+            ),
+        )
+        assertEquals(
+            LockedModeState.DISABLED,
+            deriveLockedModeState(
+                enabled = false,
+                active = true,
+                activeBootCount = 42,
+                currentBootCount = 42,
+            ),
+        )
+        assertEquals(
+            LockedModeState.READY,
+            deriveLockedModeState(
+                enabled = true,
+                active = false,
+                activeBootCount = 42,
+                currentBootCount = 42,
+            ),
+        )
+        assertEquals(
+            LockedModeState.LOCKED,
+            deriveLockedModeState(
+                enabled = true,
+                active = true,
+                activeBootCount = 42,
+                currentBootCount = 42,
+            ),
+        )
+    }
+
+    @Test
+    fun `active lock from an earlier boot becomes ready`() {
+        assertEquals(
+            LockedModeState.READY,
+            deriveLockedModeState(
+                enabled = true,
+                active = true,
+                activeBootCount = 41,
+                currentBootCount = 42,
+            ),
+        )
+        assertEquals(
+            LockedModeState.LOCKED,
+            deriveLockedModeState(
+                enabled = true,
+                active = true,
+                activeBootCount = 42,
+                currentBootCount = 42,
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown boot counts never establish a lock`() {
+        assertEquals(
+            LockedModeState.READY,
+            deriveLockedModeState(
+                enabled = true,
+                active = true,
+                activeBootCount = UNKNOWN_BOOT_COUNT,
+                currentBootCount = UNKNOWN_BOOT_COUNT,
+            ),
+        )
+        assertEquals(
+            LockedModeState.READY,
+            deriveLockedModeState(
+                enabled = true,
+                active = true,
+                activeBootCount = 42,
+                currentBootCount = UNKNOWN_BOOT_COUNT,
+            ),
+        )
+        assertEquals(
+            LockedModeState.READY,
+            deriveLockedModeState(
+                enabled = true,
+                active = true,
+                activeBootCount = UNKNOWN_BOOT_COUNT,
+                currentBootCount = 42,
+            ),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/gamelaunch/frontend/LockedModeSettingsViewModelTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/LockedModeSettingsViewModelTest.kt
@@ -5,6 +5,9 @@ import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
 import com.gamelaunch.frontend.domain.lockedmode.PinResult
 import com.gamelaunch.frontend.ui.lockedmode.LockedModeDialogStep
 import com.gamelaunch.frontend.ui.lockedmode.LockedModeSettingsViewModel
+import com.gamelaunch.frontend.systemui.SystemNavigationLockController
+import com.gamelaunch.frontend.systemui.SystemNavigationLockStatus
+import com.gamelaunch.frontend.systemui.SystemNavigationSetupProgress
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -20,18 +23,25 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LockedModeSettingsViewModelTest {
     private val dispatcher: TestDispatcher = StandardTestDispatcher()
     private lateinit var repository: FakeLockedModeRepository
+    private lateinit var controller: SystemNavigationLockController
     private lateinit var viewModel: LockedModeSettingsViewModel
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         repository = FakeLockedModeRepository()
-        viewModel = LockedModeSettingsViewModel(repository)
+        controller = mock()
+        whenever(controller.status).thenReturn(MutableStateFlow(SystemNavigationLockStatus.DISABLED))
+        whenever(controller.setupProgress).thenReturn(MutableStateFlow(SystemNavigationSetupProgress()))
+        viewModel = LockedModeSettingsViewModel(repository, controller)
     }
 
     @After
@@ -108,6 +118,28 @@ class LockedModeSettingsViewModelTest {
     }
 
     @Test
+    fun `system navigation restriction is optional and persisted through repository`() =
+        runTest(dispatcher) {
+            viewModel.setEnabled(true)
+            viewModel.setBlockSystemNavigation(true)
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.uiState.value.blockSystemNavigation)
+
+            viewModel.setBlockSystemNavigation(false)
+            advanceUntilIdle()
+
+            assertEquals(false, viewModel.uiState.value.blockSystemNavigation)
+        }
+
+    @Test
+    fun `system navigation progress refresh reconciles broker state`() {
+        viewModel.refreshSystemNavigationSetupProgress()
+
+        verify(controller).reconcile()
+    }
+
+    @Test
     fun `dismissal clears workflow and temporary PINs`() = runTest(dispatcher) {
         viewModel.startSetup()
         viewModel.submitPin("1234")
@@ -129,8 +161,10 @@ class LockedModeSettingsViewModelTest {
 private class FakeLockedModeRepository : LockedModeRepository {
     private val stateFlow = MutableStateFlow(LockedModeState.DISABLED)
     private val hasPinFlow = MutableStateFlow(false)
+    private val blockNavigationFlow = MutableStateFlow(false)
     override val state: Flow<LockedModeState> = stateFlow
     override val hasPin: Flow<Boolean> = hasPinFlow
+    override val blockSystemNavigation: Flow<Boolean> = blockNavigationFlow
     val currentState: LockedModeState get() = stateFlow.value
 
     var pin: String? = null
@@ -166,4 +200,8 @@ private class FakeLockedModeRepository : LockedModeRepository {
     }
 
     override suspend fun isLocked(): Boolean = stateFlow.value == LockedModeState.LOCKED
+
+    override suspend fun setBlockSystemNavigation(enabled: Boolean) {
+        blockNavigationFlow.value = enabled
+    }
 }

--- a/app/src/test/java/com/gamelaunch/frontend/SystemNavigationLockPresentationTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/SystemNavigationLockPresentationTest.kt
@@ -1,0 +1,128 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
+import com.gamelaunch.frontend.systemui.SystemNavigationLockStatus
+import com.gamelaunch.frontend.systemui.SystemNavigationSetupProgress
+import com.gamelaunch.frontend.ui.systemui.SystemNavigationPrompt
+import com.gamelaunch.frontend.ui.systemui.toPrompt
+import com.gamelaunch.frontend.ui.screen.settings.shouldShowSystemNavigationSetupSteps
+import com.gamelaunch.frontend.ui.screen.settings.systemNavigationSetupStepCompletion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SystemNavigationLockPresentationTest {
+    @Test
+    fun `setup step completion is gated by preceding requirements`() {
+        assertEquals(
+            listOf(false, false, false),
+            systemNavigationSetupStepCompletion(
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = false,
+                    wirelessDebuggingEnabled = false,
+                    paired = true,
+                ),
+            ),
+        )
+        assertEquals(
+            listOf(true, false, false),
+            systemNavigationSetupStepCompletion(
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = false,
+                    paired = true,
+                ),
+            ),
+        )
+        assertEquals(
+            listOf(true, true, true),
+            systemNavigationSetupStepCompletion(
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = true,
+                    paired = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `setup steps are hidden after system navigation setup completes`() {
+        listOf(
+            SystemNavigationLockStatus.READY,
+            SystemNavigationLockStatus.APPLYING,
+            SystemNavigationLockStatus.ACTIVE,
+        ).forEach { status ->
+            assertFalse(status.name, shouldShowSystemNavigationSetupSteps(status))
+        }
+    }
+
+    @Test
+    fun `setup steps remain available before setup completes or after readiness is lost`() {
+        SystemNavigationLockStatus.entries
+            .filterNot {
+                it in setOf(
+                    SystemNavigationLockStatus.READY,
+                    SystemNavigationLockStatus.APPLYING,
+                    SystemNavigationLockStatus.ACTIVE,
+                )
+            }
+            .forEach { status ->
+                assertTrue(status.name, shouldShowSystemNavigationSetupSteps(status))
+            }
+    }
+
+    @Test
+    fun `restore warning is shown regardless of current locked mode settings`() {
+        assertEquals(
+            SystemNavigationPrompt.RESTORE_NAVIGATION,
+            SystemNavigationLockStatus.RESTORE_REQUIRED.toPrompt(
+                lockedMode = LockedModeState.DISABLED,
+                optionEnabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `internal setup never requires a user-facing prompt`() {
+        assertNull(
+            SystemNavigationLockStatus.START_REQUIRED.toPrompt(
+                lockedMode = LockedModeState.READY,
+                optionEnabled = true,
+            )
+        )
+        assertNull(
+            SystemNavigationLockStatus.START_REQUIRED.toPrompt(
+                lockedMode = LockedModeState.LOCKED,
+                optionEnabled = false,
+            )
+        )
+        assertNull(
+            SystemNavigationLockStatus.START_REQUIRED.toPrompt(
+                lockedMode = LockedModeState.LOCKED,
+                optionEnabled = true,
+            )
+        )
+    }
+
+    @Test
+    fun `actionable controller failures map to their matching prompts`() {
+        val prompts = mapOf(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED to SystemNavigationPrompt.ENABLE_DEVELOPER_OPTIONS,
+            SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED to SystemNavigationPrompt.ENABLE_WIRELESS_DEBUGGING,
+            SystemNavigationLockStatus.PAIRING_REQUIRED to SystemNavigationPrompt.PAIR_DEVICE,
+        )
+
+        prompts.forEach { (status, expectedPrompt) ->
+            assertEquals(
+                expectedPrompt,
+                status.toPrompt(
+                    lockedMode = LockedModeState.LOCKED,
+                    optionEnabled = true,
+                ),
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/SystemNavigationLockRulesTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/SystemNavigationLockRulesTest.kt
@@ -1,0 +1,206 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
+import com.gamelaunch.frontend.systemui.SystemNavigationLockStatus
+import com.gamelaunch.frontend.systemui.SystemNavigationSetupProgress
+import com.gamelaunch.frontend.systemui.navigationRecoveryStatus
+import com.gamelaunch.frontend.systemui.brokerSetupRequirement
+import com.gamelaunch.frontend.systemui.shouldLockSystemNavigation
+import com.gamelaunch.frontend.systemui.setupStatus
+import com.gamelaunch.frontend.systemui.shellDisableFlags
+import com.gamelaunch.frontend.systemui.pairingCodeFrom
+import com.gamelaunch.frontend.systemui.PairingNotificationPhase
+import com.gamelaunch.frontend.systemui.shouldDismissPairingNotification
+import com.gamelaunch.frontend.systemui.shouldResetPairingNotificationLifecycle
+import com.gamelaunch.frontend.systemui.EmbeddedPairingService
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SystemNavigationLockRulesTest {
+    @Test
+    fun `usable broker states dismiss idle and setup pairing notifications`() {
+        listOf(SystemNavigationLockStatus.READY, SystemNavigationLockStatus.ACTIVE).forEach { status ->
+            assertTrue(shouldDismissPairingNotification(status, PairingNotificationPhase.IDLE))
+            assertTrue(shouldDismissPairingNotification(status, PairingNotificationPhase.SETUP))
+        }
+    }
+
+    @Test
+    fun `usable broker states preserve pairing and result notifications`() {
+        listOf(SystemNavigationLockStatus.READY, SystemNavigationLockStatus.ACTIVE).forEach { status ->
+            assertFalse(shouldDismissPairingNotification(status, PairingNotificationPhase.PAIRING))
+            assertFalse(shouldDismissPairingNotification(status, PairingNotificationPhase.RESULT))
+        }
+    }
+
+    @Test
+    fun `transitional and setup required states preserve pairing notifications`() {
+        listOf(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+            SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+            SystemNavigationLockStatus.PAIRING_REQUIRED,
+            SystemNavigationLockStatus.DISCOVERING,
+            SystemNavigationLockStatus.START_REQUIRED,
+            SystemNavigationLockStatus.STARTING,
+            SystemNavigationLockStatus.APPLYING,
+        ).forEach { status ->
+            PairingNotificationPhase.entries.forEach { phase ->
+                assertFalse(
+                    "Unexpected cleanup for $status in $phase",
+                    shouldDismissPairingNotification(status, phase),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `pairing success timeout is thirty seconds`() {
+        assertEquals(30_000L, EmbeddedPairingService.PAIRING_SUCCESS_TIMEOUT_MS)
+    }
+
+    @Test
+    fun `older result timeout cannot reset a newer pairing attempt`() {
+        assertTrue(shouldResetPairingNotificationLifecycle(PairingNotificationPhase.RESULT, 4, 4))
+        assertFalse(shouldResetPairingNotificationLifecycle(PairingNotificationPhase.RESULT, 5, 4))
+        assertFalse(shouldResetPairingNotificationLifecycle(PairingNotificationPhase.PAIRING, 4, 4))
+    }
+
+    @Test
+    fun `broker discovery requires developer options and wireless debugging`() {
+        assertEquals(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+            brokerSetupRequirement(SystemNavigationSetupProgress()),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+            brokerSetupRequirement(SystemNavigationSetupProgress(developerOptionsEnabled = true)),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+            brokerSetupRequirement(SystemNavigationSetupProgress(wirelessDebuggingEnabled = true)),
+        )
+        assertNull(
+            brokerSetupRequirement(
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `failed broker connection distinguishes pairing from paired startup recovery`() {
+        assertEquals(
+            SystemNavigationLockStatus.PAIRING_REQUIRED,
+            setupStatus(
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = true,
+                ),
+            ),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.STARTING,
+            setupStatus(
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = true,
+                    paired = true,
+                ),
+            ),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+            setupStatus(
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+                SystemNavigationSetupProgress(developerOptionsEnabled = true),
+            ),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+            setupStatus(
+                SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+                SystemNavigationSetupProgress(),
+            ),
+        )
+    }
+
+    @Test
+    fun `navigation recovery requires developer options and wireless debugging`() {
+        assertEquals(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+            navigationRecoveryStatus(SystemNavigationSetupProgress()),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.WIRELESS_DEBUGGING_REQUIRED,
+            navigationRecoveryStatus(SystemNavigationSetupProgress(developerOptionsEnabled = true)),
+        )
+        assertEquals(
+            SystemNavigationLockStatus.DEVELOPER_OPTIONS_REQUIRED,
+            navigationRecoveryStatus(SystemNavigationSetupProgress(wirelessDebuggingEnabled = true)),
+        )
+
+        assertEquals(
+            SystemNavigationLockStatus.STARTING,
+            navigationRecoveryStatus(
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = true,
+                    paired = true,
+                )
+            ),
+        )
+    }
+
+    @Test
+    fun `navigation recovery requires pairing after wireless debugging is ready`() {
+        assertEquals(
+            SystemNavigationLockStatus.PAIRING_REQUIRED,
+            navigationRecoveryStatus(
+                SystemNavigationSetupProgress(
+                    developerOptionsEnabled = true,
+                    wirelessDebuggingEnabled = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `pairing code can be re-entered after a mistake without backspace`() {
+        assertEquals("123456", pairingCodeFrom("98765 123456"))
+        assertEquals("123456", pairingCodeFrom("123456"))
+        assertNull(pairingCodeFrom("12345"))
+        assertNull(pairingCodeFrom("1234567"))
+    }
+
+    @Test
+    fun `restriction is desired only in active locked mode with opt in`() {
+        assertFalse(shouldLockSystemNavigation(false, LockedModeState.DISABLED))
+        assertFalse(shouldLockSystemNavigation(true, LockedModeState.DISABLED))
+        assertFalse(shouldLockSystemNavigation(true, LockedModeState.READY))
+        assertFalse(shouldLockSystemNavigation(false, LockedModeState.LOCKED))
+        assertTrue(shouldLockSystemNavigation(true, LockedModeState.LOCKED))
+    }
+
+    @Test
+    fun `shell disable flags are read from the shell-owned status bar record`() {
+        val dump = """
+            mDisableRecords.size=2
+              [0] userId=0 what1=0x00000000 pkg=com.android.systemui token=android.os.BinderProxy@1
+              [1] userId=0 what1=0x01210000 pkg=android token=com.android.server.statusbar.StatusBarShellCommand${'$'}StatusBarShellCommandToken@2
+        """.trimIndent()
+
+        assertEquals(0x01210000L, shellDisableFlags(dump))
+    }
+
+    @Test
+    fun `missing shell status bar record cannot be mistaken for restored`() {
+        assertNull(shellDisableFlags("mDisableRecords.size=0"))
+    }
+}

--- a/third_party/shizuku/LICENSE
+++ b/third_party/shizuku/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/shizuku/PROVENANCE.md
+++ b/third_party/shizuku/PROVENANCE.md
@@ -1,0 +1,24 @@
+# Shizuku provenance
+
+Pinned upstream revision: `b844bc491f1790c72328e1a8e5b2349f8978f0ea`.
+
+The package names, provider authority, native library names, process name,
+keystore alias, and Binder API are eOr-specific. The design adapts the upstream ADB
+protocol/TLS/RSA/mDNS/pairing and native starter architecture. Copyright headers are
+retained in adapted native files. The upstream Apache-2.0 license is reproduced in
+`LICENSE` in this directory.
+
+Adapted upstream sources:
+
+- `manager/.../adb/AdbClient.kt`, `AdbKey.kt`, `AdbMdns.kt`, `AdbMessage.kt`,
+  `AdbPairingClient.kt`, and `AdbProtocol.kt` → `EmbeddedAdb.kt`
+- `manager/src/main/jni/adb_pairing.cpp` → `eor_adb.cpp`
+- the detach/`app_process` portion of `manager/src/main/jni/starter.cpp` →
+  `eor_starter.cpp`
+- the external-provider Binder delivery pattern in
+  `starter/.../ServiceStarter.java` and `IContentProviderCompat.java` →
+  `EmbeddedBrokerBootstrapProvider.kt`
+
+Security deviations from a general ADB client: discovery is restricted to local device
+interfaces; messages are size bounded; pairing/bootstrap secrets and authenticated
+commands are never logged; and no arbitrary command API is exposed to the app.


### PR DESCRIPTION
- add embedded privilege broker and Wireless ADB pairing flow
- expose navigation-lock setup and status in settings
- restore system navigation when Locked Mode is unlocked
- reset active Locked Mode state after a device reboot
- add security and navigation-lock tests
- document Shizuku provenance and third-party licensing