### PR TITLE
Move emulator updates to Settings > Games, add notifications toggle, cut GitHub rate-limit pressure

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/MainActivity.kt
@@ -575,9 +575,12 @@ class MainActivity : ComponentActivity() {
         if (now - lastEmulatorUpdateCheckMs < UPDATE_CHECK_INTERVAL_MS) return
         lastEmulatorUpdateCheckMs = now
         lifecycleScope.launch {
+            // Respect the user's "Update notifications" toggle: when off, don't surface the launch
+            // banner or post a system notification. (The Settings card still checks on demand.)
+            val notificationsOn = settingsRepository.emulatorUpdateNotifications.first()
             val updates = runCatching { checkEmulatorUpdatesUseCase() }.getOrDefault(emptyList())
-            emulatorUpdatesState.value = updates
-            if (updates.isEmpty()) return@launch
+            emulatorUpdatesState.value = if (notificationsOn) updates else emptyList()
+            if (!notificationsOn || updates.isEmpty()) return@launch
             // De-dupe the system notification by the exact set of pending package→version pairs, so
             // we only nag once per new batch of emulator releases.
             val signature = updates.sortedBy { it.packageName }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -86,6 +86,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val RA_TOKEN = stringPreferencesKey("ra_token")
         val RA_POINTS = intPreferencesKey("ra_points")
         val RA_SOFTCORE_POINTS = intPreferencesKey("ra_softcore_points")
+        // Emulator update notifications (launch banner + system notification). Default on.
+        val EMULATOR_UPDATE_NOTIFICATIONS = booleanPreferencesKey("emulator_update_notifications")
         // Friends (P2P social) — all local. Display name is generated once on first use if blank.
         val FRIENDS_ENABLED = booleanPreferencesKey("friends_enabled")
         val FRIEND_DISPLAY_NAME = stringPreferencesKey("friend_display_name")
@@ -185,6 +187,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val raPoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_POINTS] ?: 0 }
     val raSoftcorePoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_SOFTCORE_POINTS] ?: 0 }
     // Friends feature is opt-in (off by default): enabling it starts the P2P sync engine.
+    val emulatorUpdateNotifications: Flow<Boolean> = context.dataStore.data.map { it[Keys.EMULATOR_UPDATE_NOTIFICATIONS] ?: true }
     val friendsEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.FRIENDS_ENABLED] ?: false }
     // Empty until first generated (see FriendRepository); never blank once the feature is used.
     val friendDisplayName: Flow<String> = context.dataStore.data.map { it[Keys.FRIEND_DISPLAY_NAME] ?: "" }
@@ -295,6 +298,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         it.remove(Keys.RA_SOFTCORE_POINTS)
     }
 
+    suspend fun setEmulatorUpdateNotifications(enabled: Boolean) = context.dataStore.edit { it[Keys.EMULATOR_UPDATE_NOTIFICATIONS] = enabled }
     suspend fun setFriendsEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.FRIENDS_ENABLED] = enabled }
     suspend fun setFriendDisplayName(name: String) = context.dataStore.edit { it[Keys.FRIEND_DISPLAY_NAME] = name }
     suspend fun setFriendShareLastPlayed(enabled: Boolean) = context.dataStore.edit { it[Keys.FRIEND_SHARE_LAST_PLAYED] = enabled }

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -82,6 +82,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override val raToken: Flow<String> = dataStore.raToken
     override val raPoints: Flow<Int> = dataStore.raPoints
     override val raSoftcorePoints: Flow<Int> = dataStore.raSoftcorePoints
+    override val emulatorUpdateNotifications: Flow<Boolean> = dataStore.emulatorUpdateNotifications
     override val friendsEnabled: Flow<Boolean> = dataStore.friendsEnabled
     override val friendDisplayName: Flow<String> = dataStore.friendDisplayName
     override val friendShareLastPlayed: Flow<Boolean> = dataStore.friendShareLastPlayed
