### PR TITLE
web-transfer: fix compile + reject absolute dest; folder locations, media system filter, drop Settings

### DIFF
--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/RomDestinationResolver.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/RomDestinationResolver.kt
@@ -99,6 +99,10 @@ class RomDestinationResolver @Inject constructor() {
      * (defends against `..` and absolute paths). Creates the directory. Returns null if it escapes.
      */
     fun containedDir(root: File, relPath: String): File? {
+        // Reject absolute paths outright: they are never produced by the web UI (which sends folders
+        // relative to the ROM root), and File(root, "/etc") would otherwise be silently reinterpreted
+        // as "<root>/etc" rather than treated as the escape attempt it is.
+        if (relPath.startsWith("/") || relPath.startsWith("\\") || File(relPath).isAbsolute) return null
         val candidate = File(root, relPath)
         val rootCanon = root.canonicalFile
         val candidateCanon = candidate.canonicalFile

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferServer.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferServer.kt
@@ -40,7 +40,7 @@ class WebTransferDeps(
  * `assets/webtransfer/`) and a JSON API that writes uploads straight to the user's storage.
  *
  * Security posture:
- *  - Every `/api/*` call except `/api/pair` requires a session token issued only after the browser
+ *  - Every `/api/` call except `/api/pair` requires a session token issued only after the browser
  *    submits the device-displayed [pin]. PIN attempts are rate-limited with a lockout.
  *  - Requests are accepted only from LAN (site-local / loopback) addresses.
  *  - Every filename is sanitized and every destination is confined under its intended root


### PR DESCRIPTION
Follow-up to #113 (the feature was merged without ever compiling — it was authored in a cloud sandbox that couldn't reach Google's Maven). This makes it build, fixes a security-test failure, and adds polish from testing the web UI on-device (Retroid Pocket 4 Pro, full flavor).

## Compile / correctness fixes (unblock `main`)

**Unclosed KDoc comment — hard compile error.** `WebTransferServer.kt`'s class KDoc contained `` `/api/*` ``. Kotlin block comments *nest*, so the `/*` inside opened a nested comment; the intended closing `*/` ended only that nested one, leaving the outer KDoc open through EOF. `kspFullDebugKotlin` failed with `Unclosed comment`. Reworded to `` `/api/` ``.

**`containedDir` accepted absolute paths.** `containedDir(root, "/etc")` — `File(root, "/etc")` silently resolves to `<root>/etc`, which *is* contained, so the guard returned it as valid instead of rejecting it, failing `RomDestinationResolverTest > "explicit dest that escapes the root is rejected"`. Absolute paths (never produced by the web UI) are now rejected outright.

## UI polish (from on-device testing)

- **Destination folder shows its physical location.** Each option now reads e.g. `SD card · /storage/1CE5-2B42/ROMs/famicom  (existing)` so it's clear which volume an upload lands on; the canonical `(new)` option shows where it would be created. `apiSystems` returns each folder's absolute path + a human volume label (`StorageUtils.getStorageVolumes`); `RomDestinationResolver.PlatformFolder` gains `absolutePath`.
- **Media tab gets a System selector** that filters the game list by platform (per-system counts, `All systems` default) instead of one giant flat list.
- **Removed the Settings tab for now**, plus its export/import JS (which would throw on the missing elements). `/api/settings/*` endpoints + use cases are left in place, just not surfaced.

## Verification

- `./gradlew :app:clean :app:assembleFullDebug` — succeeds
- `./gradlew :app:testFullDebugUnitTest` (RomDestinationResolverTest, SettingsTransferTest) — pass
- Confirmed the packaged `app-full-debug.apk` contains the updated assets (not a stale iCloud copy); installed and running on a Retroid Pocket 4 Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)