### PR TITLE
feat(web-transfer): device-hosted LAN web server for pushing files from a browser

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -151,6 +151,9 @@ dependencies {
     implementation("com.google.zxing:core:3.5.3")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
+    // Web Transfer — embedded LAN HTTP server so a computer browser can push files to the device.
+    implementation("org.nanohttpd:nanohttpd:2.3.1")
+
     // Media3 / ExoPlayer
     implementation(libs.media3.exoplayer)
     implementation(libs.media3.ui)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -134,6 +134,13 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- Web Transfer: hosts a LAN web server so a computer browser can push ROMs, BIOS, media,
+             background images and settings to the device. Foreground so transfers survive backgrounding. -->
+        <service
+            android:name=".data.webserver.WebTransferService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/assets/webtransfer/app.js
+++ b/app/src/main/assets/webtransfer/app.js
@@ -1,0 +1,246 @@
+"use strict";
+
+const $ = (sel) => document.querySelector(sel);
+const el = (id) => document.getElementById(id);
+
+// ── Boot: decide whether we're paired ─────────────────────────────────────────
+async function boot() {
+  try {
+    const res = await fetch("/api/systems", { credentials: "same-origin" });
+    if (res.status === 401) return showGate();
+    if (res.ok) return showApp(await res.json());
+  } catch (e) { /* fall through to gate */ }
+  showGate();
+}
+
+function showGate() {
+  el("gate").classList.remove("hidden");
+  el("app").classList.add("hidden");
+  el("pin").focus();
+}
+
+function showApp(systemsData) {
+  el("gate").classList.add("hidden");
+  el("app").classList.remove("hidden");
+  el("conn").textContent = location.host;
+  populateSystems(systemsData);
+  loadGames();
+}
+
+// ── Pairing ──────────────────────────────────────────────────────────────────
+el("pinBtn").addEventListener("click", pair);
+el("pin").addEventListener("keydown", (e) => { if (e.key === "Enter") pair(); });
+
+async function pair() {
+  const pin = el("pin").value.trim();
+  el("pinErr").textContent = "";
+  try {
+    const res = await fetch("/api/pair", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pin }),
+    });
+    if (res.ok) return boot();
+    const body = await res.json().catch(() => ({}));
+    if (body.error === "locked") {
+      el("pinErr").textContent = "Too many attempts. Wait a minute and try again.";
+    } else {
+      el("pinErr").textContent = "Incorrect PIN. Try again.";
+    }
+  } catch (e) {
+    el("pinErr").textContent = "Could not reach the device.";
+  }
+}
+
+// ── Tabs ───────────────────────────────────────────────────────────────────────
+document.querySelectorAll(".tab").forEach((tab) => {
+  tab.addEventListener("click", () => {
+    document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"));
+    document.querySelectorAll(".panel").forEach((p) => p.classList.remove("active"));
+    tab.classList.add("active");
+    $(`.panel[data-panel="${tab.dataset.tab}"]`).classList.add("active");
+  });
+});
+
+// ── Games ──────────────────────────────────────────────────────────────────────
+let SYSTEMS = [];
+
+function populateSystems(data) {
+  SYSTEMS = data.systems || [];
+  const sel = el("sysSelect");
+  sel.innerHTML = "";
+  SYSTEMS.forEach((s) => {
+    const opt = document.createElement("option");
+    opt.value = s.id;
+    const tag = s.existing && s.existing.length ? "  ✓ existing" : "";
+    opt.textContent = s.name + tag;
+    sel.appendChild(opt);
+  });
+  sel.addEventListener("change", updateDest);
+  updateDest();
+}
+
+function updateDest() {
+  const sys = SYSTEMS.find((s) => s.id === el("sysSelect").value);
+  const dest = el("destSelect");
+  const hint = el("destHint");
+  dest.innerHTML = "";
+  if (!sys) return;
+  const opts = [];
+  (sys.existing || []).forEach((p) => opts.push({ value: p, label: p + "  (existing)" }));
+  // Always offer the canonical folder as a fallback ("" = let the device decide).
+  opts.push({ value: "", label: sys.canonicalFolder + (sys.existing && sys.existing.length ? "  (new)" : "  (will be created)") });
+  opts.forEach((o) => {
+    const opt = document.createElement("option");
+    opt.value = o.value;
+    opt.textContent = o.label;
+    dest.appendChild(opt);
+  });
+  hint.textContent = (sys.existing && sys.existing.length)
+    ? "Files go into your existing folder for this system."
+    : "No folder for this system yet — one will be created.";
+}
+
+wireDrop("gamesDrop", "gamesFile", (files) => {
+  const system = el("sysSelect").value;
+  const dest = el("destSelect").value;
+  [...files].forEach((f) => {
+    let url = `/api/upload/rom?system=${encodeURIComponent(system)}&name=${encodeURIComponent(f.name)}`;
+    if (dest) url += `&dest=${encodeURIComponent(dest)}`;
+    upload("gamesQueue", "PUT", url, f, f.name);
+  });
+});
+
+// ── BIOS ─────────────────────────────────────────────────────────────────────
+wireDrop("biosDrop", "biosFile", (files) => {
+  [...files].forEach((f) => {
+    const url = `/api/upload/bios?name=${encodeURIComponent(f.name)}`;
+    upload("biosQueue", "PUT", url, f, f.name);
+  });
+});
+
+// ── Media ──────────────────────────────────────────────────────────────────────
+async function loadGames() {
+  try {
+    const res = await fetch("/api/games", { credentials: "same-origin" });
+    if (!res.ok) return;
+    const data = await res.json();
+    const sel = el("gameSelect");
+    sel.innerHTML = "";
+    (data.games || []).sort((a, b) => a.title.localeCompare(b.title)).forEach((g) => {
+      const opt = document.createElement("option");
+      opt.value = g.id;
+      opt.textContent = `${g.title} (${g.platformId})`;
+      sel.appendChild(opt);
+    });
+  } catch (e) { /* ignore */ }
+}
+
+wireDrop("mediaDrop", "mediaFile", (files) => {
+  const gameId = el("gameSelect").value;
+  const type = el("mediaType").value;
+  if (!gameId) { alert("Add some games first, then upload media for them."); return; }
+  [...files].forEach((f) => {
+    const url = `/api/upload/media?gameId=${encodeURIComponent(gameId)}&type=${encodeURIComponent(type)}`;
+    upload("mediaQueue", "PUT", url, f, f.name);
+  });
+});
+
+// ── Background ─────────────────────────────────────────────────────────────────
+wireDrop("bgDrop", "bgFile", (files) => {
+  const f = files[0];
+  if (!f) return;
+  upload("bgQueue", "POST", "/api/upload/background", f, f.name);
+});
+
+// ── Settings ─────────────────────────────────────────────────────────────────
+el("exportBtn").addEventListener("click", async () => {
+  try {
+    const res = await fetch("/api/settings/export", { credentials: "same-origin" });
+    if (!res.ok) { el("settingsMsg").textContent = "Export failed."; return; }
+    const blob = await res.blob();
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = "eor-settings.json";
+    a.click();
+    URL.revokeObjectURL(a.href);
+  } catch (e) { el("settingsMsg").textContent = "Export failed."; }
+});
+
+wireDrop("settingsDrop", "settingsFile", async (files) => {
+  const f = files[0];
+  if (!f) return;
+  try {
+    const text = await f.text();
+    const res = await fetch("/api/settings/import", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: text,
+    });
+    const body = await res.json().catch(() => ({}));
+    el("settingsMsg").textContent = res.ok
+      ? `Imported ${body.applied} settings.`
+      : "Import failed — is this an eOr settings file?";
+  } catch (e) { el("settingsMsg").textContent = "Import failed."; }
+});
+
+// ── Shared: drag/drop + upload with progress ───────────────────────────────────
+function wireDrop(dropId, inputId, handler) {
+  const drop = el(dropId);
+  const input = el(inputId);
+  drop.addEventListener("dragover", (e) => { e.preventDefault(); drop.classList.add("hover"); });
+  drop.addEventListener("dragleave", () => drop.classList.remove("hover"));
+  drop.addEventListener("drop", (e) => {
+    e.preventDefault();
+    drop.classList.remove("hover");
+    if (e.dataTransfer.files.length) handler(e.dataTransfer.files);
+  });
+  input.addEventListener("change", () => { if (input.files.length) handler(input.files); input.value = ""; });
+}
+
+function upload(queueId, method, url, file, name) {
+  const item = document.createElement("div");
+  item.className = "item";
+  item.innerHTML = `<div class="name"></div><div class="meta">Waiting…</div><div class="bar"><span></span></div>`;
+  item.querySelector(".name").textContent = name;
+  el(queueId).prepend(item);
+  const bar = item.querySelector(".bar > span");
+  const meta = item.querySelector(".meta");
+
+  const xhr = new XMLHttpRequest();
+  xhr.open(method, url, true);
+  xhr.withCredentials = true;
+  xhr.upload.onprogress = (e) => {
+    if (e.lengthComputable) {
+      const pct = Math.round((e.loaded / e.total) * 100);
+      bar.style.width = pct + "%";
+      meta.textContent = pct + "%  ·  " + human(e.loaded) + " / " + human(e.total);
+    }
+  };
+  xhr.onload = () => {
+    if (xhr.status >= 200 && xhr.status < 300) {
+      item.classList.add("done");
+      bar.style.width = "100%";
+      meta.textContent = "Done";
+      if (queueId === "games" || queueId === "mediaQueue") loadGames();
+    } else {
+      item.classList.add("error");
+      let msg = xhr.responseText || ("Error " + xhr.status);
+      if (xhr.status === 401) msg = "Session expired — refresh and pair again.";
+      meta.textContent = msg;
+    }
+  };
+  xhr.onerror = () => { item.classList.add("error"); meta.textContent = "Network error"; };
+  xhr.send(file);
+}
+
+function human(bytes) {
+  if (bytes >= 1e9) return (bytes / 1e9).toFixed(1) + " GB";
+  if (bytes >= 1e6) return (bytes / 1e6).toFixed(1) + " MB";
+  if (bytes >= 1e3) return (bytes / 1e3).toFixed(0) + " KB";
+  return bytes + " B";
+}
+
+boot();

