### PR TITLE
Harden credential storage, FileProvider, sync trust, and LAN beacon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,8 @@
     <application
         android:name=".GameLauncherApp"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/gamelaunch/frontend/GameLauncherApp.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/GameLauncherApp.kt
@@ -7,11 +7,19 @@ import coil.ImageLoaderFactory
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import coil.request.CachePolicy
+import com.gamelaunch.frontend.data.preferences.AppDataStore
 import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltAndroidApp
 class GameLauncherApp : Application(), ImageLoaderFactory {
+
+    @Inject lateinit var appDataStore: AppDataStore
+
     override fun onCreate() {
         super.onCreate()
         // Emulators expect a raw file path / file:// URI to the ROM. On targetSdk >= 24 the
@@ -20,6 +28,11 @@ class GameLauncherApp : Application(), ImageLoaderFactory {
         // lets us hand the ROM path straight to each emulator, which then reads it with its own
         // storage permissions.
         StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder().build())
+
+        // One-time: encrypt any secrets left in plaintext by installs that predate SecretCipher.
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            runCatching { appDataStore.migrateSecretsIfNeeded() }
+        }
     }
 
     /**

--- a/app/src/main/java/com/gamelaunch/frontend/data/friends/NearbyBeacon.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/friends/NearbyBeacon.kt
@@ -119,10 +119,21 @@ class NearbyBeacon @Inject constructor(
             if (obj.optString("m") != MAGIC) return
             val id = obj.optString("id").takeIf { FriendCode.isValidDeviceId(it) } ?: return
             if (id.equals(myDeviceId, ignoreCase = true)) return
-            val name = obj.optString("n").ifBlank { "Nearby player" }
-            seen[id.uppercase()] = NearbyPeer(id.uppercase(), name, System.currentTimeMillis())
+            // The name is attacker-controllable (anyone on the Wi-Fi can send a beacon), so sanitize
+            // it before it reaches the confirm dialog: strip control chars and clamp the length so it
+            // can't spoof-pad or garble the UI. The device id is the only thing actually trusted.
+            val name = sanitizeName(obj.optString("n"))
+            val key = id.uppercase()
+            // Cap the map so a LAN flood of distinct valid-looking ids can't grow it without bound.
+            if (!seen.containsKey(key) && seen.size >= MAX_PEERS) return
+            seen[key] = NearbyPeer(key, name, System.currentTimeMillis())
             publish()
         }
+    }
+
+    private fun sanitizeName(raw: String): String {
+        val cleaned = raw.filter { it == ' ' || !it.isISOControl() }.trim().take(MAX_NAME_LEN)
+        return cleaned.ifBlank { "Nearby player" }
     }
 
     private fun publish() {
@@ -155,5 +166,8 @@ class NearbyBeacon @Inject constructor(
         const val PORT = 47811
         const val MAGIC = "eor-fr-1"
         const val STALE_MS = 8000L
+        // Untrusted-beacon bounds: names are attacker-controlled and the peer set is LAN-reachable.
+        const val MAX_NAME_LEN = 48
+        const val MAX_PEERS = 64
     }
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.gamelaunch.frontend.domain.lockedmode.UNKNOWN_BOOT_COUNT
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,6 +23,10 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 
 @Singleton
 class AppDataStore @Inject constructor(@ApplicationContext private val context: Context) {
+
+    // Encrypts the handful of genuinely sensitive values (SS password, RA API key + session token)
+    // at rest so they aren't plaintext in the DataStore file. See [SecretCipher].
+    private val secrets = SecretCipher()
 
     data class LockedModeRecord(
         val enabled: Boolean,
@@ -121,7 +126,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val steamLibraryPath: Flow<String> = context.dataStore.data.map { it[Keys.STEAM_LIBRARY_PATH] ?: "" }
     val layoutMode: Flow<String> = context.dataStore.data.map { it[Keys.LAYOUT_MODE] ?: "CAROUSEL" }
     val ssId: Flow<String> = context.dataStore.data.map { it[Keys.SS_ID] ?: "" }
-    val ssPassword: Flow<String> = context.dataStore.data.map { it[Keys.SS_PASSWORD] ?: "" }
+    val ssPassword: Flow<String> = context.dataStore.data.map { secrets.decrypt(it[Keys.SS_PASSWORD] ?: "") }
     val preferredRegion: Flow<String> = context.dataStore.data.map { it[Keys.PREFERRED_REGION] ?: "us" }
     val scrapeMetadata: Flow<Boolean> = context.dataStore.data.map { it[Keys.SCRAPE_METADATA] ?: true }
     val scrapeBoxArt: Flow<Boolean> = context.dataStore.data.map { it[Keys.SCRAPE_BOX_ART] ?: true }
@@ -182,8 +187,8 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         if (legacy > 0 && "" !in map) map + ("" to legacy) else map
     }
     val raUsername: Flow<String> = context.dataStore.data.map { it[Keys.RA_USERNAME] ?: "" }
-    val raApiKey: Flow<String> = context.dataStore.data.map { it[Keys.RA_API_KEY] ?: "" }
-    val raToken: Flow<String> = context.dataStore.data.map { it[Keys.RA_TOKEN] ?: "" }
+    val raApiKey: Flow<String> = context.dataStore.data.map { secrets.decrypt(it[Keys.RA_API_KEY] ?: "") }
+    val raToken: Flow<String> = context.dataStore.data.map { secrets.decrypt(it[Keys.RA_TOKEN] ?: "") }
     val raPoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_POINTS] ?: 0 }
     val raSoftcorePoints: Flow<Int> = context.dataStore.data.map { it[Keys.RA_SOFTCORE_POINTS] ?: 0 }
     // Friends feature is opt-in (off by default): enabling it starts the P2P sync engine.
@@ -222,7 +227,7 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setLayoutMode(mode: String) = context.dataStore.edit { it[Keys.LAYOUT_MODE] = mode }
     suspend fun setSsCredentials(id: String, password: String) = context.dataStore.edit {
         it[Keys.SS_ID] = id
-        it[Keys.SS_PASSWORD] = password
+        it[Keys.SS_PASSWORD] = secrets.encrypt(password)
     }
     suspend fun setPreferredRegion(region: String) = context.dataStore.edit { it[Keys.PREFERRED_REGION] = region }
     suspend fun setScrapeMetadata(enabled: Boolean) = context.dataStore.edit { it[Keys.SCRAPE_METADATA] = enabled }
@@ -282,11 +287,11 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         if (columns > 0) prefs[Keys.GAME_GRID_COLUMNS] = columns else prefs.remove(Keys.GAME_GRID_COLUMNS)
     }
     suspend fun setRaApiKey(apiKey: String) = context.dataStore.edit {
-        it[Keys.RA_API_KEY] = apiKey
+        it[Keys.RA_API_KEY] = secrets.encrypt(apiKey)
     }
     suspend fun setRaSession(username: String, token: String, points: Int, softcorePoints: Int) = context.dataStore.edit {
         it[Keys.RA_USERNAME] = username
-        it[Keys.RA_TOKEN] = token
+        it[Keys.RA_TOKEN] = secrets.encrypt(token)
         it[Keys.RA_POINTS] = points
         it[Keys.RA_SOFTCORE_POINTS] = softcorePoints
     }
@@ -348,6 +353,23 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
 
     suspend fun clearLockedModeAllowedApps() = context.dataStore.edit {
         it[Keys.LOCKED_MODE_ALLOWED_APP_PACKAGES] = emptySet()
+    }
+
+    /**
+     * One-time migration: re-store any pre-encryption plaintext secrets (from installs that predate
+     * [SecretCipher]) in encrypted form. Idempotent and cheap — after everything is already prefixed
+     * it does nothing and never touches disk. Safe to call on every launch.
+     */
+    suspend fun migrateSecretsIfNeeded() {
+        val prefs = context.dataStore.data.first()
+        val sensitive = listOf(Keys.SS_PASSWORD, Keys.RA_API_KEY, Keys.RA_TOKEN)
+        if (sensitive.none { key -> prefs[key]?.let { secrets.needsReencrypt(it) } == true }) return
+        context.dataStore.edit { store ->
+            for (key in sensitive) {
+                val current = store[key] ?: continue
+                if (secrets.needsReencrypt(current)) store[key] = secrets.encrypt(current)
+            }
+        }
     }
 
 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/SecretCipher.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/SecretCipher.kt
