### PR TITLE
fix: keep lite build byte-identical (gate detail fullRes key)

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/component/AsyncGameArtwork.kt
@@ -77,9 +77,11 @@ fun AsyncGameArtwork(
             .data(data)
             .crossfade(true)
         when {
-            // Detail hero: full resolution, under its own key so it never shares (or evicts) the
-            // grid's compact thumbnail.
-            fullRes -> builder
+            // Detail hero (full build): full resolution, under its own key so it never shares (or
+            // evicts) the grid's compact thumbnail. Gated on !LOW_POWER so lite is byte-identical to
+            // the original — lite has no compact tiles to protect against, so it falls through to the
+            // else branch (plain path key), exactly as before.
+            fullRes && !BuildConfig.LOW_POWER -> builder
                 .memoryCacheKey(data?.let { "$it#full" })
             // Full build tiles: decode once at the compact tile size and cache under the plain path
             // key so every warmer (prewarm, neighbour prefetch) and every surface (grid/list/carousel)


### PR DESCRIPTION
Follow-up to keweis2/eOr#108. The detail-hero `fullRes` flag was un-gated, so on the lite build it changed the hero's memory-cache key (`path` → `path#full`) and stopped it reusing the grid tile's decoded bitmap — one extra full-size decode on detail-open. Gated on `!BuildConfig.LOW_POWER`; lite is now byte-identical to before for both tiles and the detail hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)