### PR TITLE
Dual-screen bottom dim: 18% + gate on gameSessionActive

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -306,10 +306,13 @@ class MainActivity : ComponentActivity() {
                 }
 
                 // Dual-screen: while a game is running on the top panel the bottom stays resumed
-                // (Android multi-resume), so dim it by 65% to push focus to the game up top. Fades
-                // in/out so returning to eOr (gameSessionState.end()) restores the menu smoothly.
+                // (Android multi-resume), so dim it down to ~18% brightness (a 0.82 black scrim) to
+                // push focus to the game up top. gameSessionActive is only ever set for a top-panel
+                // launch, so it already implies dual-screen — gate on it alone (an out-of-sync
+                // dualScreenActive would otherwise suppress the dim). Fades in/out so returning to
+                // eOr (gameSessionState.end()) restores the menu smoothly.
                 val bottomDim by animateFloatAsState(
-                    targetValue = if (dualScreenActive && gameSessionActive) 0.65f else 0f,
+                    targetValue = if (gameSessionActive) 0.82f else 0f,
                     animationSpec = tween(durationMillis = 300),
                     label = "bottomScreenDim"
                 )


### PR DESCRIPTION
Follow-up to #89, which merged before this tweak landed on the branch — so `main` still has the original `0.65` scrim with the double gate. This brings the intended values in.

## Changes
- **Bottom-panel scrim → `0.82`** (~18% brightness) while a game runs on the top panel, up from `0.65`.
- **Trigger simplified to `gameSessionActive` alone.** That flag is only ever set for a top-panel launch, so it already implies dual-screen; an out-of-sync `dualScreenActive` could previously suppress the dim entirely.

## Testing
- Built and installed the **lite debug** APK on an RG_DS (rk3568); app launches cleanly.
- On-device visual check of the 18% dim on game launch/return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)