### PR TITLE
Dual-screen bottom dim + Home-card color schemes

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -27,6 +27,8 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,8 +39,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.app.NotificationCompat
@@ -70,6 +74,9 @@ import com.gamelaunch.frontend.ui.navigation.Screen
 import com.gamelaunch.frontend.ui.navigation.backOrHome
 import com.gamelaunch.frontend.ui.theme.AppTheme
 import com.gamelaunch.frontend.ui.theme.BackgroundBranding
+import com.gamelaunch.frontend.ui.theme.CardColorConfig
+import com.gamelaunch.frontend.ui.theme.CardColorScheme
+import com.gamelaunch.frontend.ui.theme.LocalCardColorScheme
 import com.gamelaunch.frontend.ui.theme.BackgroundImageMode
 import com.gamelaunch.frontend.ui.theme.NavyBg
 import dagger.hilt.android.AndroidEntryPoint
@@ -203,11 +210,21 @@ class MainActivity : ComponentActivity() {
             val reduceMotion by performanceState.reduced.collectAsState()
             val gameSessionActive by gameSessionState.launchedOnTop.collectAsState()
 
+            // Home-card colour scheme (rainbow / black & white / monochrome) — read by tileColor().
+            val cardScheme by settingsRepository.cardColorScheme
+                .collectAsState(initial = CardColorScheme.RAINBOW)
+            val cardMonoArgb by settingsRepository.cardMonoColor
+                .collectAsState(initial = 0xFF3E7BFF.toInt())
+            val cardColorConfig = remember(cardScheme, cardMonoArgb) {
+                CardColorConfig(scheme = cardScheme, monochromeSeed = Color(cardMonoArgb))
+            }
+
             AppTheme(darkMode = darkMode, branding = branding) {
               CompositionLocalProvider(
                   LocalDualScreenActive provides dualScreenActive,
                   LocalReduceMotion provides reduceMotion,
-                  LocalGameSessionActive provides gameSessionActive
+                  LocalGameSessionActive provides gameSessionActive,
+                  LocalCardColorScheme provides cardColorConfig
               ) {
                 Box(Modifier.fillMaxSize()) {
                 val navController = rememberNavController()
@@ -284,6 +301,22 @@ class MainActivity : ComponentActivity() {
                         },
                         onDismiss = { updateState.value = null },
                         modifier = Modifier.align(Alignment.TopCenter)
+                    )
+                }
+
+                // Dual-screen: while a game is running on the top panel the bottom stays resumed
+                // (Android multi-resume), so dim it by 65% to push focus to the game up top. Fades
+                // in/out so returning to eOr (gameSessionState.end()) restores the menu smoothly.
+                val bottomDim by animateFloatAsState(
+                    targetValue = if (dualScreenActive && gameSessionActive) 0.65f else 0f,
+                    animationSpec = tween(durationMillis = 300),
+                    label = "bottomScreenDim"
+                )
+                if (bottomDim > 0f) {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = bottomDim))
                     )
                 }
                 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -65,6 +65,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val BG_IMAGE_PATH = stringPreferencesKey("background_image_path")
         val BG_IMAGE_MODE = stringPreferencesKey("background_image_mode")
         val BG_IMAGE_OPACITY = floatPreferencesKey("background_image_opacity")
+        val CARD_COLOR_SCHEME = stringPreferencesKey("card_color_scheme")
+        val CARD_MONO_COLOR = intPreferencesKey("card_mono_color")
         val SAVE_SYNC_ENABLED = booleanPreferencesKey("save_sync_enabled")
         val SYNC_WIFI_ONLY = booleanPreferencesKey("sync_wifi_only")
         val SYNC_CHARGING_ONLY = booleanPreferencesKey("sync_charging_only")
@@ -133,6 +135,10 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val backgroundImagePath: Flow<String> = context.dataStore.data.map { it[Keys.BG_IMAGE_PATH] ?: "" }
     val backgroundImageMode: Flow<String> = context.dataStore.data.map { it[Keys.BG_IMAGE_MODE] ?: "FILL" }
     val backgroundImageOpacity: Flow<Float> = context.dataStore.data.map { it[Keys.BG_IMAGE_OPACITY] ?: 0.15f }