--- a/app/src/main/assets/webtransfer/index.html
+++ b/app/src/main/assets/webtransfer/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>eOr Web Transfer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">🎮 eOr <span>Web Transfer</span></div>
+    <div id="conn" class="conn"></div>
+  </header>
+
+  <!-- PIN gate -->
+  <section id="gate" class="gate hidden">
+    <div class="card gate-card">
+      <h1>Enter the PIN</h1>
+      <p>Open <strong>Settings → Web Transfer</strong> on your device and type the 6-digit PIN shown there.</p>
+      <input id="pin" inputmode="numeric" maxlength="6" autocomplete="off" placeholder="000000" />
+      <button id="pinBtn" class="primary">Pair</button>
+      <p id="pinErr" class="err"></p>
+    </div>
+  </section>
+
+  <!-- Main app -->
+  <main id="app" class="app hidden">
+    <nav class="tabs">
+      <button class="tab active" data-tab="games">Games</button>
+      <button class="tab" data-tab="bios">BIOS</button>
+      <button class="tab" data-tab="media">Media</button>
+      <button class="tab" data-tab="background">Background</button>
+      <button class="tab" data-tab="settings">Settings</button>
+    </nav>
+
+    <section class="panel active" data-panel="games">
+      <div class="card">
+        <label class="lbl">System</label>
+        <select id="sysSelect"></select>
+        <label class="lbl">Destination folder</label>
+        <select id="destSelect"></select>
+        <p class="hint" id="destHint"></p>
+        <div id="gamesDrop" class="drop">
+          <p>Drag ROM files here, or <label class="link">browse<input id="gamesFile" type="file" multiple hidden /></label></p>
+        </div>
+      </div>
+      <div id="gamesQueue" class="queue"></div>
+    </section>
+
+    <section class="panel" data-panel="bios">
+      <div class="card">
+        <p class="hint">BIOS/firmware files are saved to your BIOS staging folder. Point your emulators at it, or copy from it.</p>
+        <div id="biosDrop" class="drop">
+          <p>Drag BIOS files here, or <label class="link">browse<input id="biosFile" type="file" multiple hidden /></label></p>
+        </div>
+      </div>
+      <div id="biosQueue" class="queue"></div>
+    </section>
+
+    <section class="panel" data-panel="media">
+      <div class="card">
+        <label class="lbl">Game</label>
+        <select id="gameSelect"></select>
+        <label class="lbl">Media type</label>
+        <select id="mediaType">
+          <option value="boxart">Box art</option>
+          <option value="screenshot">Screenshot</option>
+          <option value="wheel">Wheel / logo</option>
+          <option value="miximage">Mix image</option>
+          <option value="video">Video preview</option>
+        </select>
+        <div id="mediaDrop" class="drop">
+          <p>Drag an image/video here, or <label class="link">browse<input id="mediaFile" type="file" hidden /></label></p>
+        </div>
+      </div>
+      <div id="mediaQueue" class="queue"></div>
+    </section>
+
+    <section class="panel" data-panel="background">
+      <div class="card">
+        <p class="hint">Upload an image to use as your launcher background. It's converted to a themed silhouette automatically.</p>
+        <div id="bgDrop" class="drop">
+          <p>Drag an image here, or <label class="link">browse<input id="bgFile" type="file" accept="image/*" hidden /></label></p>
+        </div>
+      </div>
+      <div id="bgQueue" class="queue"></div>
+    </section>
+
+    <section class="panel" data-panel="settings">
+      <div class="card">
+        <p class="hint">Move your appearance, layout and library preferences between devices. Passwords and account tokens are never included.</p>
+        <button id="exportBtn" class="primary">Download settings</button>
+        <div class="drop small" id="settingsDrop">
+          <p>Drag a settings file here to import, or <label class="link">browse<input id="settingsFile" type="file" accept=".json,application/json" hidden /></label></p>
+        </div>
+        <p id="settingsMsg" class="hint"></p>
+      </div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/app/src/main/assets/webtransfer/style.css
+++ b/app/src/main/assets/webtransfer/style.css
@@ -1,0 +1,148 @@
+:root {
+  --bg: #0f1420;
+  --surface: #1a2030;
+  --surface2: #232a3d;
+  --text: #e8ecf5;
+  --muted: #9aa4bd;
+  --blue: #4d7fff;
+  --purple: #8b5cf6;
+  --green: #3ddc84;
+  --red: #ff6b6b;
+  --radius: 14px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.hidden { display: none !important; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  background: linear-gradient(90deg, rgba(77,127,255,0.18), rgba(139,92,246,0.18));
+  border-bottom: 1px solid var(--surface2);
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(8px);
+}
+.brand { font-weight: 700; font-size: 18px; }
+.brand span { color: var(--muted); font-weight: 500; }
+.conn { font-size: 13px; color: var(--muted); }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--surface2);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin: 16px auto;
+  max-width: 640px;
+}
+
+/* PIN gate */
+.gate { display: flex; justify-content: center; padding: 40px 16px; }
+.gate-card { text-align: center; }
+.gate-card h1 { margin: 0 0 8px; font-size: 22px; }
+.gate-card p { color: var(--muted); font-size: 14px; }
+#pin {
+  font-size: 32px;
+  letter-spacing: 12px;
+  text-align: center;
+  width: 220px;
+  padding: 12px;
+  margin: 16px auto 12px;
+  display: block;
+  background: var(--surface2);
+  border: 1px solid var(--blue);
+  border-radius: 10px;
+  color: var(--text);
+  font-family: "SF Mono", ui-monospace, Menlo, monospace;
+}
+
+button {
+  cursor: pointer;
+  font-size: 15px;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 22px;
+  color: #fff;
+  background: var(--surface2);
+  transition: transform 0.05s ease, filter 0.15s ease;
+}
+button:active { transform: scale(0.98); }
+button.primary { background: linear-gradient(90deg, var(--blue), var(--purple)); font-weight: 600; }
+button:hover { filter: brightness(1.08); }
+
+.app { padding-bottom: 60px; }
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding: 12px 16px 0;
+  max-width: 672px;
+  margin: 0 auto;
+}
+.tab {
+  background: transparent;
+  color: var(--muted);
+  padding: 10px 16px;
+  border-radius: 10px 10px 0 0;
+  white-space: nowrap;
+}
+.tab.active { color: #fff; background: var(--surface); }
+
+.panel { display: none; }
+.panel.active { display: block; }
+
+.lbl { display: block; font-size: 13px; color: var(--muted); margin: 12px 0 6px; }
+select {
+  width: 100%;
+  padding: 12px;
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--surface2);
+  border-radius: 10px;
+  font-size: 15px;
+}
+.hint { color: var(--muted); font-size: 13px; margin: 8px 0 0; }
+
+.drop {
+  margin-top: 16px;
+  border: 2px dashed var(--surface2);
+  border-radius: var(--radius);
+  padding: 34px 16px;
+  text-align: center;
+  color: var(--muted);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.drop.small { padding: 20px 16px; }
+.drop.hover { border-color: var(--blue); background: rgba(77,127,255,0.08); }
+.link { color: var(--blue); cursor: pointer; text-decoration: underline; }
+
+.queue { max-width: 640px; margin: 0 auto; }
+.item {
+  background: var(--surface);
+  border: 1px solid var(--surface2);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin: 8px 16px;
+}
+.item .name { font-size: 14px; word-break: break-all; }
+.item .meta { font-size: 12px; color: var(--muted); margin-top: 2px; }
+.bar { height: 6px; background: var(--surface2); border-radius: 3px; margin-top: 8px; overflow: hidden; }
+.bar > span { display: block; height: 100%; width: 0; background: linear-gradient(90deg, var(--blue), var(--purple)); transition: width 0.1s linear; }
+.item.done .bar > span { background: var(--green); }
+.item.error .bar > span { background: var(--red); }
+.item.done .meta { color: var(--green); }
+.item.error .meta { color: var(--red); }
+
+.err { color: var(--red); font-size: 13px; min-height: 18px; }

--- a/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/preferences/AppDataStore.kt
@@ -80,6 +80,13 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
         val SAVE_SYNC_ENABLED = booleanPreferencesKey("save_sync_enabled")
         val SYNC_WIFI_ONLY = booleanPreferencesKey("sync_wifi_only")
         val SYNC_CHARGING_ONLY = booleanPreferencesKey("sync_charging_only")
+        // Web Transfer — a device-hosted LAN web server for pushing files (ROMs, BIOS, media,
+        // background images, settings) from a computer's browser. Off by default; enabling starts a
+        // foreground service. Port 0 = use the built-in default port.
+        val WEB_TRANSFER_ENABLED = booleanPreferencesKey("web_transfer_enabled")
+        val WEB_TRANSFER_PORT = intPreferencesKey("web_transfer_port")
+        // Destination for BIOS/firmware uploaded via Web Transfer. Empty = "<romRoot>/bios" default.
+        val BIOS_FOLDER_PATH = stringPreferencesKey("bios_folder_path")
         val SYSTEM_SORT = stringPreferencesKey("system_sort")
         val GAME_SORT = stringPreferencesKey("game_sort")
         val GAME_GRID_COLUMNS = intPreferencesKey("game_grid_columns")
@@ -163,6 +170,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     val saveSyncEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.SAVE_SYNC_ENABLED] ?: false }
     val syncWifiOnly: Flow<Boolean> = context.dataStore.data.map { it[Keys.SYNC_WIFI_ONLY] ?: false }
     val syncChargingOnly: Flow<Boolean> = context.dataStore.data.map { it[Keys.SYNC_CHARGING_ONLY] ?: false }
+    val webTransferEnabled: Flow<Boolean> = context.dataStore.data.map { it[Keys.WEB_TRANSFER_ENABLED] ?: false }
+    val webTransferPort: Flow<Int> = context.dataStore.data.map { it[Keys.WEB_TRANSFER_PORT] ?: 0 }
+    val biosFolderPath: Flow<String> = context.dataStore.data.map { it[Keys.BIOS_FOLDER_PATH] ?: "" }
     // Up to two sort keys, comma-joined (e.g. "RELEASE_DATE,BRAND"). Empty = default order.
     val systemSort: Flow<List<String>> = context.dataStore.data.map {
         it[Keys.SYSTEM_SORT]?.split(",")?.filter { s -> s.isNotBlank() } ?: emptyList()
@@ -260,6 +270,9 @@ class AppDataStore @Inject constructor(@ApplicationContext private val context: 
     suspend fun setSaveSyncEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.SAVE_SYNC_ENABLED] = enabled }
     suspend fun setSyncWifiOnly(v: Boolean) = context.dataStore.edit { it[Keys.SYNC_WIFI_ONLY] = v }
     suspend fun setSyncChargingOnly(v: Boolean) = context.dataStore.edit { it[Keys.SYNC_CHARGING_ONLY] = v }
+    suspend fun setWebTransferEnabled(enabled: Boolean) = context.dataStore.edit { it[Keys.WEB_TRANSFER_ENABLED] = enabled }
+    suspend fun setWebTransferPort(port: Int) = context.dataStore.edit { it[Keys.WEB_TRANSFER_PORT] = port }
+    suspend fun setBiosFolderPath(path: String) = context.dataStore.edit { it[Keys.BIOS_FOLDER_PATH] = path }
     // Drop only the user's image (revert to the default silhouette); the enabled flag is controlled
     // independently by its own toggle.
     suspend fun clearBackgroundImage() = context.dataStore.edit {

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/MediaRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/MediaRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.gamelaunch.frontend.data.db.entity.GameMediaEntity
 import com.gamelaunch.frontend.data.preferences.AppDataStore
 import com.gamelaunch.frontend.domain.model.GameMedia
 import com.gamelaunch.frontend.domain.repository.MediaRepository
+import com.gamelaunch.frontend.domain.repository.MediaUploadType
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -100,6 +101,40 @@ class MediaRepositoryImpl @Inject constructor(
             destination.absolutePath
         }.getOrNull()
     }
