### PR TITLE
Sync library while eOr is running

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -25,6 +25,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.compose.animation.core.animateFloatAsState
@@ -88,6 +90,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
@@ -173,10 +177,7 @@ class MainActivity : ComponentActivity() {
         // cold start — otherwise an update that lands while the app is open is only noticed after a
         // force-close and reopen.
         startSaveSyncIfEnabled()
-        // Quietly pick up games added since last launch (new ROMs/Android/Steam). Runs on its own
-        // app scope so it never blocks the cold-start path; a launch with nothing new does no heavy
-        // work. First-run is skipped inside the scanner (onboarding owns the initial scan).
-        launchLibraryScanner.scanOnLaunch()
+        startLibraryRefreshWhileForeground()
         handleFriendDeepLink(intent)
 
         setContent {
@@ -501,6 +502,20 @@ class MainActivity : ComponentActivity() {
         if (::dualScreenManager.isInitialized) dualScreenManager.stop()
     }
 
+    /** Poll for FTP/SD-card additions only while this Activity is visible. */
+    private fun startLibraryRefreshWhileForeground() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                while (isActive) {
+                    launchLibraryScanner.scan()
+                    // The probe does no hashing or DB writes unless it finds a new path. Thirty
+                    // seconds keeps FTP additions responsive without continuously walking the card.
+                    delay(FOREGROUND_LIBRARY_SCAN_INTERVAL_MS)
+                }
+            }
+        }
+    }
+
     private fun checkForUpdate() {
         val now = SystemClock.elapsedRealtime()
         if (now - lastUpdateCheckMs < UPDATE_CHECK_INTERVAL_MS) return
@@ -659,6 +674,7 @@ class MainActivity : ComponentActivity() {
     }
 
     companion object {
+        private const val FOREGROUND_LIBRARY_SCAN_INTERVAL_MS = 30_000L
         // Minimum gap between foreground update checks. Long enough to spare GitHub's API during
         // rapid game-launch/return cycles, short enough to notice a new release soon after returning.
         private const val UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000L

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportEmbeddedArtworkUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportEmbeddedArtworkUseCase.kt
@@ -10,12 +10,16 @@ class ImportEmbeddedArtworkUseCase @Inject constructor(
     private val mediaRepository: MediaRepository,
     private val nspArtworkExtractor: NspArtworkExtractor
 ) {
+    /** The single source of truth for ROM formats from which this importer can extract artwork. */
+    fun supports(game: Game, romFile: File): Boolean =
+        game.platformId == "switch" && romFile.extension.equals("nsp", ignoreCase = true)
+
     /**
      * Best effort by design: unavailable keys, malformed packages, and storage failures must not
      * prevent the ROM itself from being added to the library.
      */
     suspend operator fun invoke(game: Game, romFile: File) {
-        if (game.platformId != "switch" || !romFile.extension.equals("nsp", ignoreCase = true)) return
+        if (!supports(game, romFile)) return
 
         runCatching {
             if (mediaRepository.getMediaForGame(game.id)?.boxArtLocalPath != null) return@runCatching

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
@@ -55,6 +55,13 @@ class LaunchLibraryScanner @Inject constructor(
             } finally {
                 _isScanning.value = false
             }
+        } else if (romPath.isNotBlank()) {
+            // A ROM may already be known even though its embedded cover could not be read earlier
+            // (partial upload, missing keys, transient I/O). Retry those misses without hashing the
+            // entire library merely because its path set is unchanged.
+            runCatching {
+                scanRomsUseCase.retryMissingEmbeddedArtwork(romPath, ROM_UPLOAD_QUIET_PERIOD_MS)
+            }
         }
     }
 

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
@@ -45,7 +45,9 @@ class LaunchLibraryScanner @Inject constructor(
         // ROMs: only run the hashing full scan when the quick probe finds something new on disk.
         val romPath = settingsRepository.romRootPath.first()
         val romsHaveNew = romPath.isNotBlank() &&
-            runCatching { scanRomsUseCase.hasNewGames(romPath) }.getOrDefault(false)
+            runCatching {
+                scanRomsUseCase.hasNewGames(romPath, ROM_UPLOAD_QUIET_PERIOD_MS)
+            }.getOrDefault(false)
         if (romsHaveNew) {
             _isScanning.value = true
             try {
@@ -56,4 +58,10 @@ class LaunchLibraryScanner @Inject constructor(
         }
     }
 
+    private companion object {
+        // Long enough to avoid importing a file between FTP write bursts. Because foreground probes
+        // run every 30 seconds, a completed upload is normally discovered on the next or following
+        // pass without repeatedly hashing a growing file.
+        const val ROM_UPLOAD_QUIET_PERIOD_MS = 10_000L
+    }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
@@ -1,26 +1,20 @@
 package com.gamelaunch.frontend.domain.usecase
 
 import com.gamelaunch.frontend.domain.repository.SettingsRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * On each app launch (returning users only — the very first run goes through
- * [FirstRunSetupManager]), quietly pick up games added since the last launch: newly-installed
- * Android games, new Steam-library entries, and new ROMs. The ROM folder is checked with a fast,
- * no-hash probe first ([ScanRomsUseCase.hasNewGames]), so the expensive full ROM scan only runs when
- * there's actually something new on disk — a launch with nothing new does no heavy work and the user
- * lands straight on Home.
+ * While the app is in the foreground (returning users only — the very first run goes through
+ * [FirstRunSetupManager]), quietly pick up newly-installed Android games, new Steam-library
+ * entries, and new ROMs, including files uploaded while Home remains visible. The ROM folder uses
+ * a periodic fast, no-hash probe first ([ScanRomsUseCase.hasNewGames]), so the expensive full ROM
+ * scan only runs when there's actually something new on disk.
  *
- * App-scoped (its own scope, not a viewModelScope) so a scan started at launch keeps running even if
- * the user navigates around; Home reflects additions live because its lists are Room-backed.
+ * Home reflects additions live because its lists are Room-backed.
  */
 @Singleton
 class LaunchLibraryScanner @Inject constructor(
@@ -29,23 +23,16 @@ class LaunchLibraryScanner @Inject constructor(
     private val scanSteamLibraryUseCase: ScanSteamLibraryUseCase,
     private val settingsRepository: SettingsRepository
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-
     // True only while the (potentially slow) full ROM scan runs, so Home can show a lightweight
     // "scanning for new games" indicator. The sub-second Android/Steam refreshes don't flip it.
     private val _isScanning = MutableStateFlow(false)
     val isScanning: StateFlow<Boolean> = _isScanning
 
-    @Volatile private var started = false
-
-    /** Kick off the launch scan once per process. Safe to call from every onCreate. */
-    fun scanOnLaunch() {
-        if (started) return
-        started = true
-        scope.launch { run() }
-    }
-
-    private suspend fun run() {
+    /**
+     * Run one library refresh. The foreground lifecycle owner calls this sequentially, so this
+     * class does not need to own a polling job or synchronize overlapping scans.
+     */
+    suspend fun scan() {
         // Never fight the first-run setup pipeline — onboarding owns the initial full scan.
         if (settingsRepository.isFirstLaunch.first()) return
 
@@ -68,4 +55,5 @@ class LaunchLibraryScanner @Inject constructor(
             }
         }
     }
+
 }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/LaunchLibraryScanner.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
  * While the app is in the foreground (returning users only — the very first run goes through
  * [FirstRunSetupManager]), quietly pick up newly-installed Android games, new Steam-library
  * entries, and new ROMs, including files uploaded while Home remains visible. The ROM folder uses
- * a periodic fast, no-hash probe first ([ScanRomsUseCase.hasNewGames]), so the expensive full ROM
+ * a periodic fast, no-hash probe first ([ScanRomsUseCase.hasLibraryChanges]), so the expensive full ROM
  * scan only runs when there's actually something new on disk.
  *
  * Home reflects additions live because its lists are Room-backed.
@@ -42,13 +42,13 @@ class LaunchLibraryScanner @Inject constructor(
             runCatching { scanSteamLibraryUseCase().collect { } }
         }
 
-        // ROMs: only run the hashing full scan when the quick probe finds something new on disk.
+        // ROMs: only run the hashing full scan when the disk and database path sets differ.
         val romPath = settingsRepository.romRootPath.first()
-        val romsHaveNew = romPath.isNotBlank() &&
+        val romLibraryChanged = romPath.isNotBlank() &&
             runCatching {
-                scanRomsUseCase.hasNewGames(romPath, ROM_UPLOAD_QUIET_PERIOD_MS)
+                scanRomsUseCase.hasLibraryChanges(romPath, ROM_UPLOAD_QUIET_PERIOD_MS)
             }.getOrDefault(false)
-        if (romsHaveNew) {
+        if (romLibraryChanged) {
             _isScanning.value = true
             try {
                 runCatching { scanRomsUseCase(romPath).collect { } }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -32,6 +32,11 @@ class ScanRomsUseCase @Inject constructor(
     private val prodKeysLocator: ProdKeysLocator,
     private val arcadeNameResolver: ArcadeNameResolver
 ) {
+    // The foreground probe runs every 30 seconds. Remember unsuccessful embedded-art attempts so a
+    // keyless/malformed NSP is not decoded forever; a changed file (for example a completed upload)
+    // gets a new signature and is tried again. A new app process also gets one fresh attempt.
+    private val embeddedArtworkAttempts = mutableSetOf<String>()
+
     private val skipExtensions = setOf(
         ".txt", ".xml", ".nfo", ".jpg", ".png", ".mp4", ".rar",
         ".sav", ".srm", ".state"
@@ -121,6 +126,41 @@ class ScanRomsUseCase @Inject constructor(
         diskPaths != knownPaths
     }
 
+    /**
+     * Retry local artwork import for existing packages that still have no box art, without
+     * hashing the whole ROM library. This closes the gap where the ROM row was created before its
+     * embedded icon could be decoded, for example while keys where unavailable.
+     */
+    suspend fun retryMissingEmbeddedArtwork(
+        rootPath: String,
+        minimumFileAgeMs: Long = 0L
+    ) = withContext(Dispatchers.IO) {
+        val resolvedRoot = File(StorageUtils.resolveStoredPath(rootPath))
+        if (!resolvedRoot.isDirectory) return@withContext
+        val rootPrefix = resolvedRoot.canonicalFile.path.trimEnd(File.separatorChar) + File.separator
+        val stableBefore = System.currentTimeMillis() - minimumFileAgeMs
+        val candidates = gameRepository.getGamesNeedingScrape(
+            needMeta = false,
+            needBox = true,
+            needShot = false,
+            needWheel = false,
+            needVideo = false
+        )
+
+        prodKeysLocator.invalidate()
+        candidates.asSequence()
+            .map { it to File(it.romPath) }
+            .filter { (game, file) -> importEmbeddedArtwork.supports(game, file) }
+            .filter { (_, file) ->
+                file.isFile && file.canonicalFile.path.startsWith(rootPrefix) &&
+                    (minimumFileAgeMs <= 0L || file.lastModified() <= stableBefore)
+            }
+            .forEach { (game, file) ->
+                val signature = "${file.absolutePath}:${file.length()}:${file.lastModified()}"
+                if (embeddedArtworkAttempts.add(signature)) importEmbeddedArtwork(game, file)
+            }
+    }
+
     operator fun invoke(rootPath: String): Flow<ScanProgress> = flow {
         // Refresh the prod.keys search once per scan. The locator memoises its (expensive) storage
         // walk so it runs once for the whole scan rather than once per NSP; invalidating here keeps
@@ -182,7 +222,10 @@ class ScanRomsUseCase @Inject constructor(
                     existing
                 }
             }
-            persistedGame?.let { importEmbeddedArtwork(it, file) }
+            persistedGame?.let {
+                importEmbeddedArtwork(it, file)
+                embeddedArtworkAttempts.add("${file.absolutePath}:${file.length()}:${file.lastModified()}")
+            }
         }
 
         if (validPaths.isEmpty()) {

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -97,9 +97,23 @@ class ScanRomsUseCase @Inject constructor(
      * the library. Used by the launch auto-scan to decide if the (expensive, hashing) full [invoke]
      * scan is worth running. Only detects additions; removals are reconciled by a full scan.
      */
-    suspend fun hasNewGames(rootPath: String): Boolean = withContext(Dispatchers.IO) {
+    suspend fun hasNewGames(
+        rootPath: String,
+        minimumFileAgeMs: Long = 0L
+    ): Boolean = withContext(Dispatchers.IO) {
         val files = collectFilteredRomFiles(rootPath) ?: return@withContext false
         if (files.isEmpty()) return@withContext false
+
+        // FTP clients commonly write directly to the final filename. Do not start a full scan while
+        // any candidate is still fresh: that could persist a partial ROM and attempt embedded-art
+        // extraction before the relevant bytes have arrived. Waiting until the whole library is
+        // quiet also prevents another stable addition from causing an in-progress file to be swept
+        // into the same full scan.
+        if (minimumFileAgeMs > 0L) {
+            val stableBefore = System.currentTimeMillis() - minimumFileAgeMs
+            if (files.any { it.lastModified() > stableBefore }) return@withContext false
+        }
+
         val knownPaths = gameRepository.getNonAndroidRomPaths().toHashSet()
         files.any { file ->
             platformDetector.detect(file, file.parentFile?.name ?: "") != null &&

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -50,7 +50,7 @@ class ScanRomsUseCase @Inject constructor(
 
     /**
      * The library-eligible ROM files under [rootPath] — the walk + cue/m3u de-duplication +
-     * platform-exclusion filtering, shared by the full [invoke] scan and the quick [hasNewGames]
+     * platform-exclusion filtering, shared by the full [invoke] scan and the quick [hasLibraryChanges]
      * check so both agree on exactly which files count as games. Returns null when the root folder
      * doesn't exist.
      */
@@ -93,16 +93,18 @@ class ScanRomsUseCase @Inject constructor(
     }
 
     /**
-     * A fast check — no hashing, no DB writes — for whether the ROM folder holds any game not yet in
-     * the library. Used by the launch auto-scan to decide if the (expensive, hashing) full [invoke]
-     * scan is worth running. Only detects additions; removals are reconciled by a full scan.
+     * A fast check — no hashing or DB writes — for whether the eligible paths on disk differ from
+     * the ROM paths in the library. A missing root returns false so an unmounted SD card can never
+     * erase the library; an existing empty root is a real change when the database still has ROMs.
      */
-    suspend fun hasNewGames(
+    suspend fun hasLibraryChanges(
         rootPath: String,
         minimumFileAgeMs: Long = 0L
     ): Boolean = withContext(Dispatchers.IO) {
         val files = collectFilteredRomFiles(rootPath) ?: return@withContext false
-        if (files.isEmpty()) return@withContext false
+        val eligibleFiles = files.filter { file ->
+            platformDetector.detect(file, file.parentFile?.name ?: "") != null
+        }
 
         // FTP clients commonly write directly to the final filename. Do not start a full scan while
         // any candidate is still fresh: that could persist a partial ROM and attempt embedded-art
@@ -111,14 +113,12 @@ class ScanRomsUseCase @Inject constructor(
         // into the same full scan.
         if (minimumFileAgeMs > 0L) {
             val stableBefore = System.currentTimeMillis() - minimumFileAgeMs
-            if (files.any { it.lastModified() > stableBefore }) return@withContext false
+            if (eligibleFiles.any { it.lastModified() > stableBefore }) return@withContext false
         }
 
+        val diskPaths = eligibleFiles.mapTo(hashSetOf()) { it.absolutePath }
         val knownPaths = gameRepository.getNonAndroidRomPaths().toHashSet()
-        files.any { file ->
-            platformDetector.detect(file, file.parentFile?.name ?: "") != null &&
-                file.absolutePath !in knownPaths
-        }
+        diskPaths != knownPaths
     }
 
     operator fun invoke(rootPath: String): Flow<ScanProgress> = flow {

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -84,10 +84,32 @@ class ScanRomsUseCaseTest {
         val uploading = File(nesDir, "uploading.nes").also { it.createNewFile() }
         whenever(gameRepository.getNonAndroidRomPaths()).thenReturn(emptyList())
 
-        assertEquals(false, useCase.hasNewGames(tmpFolder.root.absolutePath, 10_000L))
+        assertEquals(false, useCase.hasLibraryChanges(tmpFolder.root.absolutePath, 10_000L))
 
         assertTrue(uploading.setLastModified(System.currentTimeMillis() - 11_000L))
-        assertTrue(useCase.hasNewGames(tmpFolder.root.absolutePath, 10_000L))
+        assertTrue(useCase.hasLibraryChanges(tmpFolder.root.absolutePath, 10_000L))
+    }
+
+    @Test fun `detects a rom deleted from disk`() = runTest {
+        whenever(gameRepository.getNonAndroidRomPaths()).thenReturn(
+            listOf(File(tmpFolder.root, "NES/deleted.nes").absolutePath)
+        )
+
+        assertTrue(useCase.hasLibraryChanges(tmpFolder.root.absolutePath))
+    }
+
+    @Test fun `missing rom root never looks like a library deletion`() = runTest {
+        whenever(gameRepository.getNonAndroidRomPaths()).thenReturn(listOf("/sdcard/NES/game.nes"))
+
+        assertEquals(false, useCase.hasLibraryChanges(File(tmpFolder.root, "unmounted").absolutePath))
+    }
+
+    @Test fun `unchanged rom path set does not trigger a scan`() = runTest {
+        val nesDir = tmpFolder.newFolder("NES")
+        val game = File(nesDir, "game.nes").also { it.createNewFile() }
+        whenever(gameRepository.getNonAndroidRomPaths()).thenReturn(listOf(game.absolutePath))
+
+        assertEquals(false, useCase.hasLibraryChanges(tmpFolder.root.absolutePath))
     }
 
     @Test fun `detects zipped roms inside a system folder`() = runTest {

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -79,6 +79,17 @@ class ScanRomsUseCaseTest {
         assertEquals(2, final.total)
     }
 
+    @Test fun `new rom is ignored until its upload quiet period has elapsed`() = runTest {
+        val nesDir = tmpFolder.newFolder("NES")
+        val uploading = File(nesDir, "uploading.nes").also { it.createNewFile() }
+        whenever(gameRepository.getNonAndroidRomPaths()).thenReturn(emptyList())
+
+        assertEquals(false, useCase.hasNewGames(tmpFolder.root.absolutePath, 10_000L))
+
+        assertTrue(uploading.setLastModified(System.currentTimeMillis() - 11_000L))
+        assertTrue(useCase.hasNewGames(tmpFolder.root.absolutePath, 10_000L))
+    }
+
     @Test fun `detects zipped roms inside a system folder`() = runTest {
         val snesDir = tmpFolder.newFolder("SNES")
         File(snesDir, "Super Mario World.zip").createNewFile()

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -112,6 +112,49 @@ class ScanRomsUseCaseTest {
         assertEquals(false, useCase.hasLibraryChanges(tmpFolder.root.absolutePath))
     }
 
+    @Test fun `retries embedded artwork for an existing settled NSP with no box art`() = runTest {
+        val switchDir = tmpFolder.newFolder("switch")
+        val file = File(switchDir, "Existing.nsp").also {
+            it.writeBytes(byteArrayOf(1, 2, 3))
+            it.setLastModified(System.currentTimeMillis() - 11_000L)
+        }
+        val game = Game(
+            id = 9L,
+            title = "Existing",
+            romPath = file.absolutePath,
+            romFilename = file.name,
+            platformId = "switch"
+        )
+        whenever(gameRepository.getGamesNeedingScrape(false, true, false, false, false))
+            .thenReturn(listOf(game))
+        whenever(importEmbeddedArtwork.supports(game, file)).thenReturn(true)
+
+        useCase.retryMissingEmbeddedArtwork(tmpFolder.root.absolutePath, 10_000L)
+
+        verify(importEmbeddedArtwork).invoke(game, file)
+        verify(prodKeysLocator).invalidate()
+    }
+
+    @Test fun `does not repeatedly retry an unchanged NSP with missing artwork`() = runTest {
+        val switchDir = tmpFolder.newFolder("switch")
+        val file = File(switchDir, "Missing.nsp").also { it.writeBytes(byteArrayOf(1)) }
+        val game = Game(
+            id = 10L,
+            title = "Missing",
+            romPath = file.absolutePath,
+            romFilename = file.name,
+            platformId = "switch"
+        )
+        whenever(gameRepository.getGamesNeedingScrape(false, true, false, false, false))
+            .thenReturn(listOf(game))
+        whenever(importEmbeddedArtwork.supports(game, file)).thenReturn(true)
+
+        useCase.retryMissingEmbeddedArtwork(tmpFolder.root.absolutePath)
+        useCase.retryMissingEmbeddedArtwork(tmpFolder.root.absolutePath)
+
+        verify(importEmbeddedArtwork).invoke(game, file)
+    }
+
     @Test fun `detects zipped roms inside a system folder`() = runTest {
         val snesDir = tmpFolder.newFolder("SNES")
         File(snesDir, "Super Mario World.zip").createNewFile()


### PR DESCRIPTION
Scanning library at startup is ok, but also scan while eOr is running. In some situations files could be uploaded using for instance ftp. This changes will detect changes to the library and update eOr.