### PR TITLE
release: 2.5.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 40
-        versionName = "2.5.1"
+        versionCode = 41
+        versionName = "2.5.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         ndk { abiFilters += listOf("arm64-v8a", "armeabi-v7a") }


### PR DESCRIPTION
Version bump for the **v2.5.2** release — versionCode 40→41, versionName 2.5.1→2.5.2.

Ships everything merged since v2.5.1:
- #92 — settings: warn before first system-navigation block
- #93 — touch-first grid back button, empty-library onboarding tips, First Launch Setup README rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)