+
+    override suspend fun saveUploadedMedia(gameId: Long, type: MediaUploadType, bytes: ByteArray): String? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                require(bytes.isNotEmpty()) { "Empty upload" }
+                val imageExt = bytes.embeddedImageExtension()
+                val (subdir, ext) = when (type) {
+                    MediaUploadType.BOX_ART -> "boxart" to (imageExt ?: "jpg")
+                    MediaUploadType.SCREENSHOT -> "screenshots" to (imageExt ?: "jpg")
+                    MediaUploadType.WHEEL -> "wheels" to (imageExt ?: "png")
+                    MediaUploadType.MIXIMAGE -> "miximages" to (imageExt ?: "png")
+                    MediaUploadType.VIDEO -> "videos" to "mp4"
+                }
+                if (type != MediaUploadType.VIDEO) require(imageExt != null) { "Not a PNG or JPEG image" }
+
+                val dest = File(mediaDir(), "$subdir/$gameId.$ext")
+                dest.parentFile?.mkdirs()
+                // Write to a .part sibling then atomically rename so a half-received file is never read.
+                val part = File(dest.parentFile, "${dest.name}.part")
+                part.outputStream().use { it.write(bytes) }
+                if (dest.exists()) dest.delete()
+                if (!part.renameTo(dest)) error("Could not finalize upload")
+
+                val media = when (type) {
+                    MediaUploadType.BOX_ART -> GameMedia(gameId = gameId, boxArtLocalPath = dest.absolutePath)
+                    MediaUploadType.SCREENSHOT -> GameMedia(gameId = gameId, screenshotLocalPath = dest.absolutePath)
+                    MediaUploadType.WHEEL -> GameMedia(gameId = gameId, wheelLogoLocalPath = dest.absolutePath)
+                    MediaUploadType.MIXIMAGE -> GameMedia(gameId = gameId, miximageLocalPath = dest.absolutePath)
+                    MediaUploadType.VIDEO -> GameMedia(gameId = gameId, videoLocalPath = dest.absolutePath)
+                }
+                upsertMedia(media)
+                dest.absolutePath
+            }.getOrNull()
+        }
 
     override suspend fun downloadAndCacheVideo(gameId: Long, url: String): String? =
         downloadFile(url, File(mediaDir(), "videos/${gameId}.mp4"))?.also { path ->

--- a/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/repository/SettingsRepositoryImpl.kt
@@ -72,6 +72,9 @@ class SettingsRepositoryImpl @Inject constructor(
     override val saveSyncEnabled: Flow<Boolean> = dataStore.saveSyncEnabled
     override val syncWifiOnly: Flow<Boolean> = dataStore.syncWifiOnly
     override val syncChargingOnly: Flow<Boolean> = dataStore.syncChargingOnly
+    override val webTransferEnabled: Flow<Boolean> = dataStore.webTransferEnabled
+    override val webTransferPort: Flow<Int> = dataStore.webTransferPort
+    override val biosFolderPath: Flow<String> = dataStore.biosFolderPath
     override val systemSort: Flow<List<SystemSort>> =
         dataStore.systemSort.map { names -> names.mapNotNull { SystemSort.fromName(it) } }
     override val gameSort: Flow<GameSort> = dataStore.gameSort.map { GameSort.fromName(it) }
@@ -138,6 +141,9 @@ class SettingsRepositoryImpl @Inject constructor(
     override suspend fun setSaveSyncEnabled(enabled: Boolean) { dataStore.setSaveSyncEnabled(enabled) }
     override suspend fun setSyncWifiOnly(v: Boolean) { dataStore.setSyncWifiOnly(v) }
     override suspend fun setSyncChargingOnly(v: Boolean) { dataStore.setSyncChargingOnly(v) }
+    override suspend fun setWebTransferEnabled(enabled: Boolean) { dataStore.setWebTransferEnabled(enabled) }
+    override suspend fun setWebTransferPort(port: Int) { dataStore.setWebTransferPort(port) }
+    override suspend fun setBiosFolderPath(path: String) { dataStore.setBiosFolderPath(path) }
     override suspend fun clearBackgroundImage() { dataStore.clearBackgroundImage() }
     override suspend fun setSystemSort(keys: List<SystemSort>) { dataStore.setSystemSort(keys.map { it.name }) }
     override suspend fun setGameSort(sort: GameSort) { dataStore.setGameSort(sort.name) }

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/RomDestinationResolver.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/RomDestinationResolver.kt
@@ -1,0 +1,130 @@
+package com.gamelaunch.frontend.data.webserver
+
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Decides *where* a browser upload lands so it matches the user's existing library layout instead of
+ * forcing eOr's canonical folder names.
+ *
+ * A user's ROMs may already sit in a non-canonical alias (`ROMs/Famicom`, `ROMs/psx`) or a nested
+ * layout (`ROMs/Nintendo/SNES`). Writing to a fresh `<root>/<canonical>/` would split their library,
+ * so we prefer a folder that already exists for the target platform and only create the canonical one
+ * when there is nothing to reuse. All folder→platform recognition goes through
+ * [PlatformDefinitions.byFolderName], which knows every alias.
+ *
+ * Pure `java.io.File` logic (no Android dependencies) so it is unit-testable on the JVM.
+ */
+@Singleton
+class RomDestinationResolver @Inject constructor() {
+
+    /** A recognised platform folder found under the ROM root. */
+    data class PlatformFolder(
+        val platformId: String,
+        val displayName: String,
+        /** Path relative to the ROM root, using '/' separators (e.g. "Nintendo/SNES"). */
+        val relativePath: String,
+        val depth: Int,
+    )
+
+    /**
+     * Every directory under [root] whose name maps to a known platform, grouped by platform id.
+     * The walk skips hidden and emulator-data folders and is depth-limited to keep it cheap.
+     */
+    fun existingPlatformFolders(root: File): Map<String, List<PlatformFolder>> {
+        if (!root.isDirectory) return emptyMap()
+        val found = mutableListOf<PlatformFolder>()
+        fun visit(dir: File, depth: Int) {
+            if (depth > MAX_SCAN_DEPTH) return
+            val children = dir.listFiles() ?: return
+            for (child in children) {
+                if (!child.isDirectory) continue
+                val name = child.name
+                if (name.startsWith(".") || name.lowercase() in SKIP_FOLDERS) continue
+                val platform = PlatformDefinitions.byFolderName[name.lowercase()]
+                if (platform != null) {
+                    found += PlatformFolder(
+                        platformId = platform.id,
+                        displayName = platform.displayName,
+                        relativePath = relativeTo(root, child),
+                        depth = depth,
+                    )
+                }
+                visit(child, depth + 1)
+            }
+        }
+        visit(root, 1)
+        return found.groupBy { it.platformId }
+    }
+
+    /**
+     * The directory an uploaded ROM for [platformId] should be written to.
+     *
+     * @param explicitDest optional user-chosen relative path under [root]; used verbatim after
+     *   containment validation. Throws [IllegalArgumentException] if it escapes [root].
+     */
+    fun resolveRomDir(root: File, platformId: String, explicitDest: String? = null): File {
+        if (!explicitDest.isNullOrBlank()) {
+            return containedDir(root, explicitDest)
+                ?: throw IllegalArgumentException("Destination escapes the ROM root")
+        }
+        val existing = existingPlatformFolders(root)[platformId]
+        if (!existing.isNullOrEmpty()) {
+            // Prefer the shallowest existing folder (the most likely "main" one for that system).
+            val best = existing.minByOrNull { it.depth }!!
+            return File(root, best.relativePath)
+        }
+        val platform = PlatformDefinitions.byId[platformId]
+            ?: throw IllegalArgumentException("Unknown platform: $platformId")
+        return File(root, platform.folderNames.first())
+    }
+
+    /**
+     * Strip any path components from [name] and reject traversal tokens, so a filename from the
+     * network can never write outside its intended directory.
+     */
+    fun sanitizeFilename(name: String): String {
+        val base = name.substringAfterLast('/').substringAfterLast('\\').trim()
+        require(base.isNotEmpty() && base != "." && base != "..") { "Invalid filename: $name" }
+        // Drop control characters; keep everything else (ROM names carry spaces, brackets, unicode).
+        val cleaned = base.filter { it.code >= 0x20 }
+        require(cleaned.isNotEmpty()) { "Invalid filename: $name" }
+        return cleaned
+    }
+
+    /**
+     * Resolve [relPath] under [root] and return it only if the canonical result stays inside [root]
+     * (defends against `..` and absolute paths). Creates the directory. Returns null if it escapes.
+     */
+    fun containedDir(root: File, relPath: String): File? {
+        val candidate = File(root, relPath)
+        val rootCanon = root.canonicalFile
+        val candidateCanon = candidate.canonicalFile
+        val rootPath = rootCanon.path + File.separator
+        return if (candidateCanon == rootCanon || (candidateCanon.path + File.separator).startsWith(rootPath)) {
+            candidateCanon
+        } else {
+            null
+        }
+    }
+
+    private fun relativeTo(root: File, child: File): String =
+        child.canonicalFile.path
+            .removePrefix(root.canonicalFile.path)
+            .trimStart(File.separatorChar)
+            .replace(File.separatorChar, '/')
+
+    private companion object {
+        const val MAX_SCAN_DEPTH = 4
+        // Emulator-data / non-ROM folders we never descend into or treat as a destination.
+        val SKIP_FOLDERS = setOf(
+            "savedata", "save", "saves", "savestates", "states", "savefiles",
+            "sdmc", "nand", "shaders", "cache", "log", "logs", "dump", "dumps",
+            "screenshots", "cheats", "textures", "texture_cache", "system",
+            "memcards", "memory cards", "bios", "firmware", "firmwares", "tmp", "temp",
+            "config", "configs", "media", "eor_media", "downloaded_media",
+        )
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferManager.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferManager.kt
@@ -1,0 +1,139 @@
+package com.gamelaunch.frontend.data.webserver
+
+import android.content.Context
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.MediaRepository
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.domain.usecase.ConvertBackgroundImageUseCase
+import com.gamelaunch.frontend.domain.usecase.ExportSettingsUseCase
+import com.gamelaunch.frontend.domain.usecase.ImportSettingsUseCase
+import com.gamelaunch.frontend.domain.usecase.ScanRomsUseCase
+import com.gamelaunch.frontend.systemui.preferredLocalAddress
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.security.SecureRandom
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Observable state of the Web Transfer server for the settings UI. */
+data class WebTransferState(
+    val running: Boolean = false,
+    val ip: String = "",
+    val port: Int = 0,
+    val pin: String = "",
+    /** Recent activity lines (newest first), shown as a small transfer log. */
+    val log: List<String> = emptyList(),
+) {
+    val url: String get() = if (running && ip.isNotBlank()) "http://$ip:$port" else ""
+}
+
+/**
+ * Single owner of the Web Transfer server's run-state (mirrors `SyncEngineManager`). The UI persists
+ * the enabled flag then calls [start]/[stop], which drive the foreground [WebTransferService]; the
+ * service in turn calls [onServiceStart]/[onServiceStop] which actually bind and release the socket.
+ */
+@Singleton
+class WebTransferManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val settings: SettingsRepository,
+    private val gameRepository: GameRepository,
+    private val mediaRepository: MediaRepository,
+    private val convertBackground: ConvertBackgroundImageUseCase,
+    private val exportSettings: ExportSettingsUseCase,
+    private val importSettings: ImportSettingsUseCase,
+    private val destinationResolver: RomDestinationResolver,
+    private val scanRomsUseCase: ScanRomsUseCase,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val random = SecureRandom()
+
+    private val _state = MutableStateFlow(WebTransferState())
+    val state: StateFlow<WebTransferState> = _state
+
+    @Volatile private var server: WebTransferServer? = null
+    @Volatile private var rescanJob: Job? = null
+
+    /** Ask the OS to start the foreground service (which then calls [onServiceStart]). */
+    fun start() = WebTransferService.start(context)
+
+    /** Stop the foreground service (which then calls [onServiceStop]). */
+    fun stop() = WebTransferService.stop(context)
+
+    @Synchronized
+    fun onServiceStart() {
+        if (server != null) return
+        val port = runCatching {
+            kotlinx.coroutines.runBlocking { settings.webTransferPort.first() }
+        }.getOrDefault(0).let { if (it in 1..65535) it else DEFAULT_PORT }
+        val pin = generatePin()
+        val deps = WebTransferDeps(
+            context = context,
+            settings = settings,
+            gameRepository = gameRepository,
+            mediaRepository = mediaRepository,
+            convertBackground = convertBackground,
+            exportSettings = exportSettings,
+            importSettings = importSettings,
+            destinationResolver = destinationResolver,
+        )
+        val srv = WebTransferServer(
+            port = port,
+            pin = pin,
+            deps = deps,
+            onEvent = ::pushLog,
+            onRomUploaded = ::scheduleRescan,
+        )
+        srv.start(SOCKET_READ_TIMEOUT, false)
+        server = srv
+        val ip = runCatching { preferredLocalAddress().hostAddress ?: "" }.getOrDefault("")
+        _state.value = WebTransferState(running = true, ip = ip, port = port, pin = pin)
+    }
+
+    @Synchronized
+    fun onServiceStop() {
+        rescanJob?.cancel()
+        rescanJob = null
+        runCatching { server?.stop() }
+        server = null
+        _state.value = WebTransferState()
+    }
+
+    private fun pushLog(line: String) {
+        _state.update { it.copy(log = (listOf(line) + it.log).take(MAX_LOG_LINES)) }
+    }
+
+    /**
+     * Debounced library rescan after ROM uploads. Waits out the scanner's quiet period so a still-
+     * arriving file isn't imported half-written, then runs the same hashing scan the app uses.
+     */
+    private fun scheduleRescan() {
+        rescanJob?.cancel()
+        rescanJob = scope.launch {
+            delay(RESCAN_DEBOUNCE_MS)
+            val root = settings.romRootPath.first()
+            if (root.isNotBlank()) {
+                runCatching { scanRomsUseCase(root).collect { } }
+                pushLog("Library rescanned")
+            }
+        }
+    }
+
+    private fun generatePin(): String = "%06d".format(random.nextInt(1_000_000))
+
+    private companion object {
+        const val DEFAULT_PORT = 8080
+        const val SOCKET_READ_TIMEOUT = 60_000
+        const val MAX_LOG_LINES = 30
+        // Slightly longer than the scanner's own quiet period so a completed upload is stable on disk.
+        const val RESCAN_DEBOUNCE_MS = 12_000L
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferServer.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferServer.kt
@@ -1,0 +1,413 @@
+package com.gamelaunch.frontend.data.webserver
+
+import android.content.Context
+import com.gamelaunch.frontend.domain.platform.PlatformDefinitions
+import com.gamelaunch.frontend.domain.repository.GameRepository
+import com.gamelaunch.frontend.domain.repository.MediaRepository
+import com.gamelaunch.frontend.domain.repository.MediaUploadType
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.domain.usecase.ConvertBackgroundImageUseCase
+import com.gamelaunch.frontend.domain.usecase.ExportSettingsUseCase
+import com.gamelaunch.frontend.domain.usecase.ImportSettingsUseCase
+import com.gamelaunch.frontend.util.StorageUtils
+import fi.iki.elonen.NanoHTTPD
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.net.InetAddress
+import java.security.SecureRandom
+import java.util.concurrent.ConcurrentHashMap
+
+/** Everything the server needs from the app, bundled so the DI-managed pieces stay in one place. */
+class WebTransferDeps(
+    val context: Context,
+    val settings: SettingsRepository,
+    val gameRepository: GameRepository,
+    val mediaRepository: MediaRepository,
+    val convertBackground: ConvertBackgroundImageUseCase,
+    val exportSettings: ExportSettingsUseCase,
+    val importSettings: ImportSettingsUseCase,
+    val destinationResolver: RomDestinationResolver,
+)
+
+/**
+ * The LAN web server behind Web Transfer. Serves a small single-page UI (bundled under
+ * `assets/webtransfer/`) and a JSON API that writes uploads straight to the user's storage.
+ *
+ * Security posture:
+ *  - Every `/api/*` call except `/api/pair` requires a session token issued only after the browser
+ *    submits the device-displayed [pin]. PIN attempts are rate-limited with a lockout.
+ *  - Requests are accepted only from LAN (site-local / loopback) addresses.
+ *  - Every filename is sanitized and every destination is confined under its intended root
+ *    (see [RomDestinationResolver]), so a crafted request can never escape the target directory.
+ *
+ * File bodies are streamed straight to a `.part` file and atomically renamed, so a partially-received
+ * upload is never seen by the library scanner.
+ */
+class WebTransferServer(
+    port: Int,
+    private val pin: String,
+    private val deps: WebTransferDeps,
+    private val onEvent: (String) -> Unit,
+    private val onRomUploaded: () -> Unit,
+) : NanoHTTPD(port) {
+
+    private val tokens: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    private val random = SecureRandom()
+
+    @Volatile private var failedAttempts = 0
+    @Volatile private var lockoutUntil = 0L
+
+    override fun serve(session: IHTTPSession): Response {
+        return try {
+            if (!isLanClient(session)) {
+                return text(Response.Status.FORBIDDEN, "Forbidden")
+            }
+            val uri = session.uri
+            when {
+                uri == "/api/pair" && session.method == Method.POST -> handlePair(session)
+                uri.startsWith("/api/") -> {
+                    if (!isAuthed(session)) return text(Response.Status.UNAUTHORIZED, "Unauthorized")
+                    handleApi(session, uri)
+                }
+                else -> serveAsset(uri)
+            }
+        } catch (e: IllegalArgumentException) {
+            text(Response.Status.BAD_REQUEST, e.message ?: "Bad request")
+        } catch (e: Exception) {
+            onEvent("Error: ${e.message}")
+            text(Response.Status.INTERNAL_ERROR, "Server error")
+        }
+    }
+
+    // ── Auth ────────────────────────────────────────────────────────────────────────────────────
+
+    private fun handlePair(session: IHTTPSession): Response {
+        val now = System.currentTimeMillis()
+        if (now < lockoutUntil) {
+            return json(Response.Status.FORBIDDEN, JSONObject().put("error", "locked").put("retryMs", lockoutUntil - now))
+        }
+        val body = receiveToBytes(session, MAX_TEXT_BYTES).toString(Charsets.UTF_8)
+        val submitted = runCatching { JSONObject(body).optString("pin") }.getOrDefault("")
+        return if (submitted.isNotEmpty() && constantTimeEquals(submitted, pin)) {
+            failedAttempts = 0
+            val token = newToken()
+            tokens += token
+            onEvent("A computer paired successfully")
+            val r = json(Response.Status.OK, JSONObject().put("ok", true))
+            r.addHeader("Set-Cookie", "$COOKIE=$token; Path=/; HttpOnly; SameSite=Strict")
+            r
+        } else {
+            failedAttempts++
+            if (failedAttempts >= MAX_FAILED_ATTEMPTS) {
+                lockoutUntil = now + LOCKOUT_MS
+                failedAttempts = 0
+                onEvent("Too many wrong PINs — pairing locked for a minute")
+            }
+            json(Response.Status.UNAUTHORIZED, JSONObject().put("error", "bad_pin"))
+        }
+    }
+
+    private fun isAuthed(session: IHTTPSession): Boolean {
+        val token = tokenFromCookie(session) ?: return false
+        return token in tokens
+    }
+
+    private fun tokenFromCookie(session: IHTTPSession): String? {
+        val cookie = session.headers["cookie"] ?: return null
+        return cookie.split(";")
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("$COOKIE=") }
+            ?.substringAfter("=")
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun newToken(): String {
+        val bytes = ByteArray(24)
+        random.nextBytes(bytes)
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun isLanClient(session: IHTTPSession): Boolean = runCatching {
+        val ip = session.remoteIpAddress ?: return true // NanoHTTPD may not expose it; fail open on LAN bind
+        if (ip.isBlank()) return true
+        val addr = InetAddress.getByName(ip)
+        addr.isSiteLocalAddress || addr.isLoopbackAddress || addr.isLinkLocalAddress
+    }.getOrDefault(true)
+
+    // ── API routing ─────────────────────────────────────────────────────────────────────────────
+
+    private fun handleApi(session: IHTTPSession, uri: String): Response = runBlocking {
+        when (uri) {
+            "/api/systems" -> apiSystems()
+            "/api/folders" -> apiFolders()
+            "/api/games" -> apiGames()
+            "/api/upload/rom" -> apiUploadRom(session)
+            "/api/upload/bios" -> apiUploadBios(session)
+            "/api/upload/media" -> apiUploadMedia(session)
+            "/api/upload/background" -> apiUploadBackground(session)
+            "/api/settings/export" -> apiSettingsExport()
+            "/api/settings/import" -> apiSettingsImport(session)
+            else -> text(Response.Status.NOT_FOUND, "Not found")
+        }
+    }
+
+    private suspend fun romRootDir(): File? {
+        val raw = deps.settings.romRootPath.first()
+        if (raw.isBlank()) return null
+        return File(StorageUtils.resolveStoredPath(raw))
+    }
+
+    private suspend fun apiSystems(): Response {
+        val root = romRootDir()
+        val existing = root?.let { deps.destinationResolver.existingPlatformFolders(it) } ?: emptyMap()
+        val arr = JSONArray()
+        PlatformDefinitions.ALL.forEach { p ->
+            val folders = existing[p.id].orEmpty().sortedBy { it.depth }
+            arr.put(
+                JSONObject()
+                    .put("id", p.id)
+                    .put("name", p.displayName)
+                    .put("canonicalFolder", p.folderNames.first())
+                    .put("existing", JSONArray(folders.map { it.relativePath }))
+            )
+        }
+        return json(Response.Status.OK, JSONObject().put("systems", arr).put("hasRomRoot", root != null))
+    }
+
+    private suspend fun apiFolders(): Response {
+        val root = romRootDir() ?: return json(Response.Status.OK, JSONObject().put("folders", JSONArray()))
+        val arr = JSONArray()
+        deps.destinationResolver.existingPlatformFolders(root).values.flatten()
+            .sortedBy { it.relativePath }
+            .forEach {
+                arr.put(
+                    JSONObject()
+                        .put("platformId", it.platformId)
+                        .put("name", it.displayName)
+                        .put("path", it.relativePath)
+                )
+            }
+        return json(Response.Status.OK, JSONObject().put("folders", arr))
+    }
+
+    private suspend fun apiGames(): Response {
+        val games = deps.gameRepository.getAllGames().first()
+        val arr = JSONArray()
+        games.forEach {
+            arr.put(
+                JSONObject()
+                    .put("id", it.id)
+                    .put("title", it.title)
+                    .put("platformId", it.platformId)
+            )
+        }
+        return json(Response.Status.OK, JSONObject().put("games", arr))
+    }
+
+    private suspend fun apiUploadRom(session: IHTTPSession): Response {
+        val root = romRootDir() ?: throw IllegalArgumentException("No ROM folder is configured")
+        val system = param(session, "system") ?: throw IllegalArgumentException("Missing system")
+        val name = deps.destinationResolver.sanitizeFilename(
+            param(session, "name") ?: throw IllegalArgumentException("Missing name")
+        )
+        val dest = param(session, "dest")
+        val dir = deps.destinationResolver.resolveRomDir(root, system, dest)
+        dir.mkdirs()
+        val target = File(dir, name)
+        val bytes = receiveToFile(session, target)
+        onEvent("Received $name (${humanSize(bytes)}) → ${dir.name}/")
+        onRomUploaded()
+        return json(Response.Status.OK, JSONObject().put("ok", true).put("path", target.absolutePath))
+    }
+
+    private suspend fun apiUploadBios(session: IHTTPSession): Response {
+        val biosDir = biosRootDir() ?: throw IllegalArgumentException("No BIOS or ROM folder is configured")
+        biosDir.mkdirs()
+        val name = deps.destinationResolver.sanitizeFilename(
+            param(session, "name") ?: throw IllegalArgumentException("Missing name")
+        )
+        val dest = param(session, "dest")
+        val dir = if (dest.isNullOrBlank()) biosDir
+        else deps.destinationResolver.containedDir(biosDir, dest)
+            ?: throw IllegalArgumentException("Destination escapes the BIOS root")
+        dir.mkdirs()
+        val target = File(dir, name)
+        val bytes = receiveToFile(session, target)
+        onEvent("Received BIOS $name (${humanSize(bytes)})")
+        return json(Response.Status.OK, JSONObject().put("ok", true).put("path", target.absolutePath))
+    }
+
+    private suspend fun biosRootDir(): File? {
+        val configured = deps.settings.biosFolderPath.first()
+        if (configured.isNotBlank()) return File(StorageUtils.resolveStoredPath(configured))
+        val root = romRootDir() ?: return null
+        return File(root, "bios")
+    }
+
+    private suspend fun apiUploadMedia(session: IHTTPSession): Response {
+        val gameId = param(session, "gameId")?.toLongOrNull()
+            ?: throw IllegalArgumentException("Missing gameId")
+        val type = when (param(session, "type")?.lowercase()) {
+            "boxart", "box" -> MediaUploadType.BOX_ART
+            "screenshot", "shot" -> MediaUploadType.SCREENSHOT
+            "wheel", "logo" -> MediaUploadType.WHEEL
+            "miximage", "mix" -> MediaUploadType.MIXIMAGE
+            "video" -> MediaUploadType.VIDEO
+            else -> throw IllegalArgumentException("Unknown media type")
+        }
+        val bytes = receiveToBytes(session, MAX_MEDIA_BYTES)
+        val path = deps.mediaRepository.saveUploadedMedia(gameId, type, bytes)
+            ?: throw IllegalArgumentException("Could not save media (unsupported file?)")
+        onEvent("Received media for game #$gameId")
+        return json(Response.Status.OK, JSONObject().put("ok", true).put("path", path))
+    }
+
+    private suspend fun apiUploadBackground(session: IHTTPSession): Response {
+        val bytes = receiveToBytes(session, MAX_MEDIA_BYTES)
+        val temp = File.createTempFile("wt_bg_", ".img", deps.context.cacheDir)
+        try {
+            temp.outputStream().use { it.write(bytes) }
+            val path = deps.convertBackground.fromFile(temp)
+                ?: throw IllegalArgumentException("Could not process image")
+            deps.settings.setBackgroundImagePath(path)
+            deps.settings.setBackgroundImageEnabled(true)
+            onEvent("Applied a new background image")
+            return json(Response.Status.OK, JSONObject().put("ok", true))
+        } finally {
+            temp.delete()
+        }
+    }
+
+    private suspend fun apiSettingsExport(): Response {
+        val payload = deps.exportSettings()
+        val r = json(Response.Status.OK, payload)
+        r.addHeader("Content-Disposition", "attachment; filename=\"eor-settings.json\"")
+        return r
+    }
+
+    private suspend fun apiSettingsImport(session: IHTTPSession): Response {
+        val body = receiveToBytes(session, MAX_TEXT_BYTES).toString(Charsets.UTF_8)
+        val count = deps.importSettings(body)
+        onEvent("Imported $count settings")
+        return json(Response.Status.OK, JSONObject().put("ok", true).put("applied", count))
+    }
+
+    // ── Body I/O ────────────────────────────────────────────────────────────────────────────────
+
+    /** Stream the request body to [dest] via a `.part` file, then atomically rename. Returns bytes. */
+    private fun receiveToFile(session: IHTTPSession, dest: File): Long {
+        dest.parentFile?.mkdirs()
+        val part = File(dest.parentFile, "${dest.name}.part")
+        val declared = session.headers["content-length"]?.toLongOrNull() ?: -1L
+        var total = 0L
+        try {
+            part.outputStream().use { out ->
+                copyBody(session.inputStream, declared) { buf, len -> out.write(buf, 0, len); total += len }
+            }
+            if (dest.exists()) dest.delete()
+            if (!part.renameTo(dest)) throw IOException("Could not finalize upload")
+        } catch (e: Exception) {
+            part.delete()
+            throw e
+        }
+        return total
+    }
+
+    private fun receiveToBytes(session: IHTTPSession, maxBytes: Long): ByteArray {
+        val declared = session.headers["content-length"]?.toLongOrNull() ?: -1L
+        require(declared <= maxBytes) { "Upload too large" }
+        val out = ByteArrayOutputStream(if (declared in 0..maxBytes) declared.toInt() else 8192)
+        var total = 0L
+        copyBody(session.inputStream, declared) { buf, len ->
+            total += len
+            require(total <= maxBytes) { "Upload too large" }
+            out.write(buf, 0, len)
+        }
+        return out.toByteArray()
+    }
+
+    private inline fun copyBody(input: InputStream, declared: Long, sink: (ByteArray, Int) -> Unit) {
+        val buf = ByteArray(64 * 1024)
+        if (declared >= 0) {
+            var remaining = declared
+            while (remaining > 0) {
+                val toRead = minOf(buf.size.toLong(), remaining).toInt()
+                val r = input.read(buf, 0, toRead)
+                if (r < 0) break
+                sink(buf, r)
+                remaining -= r
+            }
+        } else {
+            while (true) {
+                val r = input.read(buf)
+                if (r < 0) break
+                sink(buf, r)
+            }
+        }
+    }
+
+    // ── Static assets ─────────────────────────────────────────────────────────────────────────────
+
+    private fun serveAsset(uri: String): Response {
+        val path = if (uri == "/" || uri.isBlank()) "index.html" else uri.trimStart('/')
+        // Only serve from the bundled asset folder; reject traversal.
+        if (path.contains("..")) return text(Response.Status.FORBIDDEN, "Forbidden")
+        return try {
+            val stream = deps.context.assets.open("webtransfer/$path")
+            newChunkedResponse(Response.Status.OK, mimeFor(path), stream)
+        } catch (e: IOException) {
+            text(Response.Status.NOT_FOUND, "Not found")
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────────────────────
+
+    private fun param(session: IHTTPSession, key: String): String? =
+        session.parameters[key]?.firstOrNull()?.takeIf { it.isNotBlank() }
+
+    private fun json(status: Response.Status, obj: JSONObject): Response = json(status, obj.toString())
+    private fun json(status: Response.Status, body: String): Response =
+        newFixedLengthResponse(status, "application/json; charset=utf-8", body)
+
+    private fun text(status: Response.Status, body: String): Response =
+        newFixedLengthResponse(status, "text/plain; charset=utf-8", body)
+
+    private fun constantTimeEquals(a: String, b: String): Boolean {
+        val ab = a.toByteArray(); val bb = b.toByteArray()
+        var result = ab.size xor bb.size
+        for (i in ab.indices) result = result or (ab[i].toInt() xor bb.getOrElse(i) { 0.toByte() }.toInt())
+        return result == 0
+    }
+
+    private fun humanSize(bytes: Long): String = when {
+        bytes >= 1_000_000_000 -> "%.1f GB".format(bytes / 1e9)
+        bytes >= 1_000_000 -> "%.1f MB".format(bytes / 1e6)
+        bytes >= 1_000 -> "%.0f KB".format(bytes / 1e3)
+        else -> "$bytes B"
+    }
+
+    private fun mimeFor(path: String): String = when (path.substringAfterLast('.').lowercase()) {
+        "html" -> "text/html; charset=utf-8"
+        "js" -> "application/javascript; charset=utf-8"
+        "css" -> "text/css; charset=utf-8"
+        "svg" -> "image/svg+xml"
+        "png" -> "image/png"
+        "ico" -> "image/x-icon"
+        "json" -> "application/json; charset=utf-8"
+        else -> "application/octet-stream"
+    }
+
+    companion object {
+        const val COOKIE = "eor_wt"
+        const val MAX_FAILED_ATTEMPTS = 5
+        const val LOCKOUT_MS = 60_000L
+        const val MAX_TEXT_BYTES = 5L * 1024 * 1024          // pair / settings JSON
+        const val MAX_MEDIA_BYTES = 512L * 1024 * 1024        // per-game media / background image
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferService.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferService.kt
@@ -1,0 +1,77 @@
+package com.gamelaunch.frontend.data.webserver
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.gamelaunch.frontend.R
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+/**
+ * Foreground service that hosts the Web Transfer LAN server. Keeps the server alive while eOr is
+ * backgrounded (so a big transfer doesn't die when the screen turns off) behind a persistent
+ * notification that shows the connect URL. Mirrors `SyncthingService`.
+ */
+@AndroidEntryPoint
+class WebTransferService : Service() {
+
+    @Inject lateinit var manager: WebTransferManager
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        runCatching { manager.onServiceStart() }
+            .onFailure { Log.e(TAG, "Failed to start Web Transfer server", it) }
+        startForegroundCompat()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        runCatching { manager.onServiceStop() }
+        super.onDestroy()
+    }
+
+    private fun startForegroundCompat() {
+        val nm = getSystemService(NotificationManager::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            nm.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, "Web Transfer", NotificationManager.IMPORTANCE_LOW)
+            )
+        }
+        val url = manager.state.value.url.ifBlank { "Starting…" }
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_donkey_silhouette)
+            .setContentTitle("Web Transfer is on")
+            .setContentText("Open $url in your computer's browser")
+            .setStyle(NotificationCompat.BigTextStyle().bigText("Open $url in your computer's browser to send games and files."))
+            .setOngoing(true)
+            .build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIF_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            startForeground(NOTIF_ID, notification)
+        }
+    }
+
+    companion object {
+        private const val TAG = "WebTransferService"
+        private const val CHANNEL_ID = "web_transfer"
+        private const val NOTIF_ID = 2002
+
+        fun start(context: Context) {
+            context.startForegroundService(Intent(context, WebTransferService::class.java))
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, WebTransferService::class.java))
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/MediaRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/MediaRepository.kt
@@ -3,6 +3,9 @@ package com.gamelaunch.frontend.domain.repository
 import com.gamelaunch.frontend.domain.model.GameMedia
 import kotlinx.coroutines.flow.Flow
 
+/** Kinds of per-game media a user can push from the Web Transfer page. */
+enum class MediaUploadType { BOX_ART, SCREENSHOT, WHEEL, MIXIMAGE, VIDEO }
+
 interface MediaRepository {
     suspend fun getMediaForGame(gameId: Long): GameMedia?
     fun observeMediaForGame(gameId: Long): Flow<GameMedia?>
@@ -14,6 +17,8 @@ interface MediaRepository {
     suspend fun downloadAndCacheBoxArt(gameId: Long, url: String): String?
     /** Stores artwork decoded locally from a game package. */
     suspend fun saveEmbeddedBoxArt(gameId: Long, bytes: ByteArray): String?
+    /** Stores media bytes uploaded via Web Transfer for [gameId]; returns the stored path or null. */
+    suspend fun saveUploadedMedia(gameId: Long, type: MediaUploadType, bytes: ByteArray): String?
     suspend fun downloadAndCacheVideo(gameId: Long, url: String): String?
     suspend fun downloadAndCacheScreenshot(gameId: Long, url: String): String?
     suspend fun downloadAndCacheWheelLogo(gameId: Long, url: String): String?

--- a/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/repository/SettingsRepository.kt
@@ -37,6 +37,10 @@ interface SettingsRepository {
     val saveSyncEnabled: Flow<Boolean>
     val syncWifiOnly: Flow<Boolean>
     val syncChargingOnly: Flow<Boolean>
+    val webTransferEnabled: Flow<Boolean>
+    val webTransferPort: Flow<Int>
+    /** Destination for BIOS/firmware uploaded via Web Transfer. Empty = "<romRoot>/bios". */
+    val biosFolderPath: Flow<String>
     val systemSort: Flow<List<SystemSort>>
     val gameSort: Flow<GameSort>
     /** Per-system grid column overrides, keyed by platform id (0/absent = auto-fit). */
@@ -92,6 +96,9 @@ interface SettingsRepository {
     suspend fun setSaveSyncEnabled(enabled: Boolean)
     suspend fun setSyncWifiOnly(v: Boolean)
     suspend fun setSyncChargingOnly(v: Boolean)
+    suspend fun setWebTransferEnabled(enabled: Boolean)
+    suspend fun setWebTransferPort(port: Int)
+    suspend fun setBiosFolderPath(path: String)
     suspend fun clearBackgroundImage()
     suspend fun setSystemSort(keys: List<SystemSort>)
     suspend fun setGameSort(sort: GameSort)

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ConvertBackgroundImageUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ConvertBackgroundImageUseCase.kt
@@ -34,23 +34,34 @@ class ConvertBackgroundImageUseCase @Inject constructor(
 
     /** @return absolute path of the saved mask PNG, or null if the image could not be processed. */
     suspend operator fun invoke(uri: Uri): String? = withContext(Dispatchers.IO) {
-        runCatching {
-            val source = decodeDownsampled(uri) ?: return@runCatching null
-            val mask = toAlphaMask(source)
-            if (mask !== source) source.recycle()
-
-            val dir = File(context.filesDir, "branding").apply { mkdirs() }
-            // Clear any previous mask so we don't accumulate files, and so the new path differs
-            // (a stable filename would defeat the path-keyed decode cache in the UI).
-            dir.listFiles()?.forEach { it.delete() }
-            val dest = File(dir, "background_mask_${System.currentTimeMillis()}.png")
-            dest.outputStream().use { out ->
-                mask.compress(Bitmap.CompressFormat.PNG, 100, out)
-            }
-            mask.recycle()
-            dest.absolutePath
-        }.getOrNull()
+        processAndSave(decodeDownsampled(uri))
     }
+
+    /**
+     * Same conversion as [invoke], but from a plain [File] — used by Web Transfer, which receives the
+     * uploaded image as a temp file rather than a content URI.
+     */
+    suspend fun fromFile(file: File): String? = withContext(Dispatchers.IO) {
+        processAndSave(decodeDownsampled(file))
+    }
+
+    /** Turn a decoded source bitmap into the saved alpha-mask PNG; returns its path, or null. */
+    private fun processAndSave(source: Bitmap?): String? = runCatching {
+        if (source == null) return@runCatching null
+        val mask = toAlphaMask(source)
+        if (mask !== source) source.recycle()
+
+        val dir = File(context.filesDir, "branding").apply { mkdirs() }
+        // Clear any previous mask so we don't accumulate files, and so the new path differs
+        // (a stable filename would defeat the path-keyed decode cache in the UI).
+        dir.listFiles()?.forEach { it.delete() }
+        val dest = File(dir, "background_mask_${System.currentTimeMillis()}.png")
+        dest.outputStream().use { out ->
+            mask.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        mask.recycle()
+        dest.absolutePath
+    }.getOrNull()
 
     /** Decode the URI, downsampling so the longest edge is at most [MAX_DIMENSION]. */
     private fun decodeDownsampled(uri: Uri): Bitmap? {
@@ -71,6 +82,24 @@ class ConvertBackgroundImageUseCase @Inject constructor(
         return context.contentResolver.openInputStream(uri)?.use {
             BitmapFactory.decodeStream(it, null, opts)
         }
+    }
+
+    /** Decode a file, downsampling so the longest edge is at most [MAX_DIMENSION]. */
+    private fun decodeDownsampled(file: File): Bitmap? {
+        if (!file.exists()) return null
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, bounds)
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+        var sample = 1
+        val longest = maxOf(bounds.outWidth, bounds.outHeight)
+        while (longest / sample > MAX_DIMENSION) sample *= 2
+
+        val opts = BitmapFactory.Options().apply {
+            inSampleSize = sample
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+        }
+        return BitmapFactory.decodeFile(file.absolutePath, opts)
     }
 
     /** Map each pixel to white-with-alpha, where alpha follows how far the pixel is from white. */

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ExportSettingsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ExportSettingsUseCase.kt
@@ -1,0 +1,64 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.first
+import org.json.JSONArray
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Serialises the safe subset of app settings ([SettingsTransfer.EXPORTED_KEYS]) to a JSON string that
+ * can be downloaded from the Web Transfer page and re-imported on another device. Credentials, tokens
+ * and the Locked-Mode PIN are never included (see [SettingsTransfer.SENSITIVE_KEYS]).
+ */
+class ExportSettingsUseCase @Inject constructor(
+    private val settings: SettingsRepository
+) {
+    suspend operator fun invoke(): String {
+        val scraper = settings.scraperConfig.first()
+        val json = JSONObject().apply {
+            put("format", SettingsTransfer.FORMAT)
+            put("version", SettingsTransfer.VERSION)
+
+            put(SettingsTransfer.ROM_ROOT_PATH, settings.romRootPath.first())
+            put(SettingsTransfer.BIOS_FOLDER_PATH, settings.biosFolderPath.first())
+            put(SettingsTransfer.MEDIA_STORAGE_PATH, settings.mediaStoragePath.first())
+            put(SettingsTransfer.STEAM_LIBRARY_PATH, settings.steamLibraryPath.first())
+
+            put(SettingsTransfer.LAYOUT_MODE, settings.layoutMode.first().name)
+            put(SettingsTransfer.DARK_MODE, settings.darkMode.first())
+            put(SettingsTransfer.CARD_COLOR_SCHEME, settings.cardColorScheme.first().name)
+            put(SettingsTransfer.CARD_MONO_COLOR, settings.cardMonoColor.first())
+
+            put(SettingsTransfer.BG_IMAGE_ENABLED, settings.backgroundImageEnabled.first())
+            put(SettingsTransfer.BG_IMAGE_MODE, settings.backgroundImageMode.first())
+            put(SettingsTransfer.BG_IMAGE_OPACITY, settings.backgroundImageOpacity.first().toDouble())
+
+            put(SettingsTransfer.VIDEO_AUTOPLAY_DELAY_MS, settings.videoAutoplayDelayMs.first())
+            put(SettingsTransfer.VIDEO_MUTED, settings.videoMuted.first())
+
+            put(SettingsTransfer.SHOW_RECENTLY_PLAYED, settings.showRecentlyPlayed.first())
+            put(SettingsTransfer.SHOW_FAVORITES, settings.showFavorites.first())
+            put(SettingsTransfer.SHOW_RETRO_ACHIEVEMENTS, settings.showRetroAchievements.first())
+
+            put(SettingsTransfer.DUAL_SCREEN_ENABLED, settings.dualScreenEnabled.first())
+            put(SettingsTransfer.DUAL_SCREEN_SWAP, settings.dualScreenSwap.first())
+            put(SettingsTransfer.GAME_LAUNCH_ON_TOP, settings.gameLaunchOnTop.first())
+            put(SettingsTransfer.PERFORMANCE_MODE, settings.performanceMode.first())
+
+            put(SettingsTransfer.PREFERRED_REGION, scraper.preferredRegion)
+            put(SettingsTransfer.SCRAPE_METADATA, scraper.scrapeMetadata)
+            put(SettingsTransfer.SCRAPE_BOX_ART, scraper.scrapeBoxArt)
+            put(SettingsTransfer.SCRAPE_SCREENSHOTS, scraper.scrapeScreenshots)
+            put(SettingsTransfer.SCRAPE_WHEEL_LOGOS, scraper.scrapeWheelLogos)
+            put(SettingsTransfer.SCRAPE_VIDEOS, scraper.scrapeVideos)
+
+            put(SettingsTransfer.GAME_SORT, settings.gameSort.first().name)
+            put(SettingsTransfer.SYSTEM_SORT, JSONArray(settings.systemSort.first().map { it.name }))
+            put(SettingsTransfer.MASTER_GAME_GRID_COLUMNS, settings.masterGameGridColumns.first())
+            put(SettingsTransfer.HIDDEN_PLATFORMS, JSONArray(settings.hiddenPlatforms.first().toList()))
+            put(SettingsTransfer.EMULATOR_UPDATE_NOTIFICATIONS, settings.emulatorUpdateNotifications.first())
+        }
+        return json.toString(2)
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportSettingsUseCase.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/ImportSettingsUseCase.kt
@@ -1,0 +1,88 @@
+package com.gamelaunch.frontend.domain.usecase
+
+import com.gamelaunch.frontend.domain.model.GameSort
+import com.gamelaunch.frontend.domain.platform.SystemSort
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import com.gamelaunch.frontend.ui.theme.CardColorScheme
+import com.gamelaunch.frontend.ui.theme.LayoutMode
+import kotlinx.coroutines.flow.first
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Applies a settings JSON produced by [ExportSettingsUseCase]. Only keys in
+ * [SettingsTransfer.EXPORTED_KEYS] are read; anything else in the document is ignored, so a tampered
+ * file can never reach a credential or the Locked-Mode PIN. Returns the number of settings applied.
+ */
+class ImportSettingsUseCase @Inject constructor(
+    private val settings: SettingsRepository
+) {
+    suspend operator fun invoke(jsonText: String): Int {
+        val json = JSONObject(jsonText)
+        require(json.optString("format") == SettingsTransfer.FORMAT) { "Not an eOr settings file" }
+
+        var applied = 0
+        suspend fun step(key: String, block: suspend (JSONObject) -> Unit) {
+            if (!json.has(key) || key !in SettingsTransfer.EXPORTED_KEYS) return
+            runCatching { block(json); applied++ }
+        }
+
+        step(SettingsTransfer.ROM_ROOT_PATH) { settings.setRomRootPath(it.getString(SettingsTransfer.ROM_ROOT_PATH)) }
+        step(SettingsTransfer.BIOS_FOLDER_PATH) { settings.setBiosFolderPath(it.getString(SettingsTransfer.BIOS_FOLDER_PATH)) }
+        step(SettingsTransfer.MEDIA_STORAGE_PATH) { settings.setMediaStoragePath(it.getString(SettingsTransfer.MEDIA_STORAGE_PATH)) }
+        step(SettingsTransfer.STEAM_LIBRARY_PATH) { settings.setSteamLibraryPath(it.getString(SettingsTransfer.STEAM_LIBRARY_PATH)) }
+
+        step(SettingsTransfer.LAYOUT_MODE) { settings.setLayoutMode(LayoutMode.valueOf(it.getString(SettingsTransfer.LAYOUT_MODE))) }
+        step(SettingsTransfer.DARK_MODE) { settings.setDarkMode(it.getBoolean(SettingsTransfer.DARK_MODE)) }
+        step(SettingsTransfer.CARD_COLOR_SCHEME) { settings.setCardColorScheme(CardColorScheme.fromName(it.getString(SettingsTransfer.CARD_COLOR_SCHEME))) }
+        step(SettingsTransfer.CARD_MONO_COLOR) { settings.setCardMonoColor(it.getInt(SettingsTransfer.CARD_MONO_COLOR)) }
+
+        step(SettingsTransfer.BG_IMAGE_ENABLED) { settings.setBackgroundImageEnabled(it.getBoolean(SettingsTransfer.BG_IMAGE_ENABLED)) }
+        step(SettingsTransfer.BG_IMAGE_MODE) { settings.setBackgroundImageMode(it.getString(SettingsTransfer.BG_IMAGE_MODE)) }
+        step(SettingsTransfer.BG_IMAGE_OPACITY) { settings.setBackgroundImageOpacity(it.getDouble(SettingsTransfer.BG_IMAGE_OPACITY).toFloat()) }
+
+        step(SettingsTransfer.VIDEO_AUTOPLAY_DELAY_MS) { settings.setVideoAutoplayDelayMs(it.getLong(SettingsTransfer.VIDEO_AUTOPLAY_DELAY_MS)) }
+        step(SettingsTransfer.VIDEO_MUTED) { settings.setVideoMuted(it.getBoolean(SettingsTransfer.VIDEO_MUTED)) }
+
+        step(SettingsTransfer.SHOW_RECENTLY_PLAYED) { settings.setShowRecentlyPlayed(it.getBoolean(SettingsTransfer.SHOW_RECENTLY_PLAYED)) }
+        step(SettingsTransfer.SHOW_FAVORITES) { settings.setShowFavorites(it.getBoolean(SettingsTransfer.SHOW_FAVORITES)) }
+        step(SettingsTransfer.SHOW_RETRO_ACHIEVEMENTS) { settings.setShowRetroAchievements(it.getBoolean(SettingsTransfer.SHOW_RETRO_ACHIEVEMENTS)) }
+
+        step(SettingsTransfer.DUAL_SCREEN_ENABLED) { settings.setDualScreenEnabled(it.getBoolean(SettingsTransfer.DUAL_SCREEN_ENABLED)) }
+        step(SettingsTransfer.DUAL_SCREEN_SWAP) { settings.setDualScreenSwap(it.getBoolean(SettingsTransfer.DUAL_SCREEN_SWAP)) }
+        step(SettingsTransfer.GAME_LAUNCH_ON_TOP) { settings.setGameLaunchOnTop(it.getBoolean(SettingsTransfer.GAME_LAUNCH_ON_TOP)) }
+        step(SettingsTransfer.PERFORMANCE_MODE) { settings.setPerformanceMode(it.getBoolean(SettingsTransfer.PERFORMANCE_MODE)) }
+
+        step(SettingsTransfer.PREFERRED_REGION) { settings.setPreferredRegion(it.getString(SettingsTransfer.PREFERRED_REGION)) }
+
+        // Scrape options travel as a group: merge present keys onto the current config.
+        if (SettingsTransfer.EXPORTED_KEYS.any { json.has(it) && it.startsWith("scrape_") }) {
+            runCatching {
+                val current = settings.scraperConfig.first()
+                settings.updateScraperOptions(
+                    scrapeMetadata = json.optBoolean(SettingsTransfer.SCRAPE_METADATA, current.scrapeMetadata),
+                    scrapeBoxArt = json.optBoolean(SettingsTransfer.SCRAPE_BOX_ART, current.scrapeBoxArt),
+                    scrapeScreenshots = json.optBoolean(SettingsTransfer.SCRAPE_SCREENSHOTS, current.scrapeScreenshots),
+                    scrapeWheelLogos = json.optBoolean(SettingsTransfer.SCRAPE_WHEEL_LOGOS, current.scrapeWheelLogos),
+                    scrapeVideos = json.optBoolean(SettingsTransfer.SCRAPE_VIDEOS, current.scrapeVideos),
+                )
+                applied++
+            }
+        }
+
+        step(SettingsTransfer.GAME_SORT) { settings.setGameSort(GameSort.fromName(it.getString(SettingsTransfer.GAME_SORT))) }
+        step(SettingsTransfer.SYSTEM_SORT) {
+            val arr = it.getJSONArray(SettingsTransfer.SYSTEM_SORT)
+            val keys = (0 until arr.length()).mapNotNull { i -> SystemSort.fromName(arr.getString(i)) }
+            settings.setSystemSort(keys)
+        }
+        step(SettingsTransfer.MASTER_GAME_GRID_COLUMNS) { settings.setMasterGameGridColumns(it.getInt(SettingsTransfer.MASTER_GAME_GRID_COLUMNS)) }
+        step(SettingsTransfer.HIDDEN_PLATFORMS) {
+            val arr = it.getJSONArray(SettingsTransfer.HIDDEN_PLATFORMS)
+            for (i in 0 until arr.length()) settings.setPlatformHidden(arr.getString(i), true)
+        }
+        step(SettingsTransfer.EMULATOR_UPDATE_NOTIFICATIONS) { settings.setEmulatorUpdateNotifications(it.getBoolean(SettingsTransfer.EMULATOR_UPDATE_NOTIFICATIONS)) }
+
+        return applied
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/domain/usecase/SettingsTransfer.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/domain/usecase/SettingsTransfer.kt
@@ -1,0 +1,75 @@
+package com.gamelaunch.frontend.domain.usecase
+
+/**
+ * Shared contract for exporting/importing app settings over Web Transfer.
+ *
+ * [EXPORTED_KEYS] is the exact, deliberate whitelist of settings we move between devices — appearance,
+ * layout, library paths, scraper *options* and sort preferences. [SENSITIVE_KEYS] enumerates values
+ * that must NEVER leave the device (credentials, tokens, the Locked-Mode PIN) or that are
+ * device-specific / would auto-start a network service. The two sets are asserted disjoint by a unit
+ * test, so the export can never accidentally include a secret.
+ */
+object SettingsTransfer {
+    const val FORMAT = "eor-settings"
+    const val VERSION = 1
+
+    // JSON keys (reuse the DataStore names for clarity).
+    const val ROM_ROOT_PATH = "rom_root_path"
+    const val BIOS_FOLDER_PATH = "bios_folder_path"
+    const val MEDIA_STORAGE_PATH = "media_storage_path"
+    const val STEAM_LIBRARY_PATH = "steam_library_path"
+    const val LAYOUT_MODE = "layout_mode"
+    const val DARK_MODE = "dark_mode"
+    const val CARD_COLOR_SCHEME = "card_color_scheme"
+    const val CARD_MONO_COLOR = "card_mono_color"
+    const val BG_IMAGE_ENABLED = "background_image_enabled"
+    const val BG_IMAGE_MODE = "background_image_mode"
+    const val BG_IMAGE_OPACITY = "background_image_opacity"
+    const val VIDEO_AUTOPLAY_DELAY_MS = "video_autoplay_delay_ms"
+    const val VIDEO_MUTED = "video_muted"
+    const val SHOW_RECENTLY_PLAYED = "show_recently_played"
+    const val SHOW_FAVORITES = "show_favorites"
+    const val SHOW_RETRO_ACHIEVEMENTS = "show_retro_achievements"
+    const val DUAL_SCREEN_ENABLED = "dual_screen_enabled"
+    const val DUAL_SCREEN_SWAP = "dual_screen_swap"
+    const val GAME_LAUNCH_ON_TOP = "game_launch_on_top"
+    const val PERFORMANCE_MODE = "performance_mode"
+    const val PREFERRED_REGION = "preferred_region"
+    const val SCRAPE_METADATA = "scrape_metadata"
+    const val SCRAPE_BOX_ART = "scrape_box_art"
+    const val SCRAPE_SCREENSHOTS = "scrape_screenshots"
+    const val SCRAPE_WHEEL_LOGOS = "scrape_wheel_logos"
+    const val SCRAPE_VIDEOS = "scrape_videos"
+    const val GAME_SORT = "game_sort"
+    const val SYSTEM_SORT = "system_sort"
+    const val MASTER_GAME_GRID_COLUMNS = "master_game_grid_columns"
+    const val HIDDEN_PLATFORMS = "hidden_platforms"
+    const val EMULATOR_UPDATE_NOTIFICATIONS = "emulator_update_notifications"
+
+    val EXPORTED_KEYS: Set<String> = linkedSetOf(
+        ROM_ROOT_PATH, BIOS_FOLDER_PATH, MEDIA_STORAGE_PATH, STEAM_LIBRARY_PATH,
+        LAYOUT_MODE, DARK_MODE, CARD_COLOR_SCHEME, CARD_MONO_COLOR,
+        BG_IMAGE_ENABLED, BG_IMAGE_MODE, BG_IMAGE_OPACITY,
+        VIDEO_AUTOPLAY_DELAY_MS, VIDEO_MUTED,
+        SHOW_RECENTLY_PLAYED, SHOW_FAVORITES, SHOW_RETRO_ACHIEVEMENTS,
+        DUAL_SCREEN_ENABLED, DUAL_SCREEN_SWAP, GAME_LAUNCH_ON_TOP, PERFORMANCE_MODE,
+        PREFERRED_REGION, SCRAPE_METADATA, SCRAPE_BOX_ART, SCRAPE_SCREENSHOTS,
+        SCRAPE_WHEEL_LOGOS, SCRAPE_VIDEOS,
+        GAME_SORT, SYSTEM_SORT, MASTER_GAME_GRID_COLUMNS, HIDDEN_PLATFORMS,
+        EMULATOR_UPDATE_NOTIFICATIONS,
+    )
+
+    /**
+     * Never exported: credentials/secrets, the Locked-Mode PIN, device-specific paths, and flags that
+     * would silently start a network service on the receiving device.
+     */
+    val SENSITIVE_KEYS: Set<String> = setOf(
+        "ss_id", "ss_password",
+        "ra_username", "ra_api_key", "ra_token", "ra_points", "ra_softcore_points",
+        "locked_mode_pin", "locked_mode_enabled", "locked_mode_active",
+        "locked_mode_allowed_app_packages",
+        "background_image_path",
+        "save_sync_enabled", "friends_enabled", "friend_display_name",
+        "web_transfer_enabled", "web_transfer_port",
+    )
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/AppNavGraph.kt
@@ -26,6 +26,7 @@ import com.gamelaunch.frontend.ui.screen.settings.LockedModeSettingsScreen
 import com.gamelaunch.frontend.ui.screen.settings.MediaSettingsScreen
 import com.gamelaunch.frontend.ui.screen.settings.RetroAchievementsSettingsScreen
 import com.gamelaunch.frontend.ui.screen.settings.SaveSyncSettingsScreen
+import com.gamelaunch.frontend.ui.screen.settings.WebTransferSettingsScreen
 import com.gamelaunch.frontend.ui.screen.settings.SettingsIndexScreen
 import com.gamelaunch.frontend.ui.screen.settings.SettingsViewModel
 import com.gamelaunch.frontend.domain.lockedmode.LockedModeState
@@ -188,6 +189,12 @@ fun AppNavGraph(
             composable(Screen.SettingsSaveSync.route) {
                 ProtectedRoute(lockedModeState, navController) {
                     SaveSyncSettingsScreen(onBack = { navController.backOrHome() })
+                }
+            }
+
+            composable(Screen.SettingsWebTransfer.route) {
+                ProtectedRoute(lockedModeState, navController) {
+                    WebTransferSettingsScreen(onBack = { navController.backOrHome() })
                 }
             }
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/navigation/Screen.kt
@@ -17,6 +17,7 @@ sealed class Screen(val route: String) {
     object SettingsMedia : Screen("settings_media")
     object SettingsRetroAchievements : Screen("settings_retro_achievements")
     object SettingsSaveSync : Screen("settings_save_sync")
+    object SettingsWebTransfer : Screen("settings_web_transfer")
     object SettingsFriends : Screen("settings_friends")
     object SettingsLocked : Screen("settings_locked")
 

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/SettingsIndexScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.PermMedia
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.VideogameAsset
+import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -72,6 +73,10 @@ enum class SettingsCategory(
     SAVE_SYNC(
         "settings_save_sync", "Save Sync",
         "Sync saves across devices", Icons.Default.Sync
+    ),
+    WEB_TRANSFER(
+        "settings_web_transfer", "Web Transfer",
+        "Send files from your computer's browser", Icons.Default.Wifi
     ),
     FRIENDS(
         "settings_friends", "Friends",

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/WebTransferSettingsScreen.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/WebTransferSettingsScreen.kt
@@ -1,0 +1,121 @@
+package com.gamelaunch.frontend.ui.screen.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.gamelaunch.frontend.ui.component.QrCode
+import com.gamelaunch.frontend.ui.theme.ElectricBlue
+
+/**
+ * Web Transfer settings: one master toggle that runs a small web server on the device so a computer on
+ * the same Wi-Fi can open a page and drag-and-drop games, BIOS, media, background images and settings.
+ * When running it shows the connect URL, a scannable QR of it, and the pairing PIN.
+ */
+@Composable
+fun WebTransferSettingsScreen(onBack: () -> Unit) {
+    SettingsDetailScaffold(title = "Web Transfer", onBack = onBack) {
+        WebTransferSection()
+    }
+}
+
+@Composable
+private fun WebTransferSection() {
+    val vm: WebTransferViewModel = hiltViewModel()
+    val ui by vm.uiState.collectAsState()
+
+    Text(
+        "Turn this on, then open the address below in your computer's browser to send games, BIOS files, " +
+            "artwork, background images and settings straight to this device. Both devices must be on the same Wi-Fi.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp)
+    )
+
+    SettingsCard {
+        CardSwitchRow(
+            label = "Enable Web Transfer",
+            checked = ui.enabled,
+            onCheckedChange = vm::setEnabled
+        )
+    }
+
+    if (ui.enabled) {
+        SettingsSectionHeader("Connect from your computer")
+        SettingsCard {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                if (ui.running && ui.url.isNotBlank()) {
+                    Text(
+                        ui.url,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = ElectricBlue
+                    )
+                    QrCode(content = ui.url, size = 180.dp)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            "PIN",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Text(
+                            ui.pin,
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 26.sp,
+                            letterSpacing = 6.sp,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                    Text(
+                        "Enter this PIN in the browser to pair. It changes each time you turn Web Transfer on.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        "Starting the server…",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (ui.log.isNotEmpty()) {
+            SettingsSectionHeader("Activity")
+            SettingsCard {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    ui.log.take(8).forEach { line ->
+                        Text(
+                            line,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/WebTransferViewModel.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/ui/screen/settings/WebTransferViewModel.kt
@@ -1,0 +1,63 @@
+package com.gamelaunch.frontend.ui.screen.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.gamelaunch.frontend.data.webserver.WebTransferManager
+import com.gamelaunch.frontend.domain.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Web Transfer: master on/off toggle that starts/stops the LAN web server, plus the connect URL, PIN
+ * and QR the browser needs. Mirrors the Save Sync view-model shape.
+ */
+@HiltViewModel
+class WebTransferViewModel @Inject constructor(
+    private val settings: SettingsRepository,
+    private val manager: WebTransferManager,
+) : ViewModel() {
+
+    data class UiState(
+        val enabled: Boolean = false,
+        val running: Boolean = false,
+        val url: String = "",
+        val pin: String = "",
+        val log: List<String> = emptyList(),
+    )
+
+    private val _enabled = MutableStateFlow(false)
+
+    val uiState: StateFlow<UiState> =
+        combine(_enabled, manager.state) { enabled, s ->
+            UiState(
+                enabled = enabled,
+                running = s.running,
+                url = s.url,
+                pin = s.pin,
+                log = s.log,
+            )
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), UiState())
+
+    init {
+        viewModelScope.launch {
+            val enabled = settings.webTransferEnabled.first()
+            _enabled.value = enabled
+            // If the user left it on, make sure the server is actually up when they return.
+            if (enabled) manager.start()
+        }
+    }
+
+    /** Master toggle: persist, then start or stop the server. */
+    fun setEnabled(on: Boolean) {
+        _enabled.value = on
+        viewModelScope.launch { settings.setWebTransferEnabled(on) }
+        if (on) manager.start() else manager.stop()
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/RomDestinationResolverTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/RomDestinationResolverTest.kt
@@ -1,0 +1,85 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.data.webserver.RomDestinationResolver
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * The routing contract that keeps browser uploads in the user's *existing* library layout instead of
+ * creating duplicate canonical folders.
+ */
+class RomDestinationResolverTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private lateinit var resolver: RomDestinationResolver
+    private lateinit var root: File
+
+    @Before fun setup() {
+        resolver = RomDestinationResolver()
+        root = tmp.newFolder("ROMs")
+    }
+
+    @Test fun `routes into an existing non-canonical alias folder`() {
+        // User already keeps NES games under "Famicom" (an alias), not the canonical "NES".
+        val famicom = File(root, "Famicom").apply { mkdirs() }
+        val dir = resolver.resolveRomDir(root, "nes", null)
+        assertEquals(famicom.canonicalPath, dir.canonicalPath)
+        // And crucially it did NOT invent a fresh canonical folder.
+        assertTrue(!File(root, "NES").exists())
+    }
+
+    @Test fun `routes into an existing nested folder`() {
+        val nested = File(root, "Nintendo/SNES").apply { mkdirs() }
+        val dir = resolver.resolveRomDir(root, "snes", null)
+        assertEquals(nested.canonicalPath, dir.canonicalPath)
+    }
+
+    @Test fun `falls back to the canonical folder when none exists`() {
+        val dir = resolver.resolveRomDir(root, "gba", null)
+        assertEquals(File(root, "GBA").canonicalPath, dir.canonicalPath)
+    }
+
+    @Test fun `prefers the shallowest existing folder`() {
+        File(root, "Nintendo/SNES").mkdirs()
+        val shallow = File(root, "SNES").apply { mkdirs() }
+        val dir = resolver.resolveRomDir(root, "snes", null)
+        assertEquals(shallow.canonicalPath, dir.canonicalPath)
+    }
+
+    @Test fun `explicit dest that escapes the root is rejected`() {
+        assertNull(resolver.containedDir(root, "../evil"))
+        assertNull(resolver.containedDir(root, "/etc"))
+        try {
+            resolver.resolveRomDir(root, "nes", "../evil")
+            fail("Expected IllegalArgumentException for escaping dest")
+        } catch (e: IllegalArgumentException) { /* expected */ }
+    }
+
+    @Test fun `explicit dest inside the root is honored`() {
+        val dir = resolver.resolveRomDir(root, "nes", "Custom/Nes Games")
+        assertEquals(File(root, "Custom/Nes Games").canonicalPath, dir.canonicalPath)
+    }
+
+    @Test fun `sanitizeFilename strips path components`() {
+        assertEquals("passwd", resolver.sanitizeFilename("../../etc/passwd"))
+        assertEquals("rom.zip", resolver.sanitizeFilename("a/b/rom.zip"))
+        assertEquals("game (USA).sfc", resolver.sanitizeFilename("game (USA).sfc"))
+    }
+
+    @Test fun `sanitizeFilename rejects traversal-only names`() {
+        for (bad in listOf("..", ".", "", "/")) {
+            try {
+                resolver.sanitizeFilename(bad)
+                fail("Expected rejection of '$bad'")
+            } catch (e: IllegalArgumentException) { /* expected */ }
+        }
+    }
+}

--- a/app/src/test/java/com/gamelaunch/frontend/SettingsTransferTest.kt
+++ b/app/src/test/java/com/gamelaunch/frontend/SettingsTransferTest.kt
@@ -1,0 +1,25 @@
+package com.gamelaunch.frontend
+
+import com.gamelaunch.frontend.domain.usecase.SettingsTransfer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Guards the promise that a settings export never carries a credential, token or PIN. */
+class SettingsTransferTest {
+
+    @Test fun `exported keys never overlap sensitive keys`() {
+        val overlap = SettingsTransfer.EXPORTED_KEYS intersect SettingsTransfer.SENSITIVE_KEYS
+        assertTrue("Exported settings must not include sensitive keys: $overlap", overlap.isEmpty())
+    }
+
+    @Test fun `credential and pin keys are marked sensitive`() {
+        listOf("ss_password", "ra_api_key", "ra_token", "locked_mode_pin").forEach {
+            assertTrue("$it should be sensitive", it in SettingsTransfer.SENSITIVE_KEYS)
+        }
+    }
+
+    @Test fun `format identifier is stable`() {
+        assertEquals("eor-settings", SettingsTransfer.FORMAT)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Web Transfer** — a device-hosted LAN web server so a computer on the same Wi‑Fi can open `http://<device-ip>:<port>` in its browser and drag‑and‑drop content straight onto the device: **ROMs, BIOS/firmware, per‑game media/artwork, a background image, and app settings**. It mirrors the existing **Save Sync** feature end to end (foreground `dataSync` service + single‑owner `@Singleton` manager + dedicated `@HiltViewModel` + a Settings drill‑in screen + QR of the URL).

New Settings entry: **Settings → Web Transfer** (toggle on → shows URL, QR and pairing PIN).

## What's included

- **PIN pairing** — the device shows a 6‑digit PIN (+ QR of the URL); the browser must submit it to receive a session token. PIN attempts are rate‑limited with a lockout, requests are accepted only from LAN addresses, and the server binds only while the toggle is on (foreground service with a persistent notification showing the connect URL).
- **ROM uploads match the user's existing library layout.** `RomDestinationResolver` maps folders under the ROM root to platforms via `PlatformDefinitions.byFolderName` (every alias) and routes an upload into an existing alias/nested folder (e.g. `Famicom`, `Nintendo/SNES`), only creating the canonical folder as a fallback when none exists. Existing folders are never renamed. Every filename is sanitized and every destination is confined under its root (no path traversal).
- **Atomic writes.** File bodies stream to a `.part` file then atomically rename, so the library scanner never sees a half‑written ROM; a debounced rescan runs after ROM uploads (reusing `ScanRomsUseCase`).
- **BIOS** gets a new configurable destination (defaults to `<romRoot>/bios`).
- **Settings export/import** moves a safe whitelist only; credentials, tokens and the Locked‑Mode PIN are never exported (asserted by a unit test).
- **Reused** existing utilities: `preferredLocalAddress()` (LAN IP), the `QrCode` composable (ZXing), the scanner's partial‑upload quiet period, and `ConvertBackgroundImageUseCase` (with a new `File` overload).

## Files

- New: `data/webserver/{WebTransferServer,WebTransferManager,WebTransferService,RomDestinationResolver}.kt`, `assets/webtransfer/{index.html,app.js,style.css}`, `ui/screen/settings/{WebTransferSettingsScreen,WebTransferViewModel}.kt`, `domain/usecase/{ExportSettingsUseCase,ImportSettingsUseCase,SettingsTransfer}.kt`, and two unit tests.
- Edited: `AppDataStore`, `SettingsRepository`(+Impl), `MediaRepository`(+Impl), `ConvertBackgroundImageUseCase`, `AndroidManifest.xml`, `app/build.gradle.kts` (added `org.nanohttpd:nanohttpd:2.3.1`), `Screen.kt`, `SettingsIndexScreen.kt`, `AppNavGraph.kt`.

## Testing status

⚠️ **Not yet built/run.** This was authored in a cloud session whose egress policy blocks Google's Maven (`dl.google.com`), so Gradle couldn't fetch the Android toolchain to compile. Please build locally before merging:

- `./gradlew :app:testFullDebugUnitTest` — new `RomDestinationResolverTest` (alias / nested / fallback / traversal) and `SettingsTransferTest` (export excludes sensitive keys)
- `./gradlew :app:assembleFullDebug :app:assembleLiteDebug :app:lintFullDebug`
- On‑device: enable Web Transfer, pair from a browser, upload a ROM into a pre‑existing `Famicom`/`Nintendo/SNES` layout and confirm no duplicate folder is created; then BIOS, background, media, and settings export/import (verify the export JSON has no secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sys85mbM5iNPVKEHJAeRRU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sys85mbM5iNPVKEHJAeRRU)_