@@ -1,0 +1,70 @@
+package com.gamelaunch.frontend.data.preferences
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Wraps short, sensitive strings (ScreenScraper password, RetroAchievements API key + session token)
+ * with an AndroidKeyStore AES/GCM key so they are not sitting in the DataStore file as plaintext.
+ * Mirrors the approach in [com.gamelaunch.frontend.systemui.EncryptedAdbIdentity]: the key never
+ * leaves the Keystore, so a `config`/DataStore file lifted off the device (cloud/adb backup, or a
+ * rooted read) is unreadable without it.
+ *
+ * On-disk format is `PREFIX + Base64(iv[12] || ciphertext)`. Values without the prefix are treated
+ * as legacy plaintext and returned as-is so pre-encryption installs keep working until the next write
+ * (or the one-time [reencrypt] migration) re-stores them encrypted.
+ */
+internal class SecretCipher {
+
+    /** Encrypt for storage. Blank in → blank out (nothing to protect, and keeps "unset" as ""). */
+    fun encrypt(plain: String): String {
+        if (plain.isEmpty()) return ""
+        return runCatching {
+            val c = Cipher.getInstance(TRANSFORMATION).apply { init(Cipher.ENCRYPT_MODE, key()) }
+            val body = c.iv + c.doFinal(plain.toByteArray(Charsets.UTF_8))
+            PREFIX + Base64.encodeToString(body, Base64.NO_WRAP)
+        }.getOrDefault(plain) // never lose a value we can't encrypt; it just stays plaintext
+    }
+
+    /** Decrypt a stored value. Legacy plaintext (no prefix) is returned unchanged. */
+    fun decrypt(stored: String): String {
+        if (stored.isEmpty()) return ""
+        if (!stored.startsWith(PREFIX)) return stored
+        return runCatching {
+            val body = Base64.decode(stored.removePrefix(PREFIX), Base64.NO_WRAP)
+            val c = Cipher.getInstance(TRANSFORMATION).apply {
+                init(Cipher.DECRYPT_MODE, key(), GCMParameterSpec(128, body.copyOfRange(0, 12)))
+            }
+            String(c.doFinal(body.copyOfRange(12, body.size)), Charsets.UTF_8)
+        }.getOrDefault("") // key invalidated / corrupted → treat as unset, user re-enters
+    }
+
+    /** True if [stored] is not yet in encrypted form and holds something worth migrating. */
+    fun needsReencrypt(stored: String): Boolean = stored.isNotEmpty() && !stored.startsWith(PREFIX)
+
+    private fun key(): java.security.Key {
+        val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        ks.getKey(ALIAS, null)?.let { return it }
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore").apply {
+            init(
+                KeyGenParameterSpec.Builder(
+                    ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .build()
+            )
+        }.generateKey()
+    }
+
+    companion object {
+        private const val ALIAS = "eor.datastore.secrets.v1"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val PREFIX = "enc1:"
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/sync/SyncthingController.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/sync/SyncthingController.kt
@@ -117,7 +117,7 @@ class SyncthingController @Inject constructor(
         }
     }
 
-    /** Add a peer device (from a scanned/pasted ID) as an introducer and share all eOr folders with it. */
+    /** Add a peer device (from a scanned/pasted ID) and share all eOr folders with it. */
     suspend fun addPeer(deviceId: String): Boolean = withContext(Dispatchers.IO) {
         val key = readApiKey() ?: return@withContext false
         val id = deviceId.trim().uppercase()
@@ -125,7 +125,10 @@ class SyncthingController @Inject constructor(
         val device = JSONObject().apply {
             put("deviceID", id)
             put("name", "eOr device")
-            put("introducer", true)
+            // introducer:false — each of your devices is linked explicitly (QR/ID), so we never want a
+            // linked device to silently add *its* other peers to your sync. That transitive trust was
+            // the main escalation risk if someone were tricked into linking a device that isn't theirs.
+            put("introducer", false)
             put("autoAcceptFolders", true)
             put("addresses", org.json.JSONArray(listOf("dynamic")))
         }

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsScreen.kt
@@ -1589,6 +1589,13 @@ private fun SyncEngineCard(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "Only link your own devices — a linked device can sync your save files. Never link an " +
+                    "ID someone else sent you.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error
+            )
             Spacer(Modifier.height(10.dp))
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
                 QrCode(ui.deviceId, size = 190.dp)
@@ -3238,7 +3245,16 @@ private fun FriendsSettingsSection() {
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Text(peer.displayName, style = MaterialTheme.typography.bodyMedium)
+                        Column(Modifier.weight(1f)) {
+                            Text(peer.displayName, style = MaterialTheme.typography.bodyMedium)
+                            // The name is unverified (anyone on the Wi-Fi can broadcast it); show the
+                            // start of the device id so the user can confirm who they're really adding.
+                            Text(
+                                "Unverified name · ID ${peer.deviceId.take(7)}…",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                         Text(
                             "Tap to add",
                             style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Legacy backup rules (Android 11 and below, android:fullBackupContent). See the note in
+  data_extraction_rules.xml for the rationale. Sensitive DataStore values are encrypted at rest with
+  a non-exportable Keystore key, so they stay safe even inside a backup; we only exclude the
+  device-specific ADB pairing state so it never restores onto a different device.
+-->
+<full-backup-content>
+    <exclude domain="sharedpref" path="eor_adb.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Backup / device-transfer rules (Android 12+, android:dataExtractionRules).
+
+  The sensitive credentials in the DataStore (ScreenScraper password, RetroAchievements API key +
+  session token) are encrypted at rest with an AndroidKeyStore key (see SecretCipher). Keystore keys
+  are never included in a backup, so even if the DataStore file is backed up its secrets can't be
+  decrypted on another device — they simply re-prompt. We therefore keep the DataStore in backups so
+  users keep their (non-sensitive) settings across a device transfer.
+
+  We exclude the ADB pairing state, which is device-specific: a restored "paired" flag would be wrong
+  on a new device (the paired identity lives in noBackupFilesDir and is auto-excluded anyway).
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="eor_adb.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="eor_adb.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,6 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Scoped to the storage roots where user ROMs actually live. We hand emulators a content:// URI for a
+  ROM (see EmulatorLauncher.romUriFor) with a temporary read grant; scoping the provider means such a
+  URI can only ever resolve to shared/external storage, never to app-private data, /data/data, or
+  system paths.
+
+  Both canonical forms of shared storage are covered because FileProvider matches on getCanonicalPath,
+  which differs by OEM:
+    - /storage/...      primary emulated storage AND removable SD cards (/storage/XXXX-XXXX)
+    - /data/media/...   the resolved form of emulated storage on some devices
+  <external-path> additionally covers the primary shared-storage root.
+
+  NOTE: verify a ROM launch from BOTH internal storage and an SD card on-device after this change —
+  the previous config used path="/" (whole filesystem), so any device whose ROM path canonicalizes
+  outside these roots would need another entry added here.
+-->
 <paths>
-    <!-- Covers all storage roots including SD cards at /storage/<id>/... -->
-    <root-path name="root" path="/" />
+    <root-path name="storage" path="/storage/" />
+    <root-path name="media" path="/data/media/" />
     <external-path name="external" path="." />
 </paths>


### PR DESCRIPTION
Security-hardening pass over the app's higher-risk surfaces. The privilege broker, ADB pairing, deep-link handling, and Friends folder isolation were already well-designed and are left as-is; these are the genuine hardening opportunities that surfaced in review.

## Changes

**1. Credentials at rest (highest value)**
- New `SecretCipher` (AndroidKeyStore AES/GCM, `enc1:` prefix) encrypts the ScreenScraper password and RetroAchievements API key + session token in the DataStore. Mirrors the existing `EncryptedAdbIdentity` pattern — no new dependency.
- One-time `migrateSecretsIfNeeded()` (run from `GameLauncherApp`) re-encrypts any pre-existing plaintext.
- Added `dataExtractionRules` + `fullBackupContent`. The Keystore key is non-exportable, so settings backup stays enabled (no device-transfer UX regression) while the device-specific ADB pairing state is excluded from backups.

**2. FileProvider scoping**
- `res/xml/file_paths.xml` narrowed from the whole filesystem (`path="/"`) to storage roots (`/storage/` + `/data/media/`) plus `external-path`. A generated `content://` URI can now only resolve to shared/external storage, never app-private or system paths.

**3. Save Sync trust**
- `SyncthingController.addPeer` drops `introducer:true` so a linked device can no longer silently introduce its *other* peers into your sync (the main escalation vector). Two-device save sync is unaffected; the Friends path was already isolated.
- Added a warning in the link-device UI ("only link your own devices").

**4. Nearby (LAN) beacon**
- Sanitize + length-clamp the attacker-controllable display name, cap the peer map against LAN floods, and show the trusted device id next to the unverified name in the add UI.

## Verification
- Compiles clean (`compileFullDebugKotlin` + `compileLiteDebugKotlin`); friends unit tests pass.
- **On-device (Retroid Pocket 4 Pro, Android 13):** launched an SD-card Switch ROM (`/storage/<sd>/ROMs/switch/…`) → Eden opened and read the `content://` URI with zero FileProvider/`Failed to find configured root` errors. Switch/Eden is the only emulator that uses the FileProvider `CONTENT` path, so this exercised exactly the changed code from the exact case (SD card) that could have regressed. Also confirmed empirically that SD + internal ROM canonical paths stay under `/storage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)