+    // Home-card colour scheme: "RAINBOW" (default), "BLACK_WHITE" or "MONOCHROME". The mono seed is a
+    // packed ARGB int (default 0xFF3E7BFF, BrandBlue), only meaningful in the MONOCHROME scheme.
+    val cardColorScheme: Flow<String> = context.dataStore.data.map { it[Keys.CARD_COLOR_SCHEME] ?: "RAINBOW" }
+    val cardMonoColor: Flow<Int> = context.dataStore.data.map { it[Keys.CARD_MONO_COLOR] ?: 0xFF3E7BFF.toInt() }
     val saveSyncEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.SAVE_SYNC_ENABLED] ?: false }
     val syncWifiOnly: Flow<Boolean> = context.dataStore.data.map { it[Keys.SYNC_WIFI_ONLY] ?: false }
     val syncChargingOnly: Flow<Boolean> = context.dataStore.data.map { it[Keys.SYNC_CHARGING_ONLY] ?: false }
@@ -220,6 +226,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setBackgroundImagePath(path: String) = context.dataStore.edit { it[Keys.BG_IMAGE_PATH] = path }
     suspend fun setBackgroundImageMode(mode: String) = context.dataStore.edit { it[Keys.BG_IMAGE_MODE] = mode }
     suspend fun setBackgroundImageOpacity(opacity: Float) = context.dataStore.edit { it[Keys.BG_IMAGE_OPACITY] = opacity }
+    suspend fun setCardColorScheme(scheme: String) = context.dataStore.edit { it[Keys.CARD_COLOR_SCHEME] = scheme }
+    suspend fun setCardMonoColor(argb: Int) = context.dataStore.edit { it[Keys.CARD_MONO_COLOR] = argb }
     suspend fun setSaveSyncEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.SAVE_SYNC_ENABLED] = enabled }
     suspend fun setSyncWifiOnly(v: Boolean) = context.dataStore.edit { it[Keys.SYNC_WIFI_ONLY] = v }
     suspend fun setSyncChargingOnly(v: Boolean) = context.dataStore.edit { it[Keys.SYNC_CHARGING_ONLY] = v }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.gamelaunch.frontend.domain.model.GameSort
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
 import com.gamelaunch.frontend.ui.dualscreen.TopScreenImage
