### PR TITLE
Touch-first grid back button + empty-library setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,33 @@ eOr launches straight into the emulators you already use. Installed emulators ar
 
 ## First Launch Setup
 
-On first launch the app opens **Settings** automatically. Complete these steps before scanning:
+On first launch **Otto**, the eOr donkey, walks you through a short guided setup — no menus to hunt through. The whole thing takes about a minute, and everything it asks for can be changed later in **Settings**.
 
-1. **Set your ROM folder** — tap the folder icon next to "ROM Folder" and select the directory where your ROMs live (e.g. `/sdcard/ROMs`). The scanner expects subfolders named after platforms (e.g. `ROMs/SNES/`, `ROMs/PS1/`).
+### Before you start (optional, but nice to have)
 
-2. **Configure emulators** — tap **Configure Emulators**. For each platform, choose which installed emulator to use. If using RetroArch, also set the core filename (e.g. `snes9x_libretro.so`).
+None of these are required to get through setup, but having them ready means your library is playable the moment setup finishes:
 
-3. **Add ScreenScraper credentials** — sign up for a free account at [screenscraper.fr](https://www.screenscraper.fr), then enter your username and password under the ScreenScraper section. Tap **Validate** to confirm they work.
+- **Install the emulators you want to play in.** eOr launches games *into* other emulator apps — it doesn't emulate anything itself. Install at least one (RetroArch is a great catch-all; add standalones like Dolphin, PPSSPP or DuckStation for the systems you care about) and eOr will auto-detect and assign them during setup. No emulators yet? You can install them afterwards and eOr will pick them up.
+- **Gather your ROMs.** Copy your game files onto the device (internal storage or SD card). Folders named after each system — e.g. `ROMs/SNES/`, `ROMs/PS1/` — scan most cleanly, but eOr can also create an empty, correctly-named folder tree for you and you can drop games in later.
+- **Create a free [ScreenScraper.fr](https://www.screenscraper.fr) account.** This gives the best box art and video previews. It's optional — without it eOr falls back to free libretro thumbnails and LaunchBox art.
 
-4. **Scan ROMs** — tap **Rescan ROMs** (or go back to Home; a scan runs automatically on first launch if a ROM folder is set). The scanner hashes the first 8 MB of each file for better ScreenScraper matching.
+### The guided walkthrough
 
-5. **Scrape artwork** — tap **Scrape All** to fetch box art, screenshots, and video previews for your library. Progress is shown in real time. The scraper respects ScreenScraper's rate limit (1 request per 1.2 seconds) automatically.
+1. **Welcome** — Otto says hi. Tap **Let's go!** (or press **A** on a controller) to begin.
+
+2. **Find your games** — eOr searches your storage for a ROM folder automatically. If it finds one, confirm it with **Yes, that's them!**; otherwise let it **create a games folder** for you (one subfolder per system), or pick your own. Tap **Advanced** here if you want to set a custom **artwork folder** or enter your **ScreenScraper** username and password up front.
+
+3. **Pick a theme** — choose **Light** or **Dark**. You can switch any time later from the visual theme picker in Settings.
+
+4. **Building your arcade** — eOr runs the setup pipeline automatically: it scans your ROMs, detects and assigns your installed emulators, pulls in any installed Android games, then downloads box art, screenshots and video previews. Artwork can keep downloading in the background — you can jump into the app and eOr will notify you when it's finished. When it's done, Otto celebrates 🎉 and you land on your library.
+
+> If you reach the finish line with **no games** or **no emulators** detected, Otto shows a tip on how to fix it — add ROM files and rescan, or install an emulator and eOr will assign it. Nothing is blocked; you can always sort this out afterwards.
+
+### After setup
+
+- **Added more ROMs?** Rescan from **Settings → Rescan ROMs** (a scan also runs automatically on launch) and scrape art for the new titles with **Scrape All** — re-scraping skips anything already complete.
+- **Fine-tune emulators** in **Settings → Configure Emulators** — pick which emulator handles each platform, and for RetroArch set the core filename (e.g. `snes9x_libretro.so`). Anything eOr didn't recognise can be added with a custom package name.
+- **Add or validate ScreenScraper credentials** later under the ScreenScraper section, then tap **Validate** to confirm they work and re-scrape for higher-quality media.
 
 ---
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowRightAlt
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.material.icons.filled.EmojiEvents
@@ -552,6 +553,23 @@ fun HomeScreen(
                             ),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
+                        // Touch-first back affordance: inside a system the only way back to the
+                        // console list was the controller's B button. Mirror the detail screen's
+                        // top-left back button so touch users can leave a system too.
+                        if (state.topTab == TopTab.GAMES && state.gameViewActive) {
+                            IconButton(
+                                onClick  = { viewModel.exitToSystems() },
+                                modifier = Modifier.size(40.dp).glassChip(CircleShape)
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = "Back",
+                                    tint = textPrimary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                            Spacer(Modifier.width(10.dp))
+                        }
                         Icon(
                             painter = painterResource(R.drawable.ic_donkey_silhouette),
                             contentDescription = null,

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/home/HomeScreen.kt
@@ -568,7 +568,7 @@ fun HomeScreen(
                                     modifier = Modifier.size(20.dp)
                                 )
                             }
-                            Spacer(Modifier.width(10.dp))
+                            Spacer(Modifier.width(16.dp))
                         }
                         Icon(
                             painter = painterResource(R.drawable.ic_donkey_silhouette),

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/onboarding/OnboardingScreen.kt
@@ -30,10 +30,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.VideogameAsset
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -367,6 +369,13 @@ private fun BuildStep(
                     )
                     Spacer(Modifier.height(12.dp))
                 }
+                // Nudge users who finished setup with an empty library: no games to launch, or no
+                // emulator to launch them in. Both are common on a fresh device and easy to fix.
+                val emulators = emulatorsFound(setup)
+                if (games == 0 || emulators == 0) {
+                    SetupTips(noGames = games == 0, noEmulators = emulators == 0)
+                    Spacer(Modifier.height(14.dp))
+                }
                 FillButton("Let's Play!", onFinish, Modifier.fillMaxWidth().height(54.dp))
                 if (mediaRunning) {
                     Spacer(Modifier.height(8.dp))
@@ -438,6 +447,62 @@ private fun gamesFound(setup: FirstRunSetupState): Int = when (val s = setup.rom
     is SetupStep.Running -> s.done
     is SetupStep.Done -> Regex("\\d+").find(s.summary)?.value?.toIntOrNull() ?: 0
     else -> 0
+}
+
+// Emulator count from the "Found N emulators · configured M systems" summary; -1 until settled so
+// the "install an emulator" tip never flashes before detection has actually run.
+private fun emulatorsFound(setup: FirstRunSetupState): Int = when (val s = setup.emulatorDetect) {
+    is SetupStep.Done -> Regex("\\d+").find(s.summary)?.value?.toIntOrNull() ?: 0
+    else -> -1
+}
+
+/** Friendly nudges shown on the finished-setup screen when the library came up empty. */
+@Composable
+private fun SetupTips(noGames: Boolean, noEmulators: Boolean) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (noGames) {
+            TipRow(
+                icon = Icons.Default.VideogameAsset,
+                title = "Add some games",
+                body = "Your games folder is empty. Copy ROM files into it, then rescan from " +
+                    "Settings — eOr sorts them into the right systems automatically."
+            )
+        }
+        if (noEmulators) {
+            TipRow(
+                icon = Icons.Default.Download,
+                title = "Install an emulator",
+                body = "I couldn't find any emulators. Install one — RetroArch covers most systems — " +
+                    "and eOr will detect and assign it for you in Settings › Configure Emulators."
+            )
+        }
+    }
+}
+
+@Composable
+private fun TipRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    body: String
+) {
+    Row(verticalAlignment = Alignment.Top) {
+        Icon(icon, null, tint = ElectricBlue, modifier = Modifier.size(22.dp))
+        Spacer(Modifier.width(10.dp))
+        Column {
+            Text(title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface)
+            Spacer(Modifier.height(2.dp))
+            Text(body, style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Three related touch/onboarding improvements:

### 1 · Back button on the game grid (touch-first)
Inside a system's game view the only way back to the console list was the controller's **B** button. Added a circular back button at the **top-left of the header**, mirroring the game detail screen's back button, using the header's existing `glassChip` style. It only appears in a system's game view and calls `exitToSystems()`.

### 2 · Empty-library nudges in first-run setup
On the finished-setup celebration screen, if detection came up with **0 games** or **0 emulators**, Otto now shows a tip card:
- *Add some games* — copy ROM files in and rescan
- *Install an emulator* — install one (RetroArch suggested) and eOr auto-assigns it

Counts come from the existing `romScan` / `emulatorDetect` pipeline summaries; tips only render once detection has settled, so they never flash prematurely.

### 3 · README "First Launch Setup" rewrite
The old section described a Settings-based flow that no longer exists. Replaced it with the actual **Otto-guided walkthrough** (Welcome → Find your games → Theme → Building your arcade), plus **Before you start** (install emulators, gather ROMs, optional ScreenScraper account) and **After setup** (rescan/scrape, configure emulators, validate creds) subsections.

## Testing
- `:app:compileFullDebugKotlin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)