### PR TITLE
fix(settings): remove duplicate Friends enable toggle

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/FriendsSettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/FriendsSettingsScreen.kt
@@ -142,20 +142,9 @@ private fun FriendsSettingsSection() {
         return
     }
 
-    // Master switch — always shown here so this tab stays reachable. Turning it off stops all
-    // sharing and hides the Home Friends tab, but keeps this tab (and your friends list).
-    SettingsSectionHeader("Friends")
-    SettingsCard {
-        Text(
-            "Turning this off stops all sharing and hides the Friends tab on the home screen. Your friends list is kept for when you turn it back on.",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Spacer(Modifier.height(8.dp))
-        CardSwitchRow("Friends enabled", ui.enabled) { vm.setEnabled(it) }
-    }
-
-    // When off, this tab shows only the toggle above — nothing else is active.
+    // The enable/disable master switch lives in FriendsToggleSection above — both wrote the same
+    // friends_enabled pref, so a second toggle here was a pure duplicate. When off, hide the
+    // pairing + friends-management UI below (ui.enabled reads that same pref).
     if (!ui.enabled) return
 
     Spacer(Modifier.height(12.dp))


### PR DESCRIPTION
The Friends drill-in showed **two** enable toggles — "Enable Friends" (`FriendsToggleSection`) and "Friends enabled" (`FriendsSettingsSection`) — both writing the same `friends_enabled` pref (`FriendsViewModel.setEnabled` → `friendRepository.setEnabled` → `settingsRepository.setFriendsEnabled`). Introduced by the settings index/drill-in reorg layering a category toggle over the screen's existing master toggle.

Removed the redundant in-section toggle. The top toggle is now the single source of truth, and the existing `if (!ui.enabled) return` gate still hides the pairing/management UI when off.

Not yet verified on-device (untested build) — flagging so it's checked before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)