### PR TITLE
release: 2.6.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 41
-        versionName = "2.5.2"
+        versionCode = 42
+        versionName = "2.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         ndk { abiFilters += listOf("arm64-v8a", "armeabi-v7a") }


### PR DESCRIPTION
Version bump to 2.6.0 (versionCode 42).

Headline: Obtainium emulator update tracking (#99, #100). Also ChuckStation3 PS3 support (#97), live library sync while running (#96), Steam foreground-scan thrash fix + ROM path reconciliation (#98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)