+import com.gamelaunch.frontend.ui.theme.CardColorScheme
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -65,6 +66,9 @@ class SettingsRepositoryImpl @Inject constructor(
     override val backgroundImagePath: Flow<String> = dataStore.backgroundImagePath
     override val backgroundImageMode: Flow<String> = dataStore.backgroundImageMode
     override val backgroundImageOpacity: Flow<Float> = dataStore.backgroundImageOpacity
+    override val cardColorScheme: Flow<CardColorScheme> =
+        dataStore.cardColorScheme.map { CardColorScheme.fromName(it) }
+    override val cardMonoColor: Flow<Int> = dataStore.cardMonoColor
     override val saveSyncEnabled: Flow<Boolean> = dataStore.saveSyncEnabled
     override val syncWifiOnly: Flow<Boolean> = dataStore.syncWifiOnly
     override val syncChargingOnly: Flow<Boolean> = dataStore.syncChargingOnly
@@ -127,6 +131,8 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setBackgroundImagePath(path: String) { dataStore.setBackgroundImagePath(path) }
     override suspend fun setBackgroundImageMode(mode: String) { dataStore.setBackgroundImageMode(mode) }
     override suspend fun setBackgroundImageOpacity(opacity: Float) { dataStore.setBackgroundImageOpacity(opacity) }
+    override suspend fun setCardColorScheme(scheme: CardColorScheme) { dataStore.setCardColorScheme(scheme.name) }
+    override suspend fun setCardMonoColor(argb: Int) { dataStore.setCardMonoColor(argb) }
     override suspend fun setSaveSyncEnabled(enabled: Boolean) { dataStore.setSaveSyncEnabled(enabled) }
     override suspend fun setSyncWifiOnly(v: Boolean) { dataStore.setSyncWifiOnly(v) }
     override suspend fun setSyncChargingOnly(v: Boolean) { dataStore.setSyncChargingOnly(v) }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -4,6 +4,7 @@ import com.gamelaunch.frontend.domain.model.GameSort
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.platform.SystemSort
 import com.gamelaunch.frontend.ui.dualscreen.TopScreenImage
+import com.gamelaunch.frontend.ui.theme.CardColorScheme
 import com.gamelaunch.frontend.ui.theme.LayoutMode
 import kotlinx.coroutines.flow.Flow
 
@@ -30,6 +31,9 @@ interface SettingsRepository {
     val backgroundImagePath: Flow<String>
     val backgroundImageMode: Flow<String>
     val backgroundImageOpacity: Flow<Float>
+    val cardColorScheme: Flow<CardColorScheme>
+    /** Packed ARGB seed colour for the monochrome card scheme. */
+    val cardMonoColor: Flow<Int>
     val saveSyncEnabled: Flow<Boolean>
     val syncWifiOnly: Flow<Boolean>
     val syncChargingOnly: Flow<Boolean>
@@ -81,6 +85,8 @@ interface SettingsRepository {
     suspend fun setBackgroundImagePath(path: String)
     suspend fun setBackgroundImageMode(mode: String)
     suspend fun setBackgroundImageOpacity(opacity: Float)
+    suspend fun setCardColorScheme(scheme: CardColorScheme)
+    suspend fun setCardMonoColor(argb: Int)
     suspend fun setSaveSyncEnabled(enabled: Boolean)
     suspend fun setSyncWifiOnly(v: Boolean)
     suspend fun setSyncChargingOnly(v: Boolean)

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -99,6 +99,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
@@ -135,8 +136,10 @@ import com.gamelaunch.frontend.ui.lockedmode.LockedModeDialogStep
 import com.gamelaunch.frontend.ui.lockedmode.LockedModeActivationDialog
 import com.gamelaunch.frontend.ui.lockedmode.LockedModeSettingsViewModel
 import com.gamelaunch.frontend.ui.lockedmode.PinPadDialog
+import com.gamelaunch.frontend.ui.theme.CardColorScheme
 import com.gamelaunch.frontend.ui.theme.ElectricBlue
 import com.gamelaunch.frontend.ui.theme.LayoutMode
+import com.gamelaunch.frontend.ui.theme.MonochromeSeeds
 import com.gamelaunch.frontend.ui.theme.NeonPurple
 import com.gamelaunch.frontend.ui.theme.ThemedScreen
 import com.gamelaunch.frontend.util.StorageUtils
@@ -802,6 +805,20 @@ private fun DisplaySection(state: SettingsUiState, viewModel: SettingsViewModel)
         )
         Spacer(Modifier.height(8.dp))
         ThemePicker(selectedDark = state.darkMode, onSelect = viewModel::setDarkMode)
+
+        Spacer(Modifier.height(12.dp))
+        Text(
+            "Card colors",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        CardColorSchemePicker(
+            scheme              = state.cardColorScheme,
+            monoColor           = state.cardMonoColor,
+            onSchemeSelected    = viewModel::setCardColorScheme,
+            onMonoColorSelected = viewModel::setCardMonoColor
+        )
 
         Spacer(Modifier.height(10.dp))
         if (BuildConfig.LOW_POWER) {
@@ -1501,6 +1518,97 @@ private fun ThemeOption(
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
                 color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+/**
+ * Home-card colour scheme picker: three chips (Rainbow / Black & White / Monochrome). When
+ * Monochrome is active a scrollable row of colour swatches is revealed so the user can pick the
+ * single hue the whole grid is tinted with. Mirrors the tile-colour logic in Glass.kt.
+ */
+@Composable
+private fun CardColorSchemePicker(
+    scheme: CardColorScheme,
+    monoColor: Int,
+    onSchemeSelected: (CardColorScheme) -> Unit,
+    onMonoColorSelected: (Int) -> Unit
+) {
+    Column(Modifier.fillMaxWidth()) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            BackgroundModeChip(
+                label    = "Rainbow",
+                selected = scheme == CardColorScheme.RAINBOW,
+                onClick  = { onSchemeSelected(CardColorScheme.RAINBOW) },
+                modifier = Modifier.weight(1f)
+            )
+            BackgroundModeChip(
+                label    = "B & W",
+                selected = scheme == CardColorScheme.BLACK_WHITE,
+                onClick  = { onSchemeSelected(CardColorScheme.BLACK_WHITE) },
+                modifier = Modifier.weight(1f)
+            )
+            BackgroundModeChip(
+                label    = "Mono",
+                selected = scheme == CardColorScheme.MONOCHROME,
+                onClick  = { onSchemeSelected(CardColorScheme.MONOCHROME) },
+                modifier = Modifier.weight(1f)
+            )
+        }
+        if (scheme == CardColorScheme.MONOCHROME) {
+            Spacer(Modifier.height(10.dp))
+            Text(
+                "Tile color",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(6.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                MonochromeSeeds.forEach { seed ->
+                    val argb = seed.toArgb()
+                    ColorSwatch(
+                        color    = seed,
+                        selected = argb == monoColor,
+                        onClick  = { onMonoColorSelected(argb) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** A single circular colour swatch for the monochrome-seed picker; a ring marks the active one. */
+@Composable
+private fun ColorSwatch(color: Color, selected: Boolean, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .size(38.dp)
+            .clip(CircleShape)
+            .background(color)
+            .border(
+                width = if (selected) 3.dp else 1.dp,
+                color = if (selected) MaterialTheme.colorScheme.onSurface
+                        else MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                shape = CircleShape
+            )
+            .dpadFocusable(shape = CircleShape, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        if (selected) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(20.dp)
             )
         }
     }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -79,6 +79,9 @@ data class SettingsUiState(
     val backgroundImagePath: String = "",
     val backgroundImageMode: String = "FILL",
     val backgroundImageOpacity: Float = 0.15f,
+    val cardColorScheme: com.gamelaunch.frontend.ui.theme.CardColorScheme =
+        com.gamelaunch.frontend.ui.theme.CardColorScheme.RAINBOW,
+    val cardMonoColor: Int = 0xFF3E7BFF.toInt(),
     val convertingBackground: Boolean = false,
     val systemSort: List<SystemSort> = emptyList(),
     // Systems currently in the library (platform ids) and which of them the user has hidden,
@@ -267,6 +270,16 @@ class SettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            settingsRepository.cardColorScheme.collect { scheme ->
+                _uiState.update { it.copy(cardColorScheme = scheme) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.cardMonoColor.collect { argb ->
+                _uiState.update { it.copy(cardMonoColor = argb) }
+            }
+        }
+        viewModelScope.launch {
             settingsRepository.raUsername.collect { u ->
                 _uiState.update { it.copy(raUsername = u) }
             }
@@ -309,6 +322,14 @@ class SettingsViewModel @Inject constructor(
      *  profile sharing are brought up or fully torn down. */
     fun setFriendsEnabled(enabled: Boolean) {
         viewModelScope.launch { friendRepository.setEnabled(enabled) }
+    }
+
+    fun setCardColorScheme(scheme: com.gamelaunch.frontend.ui.theme.CardColorScheme) {
+        viewModelScope.launch { settingsRepository.setCardColorScheme(scheme) }
+    }
+
+    fun setCardMonoColor(argb: Int) {
+        viewModelScope.launch { settingsRepository.setCardMonoColor(argb) }
     }
 
     fun setDualScreenEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/theme/Glass.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
+import android.graphics.Color as AndroidColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
@@ -24,6 +26,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -55,7 +58,8 @@ val TileText  = Color(0xFF20242E)   // dark slate for labels on light/pastel til
 val TileSub   = Color(0xFF5A6173)   // muted slate for subtitles
 val BrandBlue = Color(0xFF3E7BFF)   // accent for selected chips / branding
 
-// Cheerful 3DS-ish tile palette — assigned per tile so the grid reads colourful.
+// Cheerful 3DS-ish tile palette — assigned per tile so the grid reads colourful. This is the
+// "Rainbow" card-colour scheme (the default); the other schemes are derived in [tilePalette].
 val TilePalette = listOf(
     Color(0xFF4FB7F5), // sky
     Color(0xFF7C8CFF), // periwinkle
@@ -66,7 +70,85 @@ val TilePalette = listOf(
     Color(0xFF3FD3A6), // mint
     Color(0xFF53CFE0), // teal
 )
-fun tileColor(index: Int): Color = TilePalette[index % TilePalette.size]
+
+// Black-and-white scheme: neutral greys, one per tile position, varied in lightness so the grid
+// keeps the rainbow's positional variety without any hue. glassTile still lightens them in light
+// mode / darkens them in dark mode, so these are mid-greys chosen to read well after that treatment.
+private val GreyTilePalette = listOf(
+    Color(0xFFB8BDC7),
+    Color(0xFF9AA0AC),
+    Color(0xFFC5CAD3),
+    Color(0xFF868D9B),
+    Color(0xFFAEB4BF),
+    Color(0xFF757C8A),
+    Color(0xFFCFD3DB),
+    Color(0xFF9199A6),
+)
+
+/**
+ * Eight shades of a single [seed] hue for the Monochrome scheme: the seed's hue is held constant
+ * while saturation and brightness step across the set, so the grid keeps depth and per-tile variety
+ * while reading as one colour. A near-greyscale seed (no usable hue) falls back to [GreyTilePalette].
+ */
+private fun monochromePalette(seed: Color): List<Color> {
+    val hsv = FloatArray(3)
+    AndroidColor.colorToHSV(seed.toArgb(), hsv)
+    if (hsv[1] < 0.05f) return GreyTilePalette
+    val hue = hsv[0]
+    return List(8) { i ->
+        val t = i / 7f
+        val sat   = 0.80f + (0.42f - 0.80f) * t
+        val value = 0.96f + (0.60f - 0.96f) * t
+        Color(AndroidColor.HSVToColor(floatArrayOf(hue, sat, value)))
+    }
+}
+
+/** How the home tiles (systems, apps, friends, achievements) are coloured. */
+enum class CardColorScheme {
+    RAINBOW, BLACK_WHITE, MONOCHROME;
+    companion object {
+        fun fromName(name: String?): CardColorScheme =
+            entries.firstOrNull { it.name == name } ?: RAINBOW
+    }
+}
+
+/** The user's tile-colour choice: a [scheme] plus the seed colour used when it is [MONOCHROME]. */
+data class CardColorConfig(
+    val scheme: CardColorScheme = CardColorScheme.RAINBOW,
+    val monochromeSeed: Color = BrandBlue
+)
+
+/** Curated seed colours offered for the Monochrome scheme (dpad-friendly swatches in Settings). */
+val MonochromeSeeds = listOf(
+    Color(0xFF3E7BFF), // blue (default)
+    Color(0xFF7C4DFF), // violet
+    Color(0xFFB07BFF), // lavender
+    Color(0xFFFF4D8D), // pink
+    Color(0xFFFF5A5A), // red
+    Color(0xFFFF9F1C), // orange
+    Color(0xFFFFC93C), // amber
+    Color(0xFF2ECC71), // green
+    Color(0xFF17C3B2), // teal
+    Color(0xFF00B4D8), // cyan
+)
+
+/** Provided at the root by MainActivity; read by [tileColor] to colour the home tiles. */
+val LocalCardColorScheme = compositionLocalOf { CardColorConfig() }
+
+/** The full tile palette for the active [config]'s scheme. */
+fun tilePalette(config: CardColorConfig): List<Color> = when (config.scheme) {
+    CardColorScheme.RAINBOW     -> TilePalette
+    CardColorScheme.BLACK_WHITE -> GreyTilePalette
+    CardColorScheme.MONOCHROME  -> monochromePalette(config.monochromeSeed)
+}
+
+/** Per-tile colour for [index], honouring the user's card-colour scheme ([LocalCardColorScheme]). */
+@Composable
+fun tileColor(index: Int): Color {
+    val config = LocalCardColorScheme.current
+    val palette = remember(config) { tilePalette(config) }
+    return palette[index % palette.size]
+}
 
 // ── Text drawn on top of a coloured glass tile ──────────────────────────────
 // On a [glassTile] the background is a shade of the tile's colour, not the ambient background, so


### PR DESCRIPTION
Two eOr updates.

## 1. Dim the bottom screen when a game opens on top (dual-screen)
On dual-screen handhelds eOr stays resumed on the bottom while the emulator runs on the top panel. This dims the bottom screen by **65%** while a game is up, so focus goes to the game. Implemented as an animated black overlay (300ms fade) gated on `dualScreenActive && gameSessionActive`; it clears automatically on return via the existing `gameSessionState.end()` path.

## 2. Home-card color schemes
The shared `tileColor(index)` (system, apps, friends, achievements cards) is now scheme-aware via a new `LocalCardColorScheme`:

- **Rainbow** (default) — the existing 8-color palette.
- **Black & White** — per-tile greys varied in lightness, keeping positional variety without hue.
- **Monochrome** — 8 shades of one hue (hue held constant, saturation/brightness stepped), seeded from a user-picked color.

Configurable under **Settings → Display → Appearance → "Card colors"** (three chips; a scrollable swatch row appears for Monochrome). Persisted in DataStore.

**Note:** the monochrome color is chosen from ~10 curated swatches rather than a free color wheel, for d-pad/controller operability on handhelds. Easy to swap for a hue wheel if arbitrary colors are wanted.

## Testing
- `compileFullDebugKotlin`, `compileLiteDebugKotlin`, and `compileFullDebugUnitTestKotlin` all pass.
- Not visually verified — needs a dual-screen device/emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)