### PR TITLE
Add ChuckStation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <package android:name="xyz.aethersx2.android" />
         <package android:name="xyz.trizle.nethersx2" />
         <package android:name="net.play.ptmk.ps2" />
+        <package android:name="com.chuckstation.chuckstation3" />
         <!-- PSP / Vita -->
         <package android:name="org.ppsspp.ppsspp" />
         <package android:name="org.ppsspp.ppssppgold" />

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/PlatformDefinitions.kt
@@ -62,6 +62,12 @@ object PlatformDefinitions {
             defaultCoreForRetroArch = "pcsx2_libretro.so"
         ),
         Platform(
+            id = "ps3", displayName = "PlayStation 3", scraperSystemId = 80,
+            extensions = listOf(".iso", ".pkg", ".elf", ".bin"),
+            folderNames = listOf("PS3", "ps3", "PlayStation 3", "PlayStation3"),
+            defaultEmulatorPackage = "com.chuckstation.chuckstation3"
+        ),
+        Platform(
             id = "psp", displayName = "PSP", scraperSystemId = 61,
             extensions = listOf(".iso", ".cso", ".pbp"),
             folderNames = listOf("PSP", "psp"),

--- a/app/src/main/java/com/gamelaunch/frontend/domain/platform/SystemSort.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/platform/SystemSort.kt
@@ -34,6 +34,7 @@ object PlatformMetadata {
         "switch"    to PlatformMeta(2017, "Nintendo", ConsoleKind.CONSOLE),
         "ps1"       to PlatformMeta(1994, "Sony", ConsoleKind.CONSOLE),
         "ps2"       to PlatformMeta(2000, "Sony", ConsoleKind.CONSOLE),
+        "ps3"       to PlatformMeta(2006, "Sony", ConsoleKind.CONSOLE),
         "psp"       to PlatformMeta(2004, "Sony", ConsoleKind.HANDHELD),
         "psvita"    to PlatformMeta(2011, "Sony", ConsoleKind.HANDHELD),
         "genesis"   to PlatformMeta(1988, "Sega", ConsoleKind.CONSOLE),

--- a/app/src/main/java/com/gamelaunch/frontend/domain/sync/SaveLocationRegistry.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/sync/SaveLocationRegistry.kt
@@ -96,6 +96,12 @@ object SaveLocationRegistry {
             note = "Memcards in Android/data — use the emulator's Transfer Data export."
         ),
         EmulatorSaveSpec(
+            packages = listOf("com.chuckstation.chuckstation3"),
+            displayName = "ChuckStation3 (PS3)",
+            storageClass = SaveStorageClass.APP_PRIVATE,
+            note = "Saves in Android/data — not directly syncable on this Android version."
+        ),
+        EmulatorSaveSpec(
             packages = listOf("org.citra.emu"),
             displayName = "Citra",
             storageClass = SaveStorageClass.APP_PRIVATE,

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportEsdeMediaUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportEsdeMediaUseCase.kt
@@ -60,6 +60,7 @@ class ImportEsdeMediaUseCase @Inject constructor(
         "nds"       to listOf("nds"),
         "ps1"       to listOf("psx", "ps1"),
         "ps2"       to listOf("ps2"),
+        "ps3"       to listOf("ps3", "playstation3"),
         "psp"       to listOf("psp"),
         "dc"        to listOf("dreamcast"),
         "genesis"   to listOf("megadrive", "genesis"),

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/EmulatorLauncher.kt
@@ -257,6 +257,9 @@ class EmulatorLauncher @Inject constructor(
         "net.play.ptmk.ps2" to
             LaunchSpec("xyz.aethersx2.android.EmulationActivity",
                        romExtraKey = "bootPath", action = Intent.ACTION_MAIN),
+        // PS3 — ChuckStation 3 NativeActivity shim
+        "com.chuckstation.chuckstation3" to
+            LaunchSpec("com.chuckstation.chuckstation3.MainActivity"),
         // GameCube / Wii — Dolphin boots a game when MainActivity gets an "AutoStartFile" path
         // extra. It must NOT be an ACTION_VIEW intent (its MainActivity rejects VIEW), otherwise
         // it just opens the game-list menu and sits on a loading screen.

--- a/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/launcher/PackageManagerHelper.kt
@@ -20,11 +20,12 @@ class PackageManagerHelper @Inject constructor(
         // RetroArch variants
         "com.retroarch.aarch64"              to "RetroArch (AArch64)",          // Retroid Pocket build
         "org.libretro.retroarch"             to "RetroArch",
-        // PS1 / PS2 / PSP / Vita
+        // PS1 / PS2 / PS3 / PSP / Vita
         "com.github.stenzek.duckstation"     to "DuckStation (PS1)",
         "xyz.aethersx2.android"              to "NetherSX2 / AetherSX2 (PS2)",  // shared package id
         "xyz.trizle.nethersx2"               to "NetherSX2 (PS2)",
         "net.play.ptmk.ps2"                  to "AetherSX2 (PS2)",
+        "com.chuckstation.chuckstation3"     to "ChuckStation3 (PS3)",
         "org.ppsspp.ppssppgold"              to "PPSSPP Gold (PSP)",
         "org.ppsspp.ppsspp"                  to "PPSSPP (PSP)",
         "org.vita3k.emulator"                to "Vita3K (PS Vita)",
@@ -93,6 +94,7 @@ class PackageManagerHelper @Inject constructor(
         "switch"    to listOf("dev.eden.eden_emulator", "dev.eden.emulator", "org.sudachi.sudachi_emu", "org.yuzu.yuzu_emu"),
         "ps1"       to listOf("com.github.stenzek.duckstation", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "ps2"       to listOf("xyz.aethersx2.android", "xyz.trizle.nethersx2", "net.play.ptmk.ps2", "com.retroarch.aarch64", "org.libretro.retroarch"),
+        "ps3"       to listOf("com.chuckstation.chuckstation3"),
         "psp"       to listOf("org.ppsspp.ppssppgold", "org.ppsspp.ppsspp", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "dc"        to listOf("io.recompiled.redream", "com.flycast.emulator", "com.reicast.emulator", "com.retroarch.aarch64", "org.libretro.retroarch"),
         "genesis"   to listOf("com.retroarch.aarch64", "org.libretro.retroarch"),

--- a/app/src/test/java/com/gamelaunch/frontend/PlatformDetectorTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/PlatformDetectorTest.kt
@@ -80,4 +80,16 @@ class PlatformDetectorTest {
         val file = File(dir, "game.stfs").also { it.createNewFile() }
         assertEquals("xbox360", detector.detect(file, "360")?.id)
     }
+
+    @Test fun `ps3 pkg detected via PS3 folder`() {
+        val dir = tmpFolder.newFolder("PS3")
+        val file = File(dir, "game.pkg").also { it.createNewFile() }
+        assertEquals("ps3", detector.detect(file, "PS3")?.id)
+    }
+
+    @Test fun `ps3 iso detected via PS3 folder`() {
+        val dir = tmpFolder.newFolder("PS3")
+        val file = File(dir, "game.iso").also { it.createNewFile() }
+        assertEquals("ps3", detector.detect(file, "PS3")?.id)
+    }
 }


### PR DESCRIPTION
Add support for ChuckStation3 PS3 emulator (com.chuckstation.chuckstation3) on Android. Included platform definitions, package queries, launch specifications, save location specs, and unit tests.

