### PR TITLE
release: 2.5.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 39
-        versionName = "2.5.0"
+        versionCode = 40
+        versionName = "2.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         ndk { abiFilters += listOf("arm64-v8a", "armeabi-v7a") }


### PR DESCRIPTION
Version bump to **2.5.1** (versionCode 40) for this week's release.

Rolls up everything merged to main since v2.5.0:

- **Dark-mode contrast, launch-scan & smarter scraping** — dark-mode contrast, per-system scraping, scan-on-launch, ES-DE-aware scraping, dual-screen tab icons (#86)
- **Scrollable home tabs** — horizontal-scrolling home tabs, settings tab reorder, arcade name resolution (#87)
- **Master game-grid size** — one grid size across the whole library from Library Layout (#85)
- **Dual-screen game-launch dim** — bottom screen dims to 18% on launch + home-card color schemes (#89, #90)
- **Locked Mode: system-nav blocking** via embedded wireless ADB — thanks @picodspi (#88)

### Release verification
- Both `full` and `lite` minified release APKs build clean under R8 full mode.
- Signed with the debug keystore; cert SHA-256 matches the published v2.5.0 (`45aa4037…adee`) so users update in place.
- ⚠️ On-device game-launch smoke test skipped this cycle (no device connected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)