### PR TITLE
Fix foreground scan thrash with Steam library; lite build skips constant polling

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -502,15 +502,26 @@ class MainActivity : ComponentActivity() {
         if (::dualScreenManager.isInitialized) dualScreenManager.stop()
     }
 
-    /** Poll for FTP/SD-card additions only while this Activity is visible. */
+    /**
+     * Keep the library in sync with FTP/SD-card additions while this Activity is visible.
+     *
+     * Full build polls every [FOREGROUND_LIBRARY_SCAN_INTERVAL_MS] so uploads appear live without
+     * leaving Home. The lite build (LOW_POWER — weak RK356x chipsets) scans once per foreground
+     * entry instead: continuous polling isn't worth the wakeups there, and additions are still
+     * picked up on the next launch or resume.
+     */
     private fun startLibraryRefreshWhileForeground() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                while (isActive) {
+                if (BuildConfig.LOW_POWER) {
                     launchLibraryScanner.scan()
-                    // The probe does no hashing or DB writes unless it finds a new path. Thirty
-                    // seconds keeps FTP additions responsive without continuously walking the card.
-                    delay(FOREGROUND_LIBRARY_SCAN_INTERVAL_MS)
+                } else {
+                    while (isActive) {
+                        launchLibraryScanner.scan()
+                        // The probe does no hashing or DB writes unless it finds a new path. Thirty
+                        // seconds keeps FTP additions responsive without continuously walking the card.
+                        delay(FOREGROUND_LIBRARY_SCAN_INTERVAL_MS)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/db/dao/GameDao.kt
@@ -175,10 +175,14 @@ interface GameDao {
     @Query("UPDATE games SET last_played_ms = :timestamp, play_count = play_count + 1 WHERE id = :gameId")
     suspend fun recordPlay(gameId: Long, timestamp: Long)
 
-    @Query("DELETE FROM games WHERE platform_id != 'android' AND rom_path NOT IN (:validPaths)")
+    // Reconciles ROM-folder games only. Steam entries (rom_path "steam:…") are not files under the
+    // ROM root and are never in validPaths, so the synthetic 'steam' platform is excluded here —
+    // otherwise a full ROM scan would delete the whole Steam library.
+    @Query("DELETE FROM games WHERE platform_id NOT IN ('android', 'steam') AND rom_path NOT IN (:validPaths)")
     suspend fun deleteGamesNotInPaths(validPaths: List<String>): Int
 
-    @Query("DELETE FROM games WHERE platform_id != 'android'")
+    // Used when the ROM folder is empty. Still must not touch Android or Steam games.
+    @Query("DELETE FROM games WHERE platform_id NOT IN ('android', 'steam')")
     suspend fun deleteAllNonAndroidGames(): Int
 
     @Query("DELETE FROM games WHERE platform_id = 'android' AND rom_path NOT IN (:validPaths)")

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ScanRomsUseCase.kt
@@ -122,8 +122,13 @@ class ScanRomsUseCase @Inject constructor(
         }
 
         val diskPaths = eligibleFiles.mapTo(hashSetOf()) { it.absolutePath }
-        val knownPaths = gameRepository.getNonAndroidRomPaths().toHashSet()
-        diskPaths != knownPaths
+        // Compare only against real on-disk ROM paths. Synthetic library entries — Steam games are
+        // stored with a "steam:<source>:<appid>" rom_path — never appear in the folder walk, so
+        // counting them here would make the sets differ forever and re-run the full scan on every
+        // foreground tick. Absolute filesystem paths start with '/'; the synthetic ones do not.
+        val knownRomPaths = gameRepository.getNonAndroidRomPaths()
+            .filterTo(hashSetOf()) { it.startsWith('/') }
+        diskPaths != knownRomPaths
     }
 
     /**

--- a/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/ScanRomsUseCaseTest.kt
@@ -112,6 +112,19 @@ class ScanRomsUseCaseTest {
         assertEquals(false, useCase.hasLibraryChanges(tmpFolder.root.absolutePath))
     }
 
+    @Test fun `steam library entries do not count as rom library changes`() = runTest {
+        val nesDir = tmpFolder.newFolder("NES")
+        val game = File(nesDir, "game.nes").also { it.createNewFile() }
+        // A Steam game shares the games table but has a synthetic "steam:<source>:<appid>" rom_path
+        // that never appears in the folder walk. It must be ignored by the ROM-folder change probe;
+        // otherwise every foreground tick sees a phantom change and re-runs the full scan forever.
+        whenever(gameRepository.getNonAndroidRomPaths()).thenReturn(
+            listOf(game.absolutePath, "steam:STEAM:440")
+        )
+
+        assertEquals(false, useCase.hasLibraryChanges(tmpFolder.root.absolutePath))
+    }
+
     @Test fun `retries embedded artwork for an existing settled NSP with no box art`() = runTest {
         val switchDir = tmpFolder.newFolder("switch")
         val file = File(switchDir, "Existing.nsp").also {


### PR DESCRIPTION
## Problem

The foreground library refresh added in #96 re-ran the **full hashing ROM scan every 30 seconds** — and deleted/re-added Steam games on a loop — for any user with a Steam library. Root cause is that the new change-detection compares the ROM-folder walk against *all* non-Android `rom_path`s, but Steam games are stored with a synthetic `steam:<source>:<appid>` path that never appears on disk. The path sets therefore differ forever, firing the expensive scan on every tick; the scan's cleanup query then deletes the Steam rows (they're never in `validPaths`), and the next tick re-adds them.

## Fix

- **`hasLibraryChanges`** compares `diskPaths` only against real on-disk (absolute) ROM paths, filtering out synthetic `steam:` entries — stops the phantom mismatch and the 30s scan loop.
- **`deleteGamesNotInPaths` / `deleteAllNonAndroidGames`** now exclude the synthetic `steam` platform, so a *legitimate* full scan (e.g. a real ROM added) can no longer wipe the Steam library. This was a pre-existing latent bug that #96 made continuous.
- **Lite build** (`LOW_POWER`, weak RK356x chipsets) now scans **once per foreground entry** instead of polling every 30s. Additions are still picked up on launch/resume, without continuous wakeups on the low-power devices.

## Tests

- New regression test `steam library entries do not count as rom library changes` (fails on old code, passes now).
- `:app:testFullDebugUnitTest` `ScanRomsUseCaseTest` passes; both `full` and `lite` flavors compile.

## Not covered here
- The unchanged-library branch still runs `prodKeysLocator.invalidate()` + a `getGamesNeedingScrape` query each tick (full build) — minor, left for a follow-up.
- PR #97's ChuckStation launch intent still needs an on-device boot check on the minified release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)