@@ -148,6 +149,7 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun clearRaCredentials() { dataStore.clearRaCredentials() }
     override suspend fun setPlatformHidden(platformId: String, hidden: Boolean) { dataStore.setPlatformHidden(platformId, hidden) }
     override suspend fun addExcludedPath(romPath: String) { dataStore.addExcludedPath(romPath) }
+    override suspend fun setEmulatorUpdateNotifications(enabled: Boolean) { dataStore.setEmulatorUpdateNotifications(enabled) }
     override suspend fun setFriendsEnabled(enabled: Boolean) { dataStore.setFriendsEnabled(enabled) }
     override suspend fun setFriendDisplayName(name: String) { dataStore.setFriendDisplayName(name) }
     override suspend fun setFriendShareLastPlayed(enabled: Boolean) { dataStore.setFriendShareLastPlayed(enabled) }

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -48,6 +48,7 @@ interface SettingsRepository {
     val raToken: Flow<String>
     val raPoints: Flow<Int>
     val raSoftcorePoints: Flow<Int>
+    val emulatorUpdateNotifications: Flow<Boolean>
     val friendsEnabled: Flow<Boolean>
     val friendDisplayName: Flow<String>
     val friendShareLastPlayed: Flow<Boolean>
@@ -100,6 +101,7 @@ interface SettingsRepository {
     suspend fun clearRaCredentials()
     suspend fun setPlatformHidden(platformId: String, hidden: Boolean)
     suspend fun addExcludedPath(romPath: String)
+    suspend fun setEmulatorUpdateNotifications(enabled: Boolean)
     suspend fun setFriendsEnabled(enabled: Boolean)
     suspend fun setFriendDisplayName(name: String)
     suspend fun setFriendShareLastPlayed(enabled: Boolean)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/CheckEmulatorUpdatesUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/CheckEmulatorUpdatesUseCase.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Native emulator-update check: for each installed emulator the Obtainium pack tracks from GitHub
@@ -21,17 +23,39 @@ import javax.inject.Inject
  * HTML-scraped, unmapped, or ambiguous ones are left to Obtainium (which owns full coverage and
  * background notifications), so eOr never shows a false "update available".
  */
+@Singleton
 class CheckEmulatorUpdatesUseCase @Inject constructor(
     private val packageManagerHelper: PackageManagerHelper,
     private val packRepository: ObtainiumPackRepository
 ) {
     private val client = OkHttpClient()
 
-    suspend operator fun invoke(): List<EmulatorUpdate> = withContext(Dispatchers.IO) {
+    // GitHub's anonymous API limit is 60 req/hr *per IP* — shared with Obtainium, which polls the
+    // same repos. To avoid draining that budget (and tripping Obtainium's "rate limited" errors) we
+    // (a) cache each repo's ETag and send If-None-Match so unchanged releases return 304, which does
+    // NOT count against the limit, and (b) throttle full network sweeps. Singleton so the cache and
+    // throttle are shared across every caller (launch banner + Settings card).
+    private data class RepoCache(val etag: String?, val version: String?)
+    private val repoCache = ConcurrentHashMap<String, RepoCache>()
+
+    @Volatile private var lastSweepAt = 0L
+    @Volatile private var lastResult: List<EmulatorUpdate> = emptyList()
+
+    /** The most recent result, with no network call — safe to read on UI navigation. */
+    fun cachedUpdates(): List<EmulatorUpdate> = lastResult
+
+    /**
+     * @param force bypass the sweep throttle (for an explicit user "Check for updates" tap). Even a
+     * forced sweep is mostly free: unchanged repos answer 304 via their cached ETag.
+     */
+    suspend operator fun invoke(force: Boolean = false): List<EmulatorUpdate> = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        if (!force && now - lastSweepAt < SWEEP_THROTTLE_MS) return@withContext lastResult
+
         val installed = packageManagerHelper.getInstalledEmulators()
             .filter { it.isInstalled && !it.versionName.isNullOrBlank() }
 
-        installed.mapNotNull { emu ->
+        val result = installed.mapNotNull { emu ->
             val entry = packRepository.entryForPackage(emu.packageName) ?: return@mapNotNull null
             if (!entry.isGitHubSource) return@mapNotNull null
             val latest = latestGitHubVersion(entry) ?: return@mapNotNull null
@@ -45,6 +69,9 @@ class CheckEmulatorUpdatesUseCase @Inject constructor(
                 sourceUrl = entry.url
             )
         }
+        lastSweepAt = now
+        lastResult = result
+        result
     }
 
     /** The latest stable release version for [entry], honoring the pack's version-extraction regex. */
@@ -54,20 +81,29 @@ class CheckEmulatorUpdatesUseCase @Inject constructor(
         val includePrereleases = settings?.optBoolean("includePrereleases", false) ?: false
         val versionRegEx = settings?.optString("versionExtractionRegEx").orEmpty()
 
+        val cached = repoCache[repoPath]
         val request = Request.Builder()
             .url("https://api.github.com/repos/$repoPath/releases/latest")
             .header("Accept", "application/vnd.github+json")
+            .apply { cached?.etag?.let { header("If-None-Match", it) } }
             .build()
 
         client.newCall(request).execute().use { resp ->
-            if (!resp.isSuccessful) return null
-            val json = JSONObject(resp.body?.string() ?: return null)
+            // 304 = release unchanged since last check; free (not counted against the rate limit).
+            if (resp.code == 304) return cached?.version
+            // On any failure — including 403 when we're rate-limited — fall back to the last known
+            // version rather than dropping the emulator from the list.
+            if (!resp.isSuccessful) return cached?.version
+            val etag = resp.header("ETag")
+            val json = JSONObject(resp.body?.string() ?: return cached?.version)
             if (json.optBoolean("draft")) return null
             if (json.optBoolean("prerelease") && !includePrereleases) return null
 
             val tag = json.optString("tag_name").ifBlank { json.optString("name") }
             if (tag.isBlank()) return null
-            extractVersion(tag, versionRegEx) ?: tag.trimStart('v', 'V')
+            val version = extractVersion(tag, versionRegEx) ?: tag.trimStart('v', 'V')
+            repoCache[repoPath] = RepoCache(etag, version)
+            version
         }
     }.getOrNull()
 
@@ -86,5 +122,10 @@ class CheckEmulatorUpdatesUseCase @Inject constructor(
         val match = Regex("""github\.com/([^/]+)/([^/#?]+)""").find(url) ?: return null
         val (owner, repo) = match.destructured
         return "$owner/${repo.removeSuffix(".git")}"
+    }
+
+    companion object {
+        // Skip a fresh network sweep if one ran this recently (unless forced by an explicit tap).
+        private const val SWEEP_THROTTLE_MS = 10 * 60 * 1000L
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/EmulatorConfigScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/EmulatorConfigScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Badge
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
@@ -44,7 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.gamelaunch.frontend.domain.model.EmulatorMapping
-import com.gamelaunch.frontend.domain.model.EmulatorUpdate
 import com.gamelaunch.frontend.domain.model.InstalledEmulator
 import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
 import com.gamelaunch.frontend.ui.theme.ThemedScreen
@@ -106,19 +104,6 @@ fun EmulatorConfigScreen(
                 .padding(paddingValues)
                 .padding(8.dp)
         ) {
-            item(key = "obtainium_updates") {
-                EmulatorUpdatesCard(
-                    obtainiumInstalled = state.obtainiumInstalled,
-                    isChecking = state.isCheckingUpdates,
-                    updates = state.emulatorUpdates,
-                    onTrack = { viewModel.trackWithObtainium() },
-                    onCheck = { viewModel.checkForEmulatorUpdates() },
-                    onUpdate = { viewModel.updateWithObtainium(it) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp)
-                )
-            }
             items(PlatformDefinitions.ALL, key = { it.id }) { platform ->
                 val mapping = state.mappings[platform.id]
                 PlatformEmulatorCard(
@@ -134,75 +119,6 @@ fun EmulatorConfigScreen(
             }
         }
     }
-    }
-}
-
-@Composable
-private fun EmulatorUpdatesCard(
-    obtainiumInstalled: Boolean,
-    isChecking: Boolean,
-    updates: List<EmulatorUpdate>,
-    onTrack: () -> Unit,
-    onCheck: () -> Unit,
-    onUpdate: (EmulatorUpdate) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(modifier = modifier) {
-        Column(Modifier.padding(12.dp)) {
-            Text("Emulator updates", style = MaterialTheme.typography.titleSmall)
-            Spacer(Modifier.height(4.dp))
-            Text(
-                if (obtainiumInstalled) {
-                    "Obtainium keeps your emulators up to date in the background."
-                } else {
-                    "Track and install emulator updates with Obtainium — a free, open-source app " +
-                        "updater. Tap below to install it, then come back."
-                },
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(Modifier.height(8.dp))
-
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Button(onClick = onTrack) {
-                    Text(if (obtainiumInstalled) "Track updates" else "Set up Obtainium")
-                }
-                Spacer(Modifier.width(8.dp))
-                IconButton(onClick = onCheck, enabled = !isChecking) {
-                    if (isChecking) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                    } else {
-                        Icon(Icons.Default.Search, contentDescription = "Check for emulator updates")
-                    }
-                }
-            }
-
-            if (updates.isNotEmpty()) {
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    "${updates.size} update${if (updates.size != 1) "s" else ""} available",
-                    style = MaterialTheme.typography.labelLarge
-                )
-                updates.forEach { update ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(Modifier.weight(1f)) {
-                            Text(update.displayName, style = MaterialTheme.typography.bodyMedium)
-                            Text(
-                                "${update.installedVersion ?: "?"} → ${update.latestVersion}",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        Button(onClick = { onUpdate(update) }) { Text("Update") }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/EmulatorConfigViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/EmulatorConfigViewModel.kt
@@ -3,12 +3,8 @@ package com.gamelaunch.frontend.ui.screen.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.domain.model.EmulatorMapping
-import com.gamelaunch.frontend.domain.model.EmulatorUpdate
 import com.gamelaunch.frontend.domain.model.InstalledEmulator
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
-import com.gamelaunch.frontend.domain.repository.ObtainiumPackRepository
-import com.gamelaunch.frontend.domain.usecase.CheckEmulatorUpdatesUseCase
-import com.gamelaunch.frontend.launcher.ObtainiumLauncher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -21,19 +17,12 @@ data class EmulatorConfigUiState(
     val mappings: Map<String, EmulatorMapping> = emptyMap(),
     val installedEmulators: List<InstalledEmulator> = emptyList(),
     val isScanning: Boolean = false,
-    val scanResult: String? = null,  // shown as a one-shot snackbar message
-    // Obtainium update tracking
-    val obtainiumInstalled: Boolean = false,
-    val isCheckingUpdates: Boolean = false,
-    val emulatorUpdates: List<EmulatorUpdate> = emptyList()
+    val scanResult: String? = null  // shown as a one-shot snackbar message
 )
 
 @HiltViewModel
 class EmulatorConfigViewModel @Inject constructor(
-    private val emulatorRepository: EmulatorRepository,
-    private val packRepository: ObtainiumPackRepository,
-    private val checkEmulatorUpdatesUseCase: CheckEmulatorUpdatesUseCase,
-    private val obtainiumLauncher: ObtainiumLauncher
+    private val emulatorRepository: EmulatorRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(EmulatorConfigUiState())
@@ -42,9 +31,8 @@ class EmulatorConfigViewModel @Inject constructor(
     init {
         val installed = emulatorRepository.getInstalledEmulators()
         _uiState.update {
-            it.copy(installedEmulators = installed, obtainiumInstalled = obtainiumLauncher.isInstalled())
+            it.copy(installedEmulators = installed)
         }
-        checkForEmulatorUpdates()
 
         viewModelScope.launch {
             emulatorRepository.getAllMappings().collect { mappings ->
@@ -79,50 +67,6 @@ class EmulatorConfigViewModel @Inject constructor(
 
     fun clearScanResult() {
         _uiState.update { it.copy(scanResult = null) }
-    }
-
-    /** Native check of installed, GitHub-tracked emulators for newer releases. */
-    fun checkForEmulatorUpdates() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isCheckingUpdates = true) }
-            val updates = runCatching { checkEmulatorUpdatesUseCase() }.getOrDefault(emptyList())
-            _uiState.update { it.copy(isCheckingUpdates = false, emulatorUpdates = updates) }
-        }
-    }
-
-    /**
-     * Hand the user's installed emulators to Obtainium so it tracks and installs their updates.
-     * Routes to Obtainium's install page when it isn't installed yet.
-     */
-    fun trackWithObtainium() {
-        viewModelScope.launch {
-            if (!obtainiumLauncher.isInstalled()) {
-                obtainiumLauncher.openInstallPage()
-                _uiState.update { it.copy(scanResult = "Install Obtainium, then tap “Track updates” again") }
-                return@launch
-            }
-            val entries = _uiState.value.installedEmulators
-                .filter { it.isInstalled }
-                .mapNotNull { packRepository.entryForPackage(it.packageName) }
-                .distinctBy { it.id }
-            val ok = obtainiumLauncher.importApps(entries)
-            _uiState.update {
-                it.copy(
-                    obtainiumInstalled = true,
-                    scanResult = when {
-                        entries.isEmpty() -> "No installed emulators are tracked by the Obtainium pack yet"
-                        ok -> "Opening Obtainium to track ${entries.size} emulator${if (entries.size != 1) "s" else ""}…"
-                        else -> "Couldn't open Obtainium"
-                    }
-                )
-            }
-        }
-    }
-
-    /** Send a single emulator's source to Obtainium to update it (falls back to opening Obtainium). */
-    fun updateWithObtainium(update: EmulatorUpdate) {
-        val ok = obtainiumLauncher.addSingle(update.sourceUrl)
-        if (!ok) obtainiumLauncher.open()
     }
 
     private suspend fun runAutoDetect(silent: Boolean) {

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.material.icons.filled.VideogameAsset
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.AlertDialog
+import com.gamelaunch.frontend.domain.model.EmulatorUpdate
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -2403,6 +2404,94 @@ private fun EmulatorsSection(
             onClick = onEmulatorConfigClick,
             modifier = Modifier.fillMaxWidth()
         )
+    }
+    Spacer(Modifier.height(10.dp))
+    EmulatorUpdatesCard(
+        obtainiumInstalled = state.obtainiumInstalled,
+        isChecking = state.isCheckingUpdates,
+        updates = state.emulatorUpdates,
+        notificationsEnabled = state.emulatorUpdateNotifications,
+        onTrack = { viewModel.trackWithObtainium() },
+        onCheck = { viewModel.checkForEmulatorUpdates() },
+        onUpdate = { viewModel.updateWithObtainium(it) },
+        onNotificationsChange = { viewModel.setEmulatorUpdateNotifications(it) }
+    )
+}
+
+@Composable
+private fun EmulatorUpdatesCard(
+    obtainiumInstalled: Boolean,
+    isChecking: Boolean,
+    updates: List<EmulatorUpdate>,
+    notificationsEnabled: Boolean,
+    onTrack: () -> Unit,
+    onCheck: () -> Unit,
+    onUpdate: (EmulatorUpdate) -> Unit,
+    onNotificationsChange: (Boolean) -> Unit
+) {
+    SettingsCard {
+        Text("Emulator updates", style = MaterialTheme.typography.titleSmall)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            if (obtainiumInstalled) {
+                "Obtainium keeps your emulators up to date in the background."
+            } else {
+                "Track and install emulator updates with Obtainium — a free, open-source app " +
+                    "updater. Tap below to install it, then come back."
+            },
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(10.dp))
+        GradientFillButton(
+            text = if (obtainiumInstalled) "Track updates" else "Set up Obtainium",
+            onClick = onTrack,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+        GradientOutlineButton(
+            text = if (isChecking) "Checking…" else "Check for updates",
+            onClick = onCheck,
+            enabled = !isChecking,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(4.dp))
+        CardSwitchRow(
+            label = "Update notifications",
+            checked = notificationsEnabled,
+            onCheckedChange = onNotificationsChange
+        )
+
+        if (updates.isNotEmpty()) {
+            Spacer(Modifier.height(12.dp))
+            Text(
+                "${updates.size} update${if (updates.size != 1) "s" else ""} available",
+                style = MaterialTheme.typography.labelLarge,
+                color = ElectricBlue
+            )
+            updates.forEach { update ->
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(update.displayName, style = MaterialTheme.typography.bodyMedium)
+                        Text(
+                            "${update.installedVersion ?: "?"} → ${update.latestVersion}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    GradientFillButton(
+                        text = "Update",
+                        onClick = { onUpdate(update) },
+                        modifier = Modifier.width(104.dp)
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsViewModel.kt
@@ -3,8 +3,12 @@ package com.gamelaunch.frontend.ui.screen.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gamelaunch.frontend.data.db.dao.LaunchBoxDao
+import com.gamelaunch.frontend.domain.model.EmulatorUpdate
 import com.gamelaunch.frontend.domain.model.ScraperConfig
 import com.gamelaunch.frontend.domain.repository.EmulatorRepository
+import com.gamelaunch.frontend.domain.repository.ObtainiumPackRepository
+import com.gamelaunch.frontend.domain.usecase.CheckEmulatorUpdatesUseCase
+import com.gamelaunch.frontend.launcher.ObtainiumLauncher
 import com.gamelaunch.frontend.domain.repository.GameRepository
 import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
 import com.gamelaunch.frontend.domain.repository.RetroAchievementsRepository
@@ -59,6 +63,11 @@ data class SettingsUiState(
     val videoMuted: Boolean = true,
     val emulatorDetecting: Boolean = false,
     val emulatorDetectResult: String? = null,
+    // Obtainium emulator-update tracking (surfaced in the Emulators section)
+    val obtainiumInstalled: Boolean = false,
+    val isCheckingUpdates: Boolean = false,
+    val emulatorUpdates: List<EmulatorUpdate> = emptyList(),
+    val emulatorUpdateNotifications: Boolean = true,
     val lbSyncStatus: LbSyncStatus? = null,
     val lbGameCount: Int = 0,
     val mediaFolderPath: String = "",
@@ -107,6 +116,9 @@ class SettingsViewModel @Inject constructor(
     private val gameRepository: GameRepository,
     private val friendRepository: com.gamelaunch.frontend.domain.repository.FriendRepository,
     private val launchBoxDao: LaunchBoxDao,
+    private val obtainiumPackRepository: ObtainiumPackRepository,
+    private val checkEmulatorUpdatesUseCase: CheckEmulatorUpdatesUseCase,
+    private val obtainiumLauncher: ObtainiumLauncher,
     val packageManagerHelper: com.gamelaunch.frontend.launcher.PackageManagerHelper
 ) : ViewModel() {
 
@@ -114,6 +126,15 @@ class SettingsViewModel @Inject constructor(
     val uiState: StateFlow<SettingsUiState> = _uiState
 
     init {
+        // Pre-fill from the shared cache (populated by the launch check) — no network call on open.
+        // A fresh GitHub check only happens when the user taps "Check for updates".
+        _uiState.update {
+            it.copy(
+                obtainiumInstalled = obtainiumLauncher.isInstalled(),
+                emulatorUpdates = checkEmulatorUpdatesUseCase.cachedUpdates()
+            )
+        }
+
         viewModelScope.launch {
             combine(
                 settingsRepository.romRootPath,
@@ -200,6 +221,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             settingsRepository.friendsEnabled.collect { on ->
                 _uiState.update { it.copy(friendsEnabled = on) }
+            }
+        }
+        viewModelScope.launch {
+            settingsRepository.emulatorUpdateNotifications.collect { on ->
+                _uiState.update { it.copy(emulatorUpdateNotifications = on) }
             }
         }
         viewModelScope.launch {
@@ -569,6 +595,58 @@ class SettingsViewModel @Inject constructor(
 
     fun clearEmulatorDetectResult() {
         _uiState.update { it.copy(emulatorDetectResult = null) }
+    }
+
+    fun setEmulatorUpdateNotifications(enabled: Boolean) {
+        viewModelScope.launch { settingsRepository.setEmulatorUpdateNotifications(enabled) }
+    }
+
+    /** Explicit user check of installed, GitHub-tracked emulators for newer releases. */
+    fun checkForEmulatorUpdates() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isCheckingUpdates = true) }
+            val updates = runCatching { checkEmulatorUpdatesUseCase(force = true) }.getOrDefault(emptyList())
+            _uiState.update { it.copy(isCheckingUpdates = false, emulatorUpdates = updates) }
+        }
+    }
+
+    /**
+     * Hand the user's installed emulators to Obtainium so it tracks and installs their updates.
+     * Routes to Obtainium's install page when it isn't installed yet. Status is surfaced through
+     * the shared emulator snackbar (emulatorDetectResult).
+     */
+    fun trackWithObtainium() {
+        viewModelScope.launch {
+            if (!obtainiumLauncher.isInstalled()) {
+                obtainiumLauncher.openInstallPage()
+                _uiState.update { it.copy(emulatorDetectResult = "Install Obtainium, then tap “Track updates” again") }
+                return@launch
+            }
+            val entries = emulatorRepository.getInstalledEmulators()
+                .filter { it.isInstalled }
+                .mapNotNull { obtainiumPackRepository.entryForPackage(it.packageName) }
+                .distinctBy { it.id }
+            val ok = obtainiumLauncher.importApps(entries)
+            _uiState.update {
+                it.copy(
+                    obtainiumInstalled = true,
+                    emulatorDetectResult = when {
+                        entries.isEmpty() -> "No installed emulators are tracked by the Obtainium pack yet"
+                        ok -> "Opening Obtainium to track ${entries.size} emulator${if (entries.size != 1) "s" else ""}…"
+                        else -> "Couldn't open Obtainium"
+                    }
+                )
+            }
+        }
+    }
+
+    /**
+     * The emulator is already tracked in Obtainium. Obtainium exposes no per-app install and its
+     * refresh-all call is what trips GitHub's rate limit, so just open Obtainium — the update it
+     * already tracks installs from there in one tap, without provoking a bulk re-poll.
+     */
+    fun updateWithObtainium(@Suppress("UNUSED_PARAMETER") update: EmulatorUpdate) {
+        obtainiumLauncher.open()
     }
 
     fun syncLaunchBox() {


### PR DESCRIPTION
## Summary
- Surface the Obtainium **Emulator updates** card directly in **Settings → Games → Emulators** (moved out of the buried Configure Emulators sub-screen).
- Restyle the per-row **Update** buttons as gradient fills (matching the rest of the page) and point them at **opening Obtainium** — the emulator is already tracked, so no Add-App deep link.
- Add a persisted **Update notifications** toggle under *Check for updates* (default on). When off, the launch banner and system notification are suppressed; the manual check still works.

## Rate-limit fixes
GitHub's anonymous API limit is 60 req/hr **per IP**, shared with Obtainium — which was showing "too many requests". eOr was adding to that:
- `CheckEmulatorUpdatesUseCase` is now `@Singleton` and sends `If-None-Match` from a per-repo cached ETag, so unchanged releases return **304 (free — not counted against the limit)**.
- On failure (including a 403 rate-limit) it falls back to the last-known version instead of dropping the emulator.
- Full sweeps are throttled, and the Settings card no longer auto-checks on open — it pre-fills from the shared cache and only hits the network on an explicit **Check for updates** tap.

## Testing
- Built full-flavor **minified release** (R8) from a clean state and installed on a Retroid Pocket 4 Pro; launches clean, no R8 casualties.
- Verified the new toggle string is present in the signed APK and the card renders in the Games tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)