### PR TITLE
release: 2.6.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.gamelaunch.frontend"
         minSdk = 26
         targetSdk = 34
-        versionCode = 42
-        versionName = "2.6.0"
+        versionCode = 43
+        versionName = "2.6.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         ndk { abiFilters += listOf("arm64-v8a", "armeabi-v7a") }


### PR DESCRIPTION
Version bump to 2.6.3 (versionCode 43). Release from main as-is: grid box-art batch loading + idle-motion perf, settings index/drill-in reorg, and the phase 1–4 security hardening (all previously merged, on-device tested per PR). Signed APKs built and verified (cert 45aa40…adee, matches prior releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)