### PR TITLE
web-transfer: folder storage locations, media system filter, drop Settings tab

### DIFF
--- a/app/src/main/assets/webtransfer/app.js
+++ b/app/src/main/assets/webtransfer/app.js
@@ -88,9 +88,15 @@ function updateDest() {
   dest.innerHTML = "";
   if (!sys) return;
   const opts = [];
-  (sys.existing || []).forEach((p) => opts.push({ value: p, label: p + "  (existing)" }));
+  (sys.existing || []).forEach((f) => {
+    // Each existing folder carries its on-device location (e.g. "SD card · /storage/…/ROMs/nes").
+    const loc = f.location || f.path;
+    opts.push({ value: f.path, label: loc + "  (existing)" });
+  });
   // Always offer the canonical folder as a fallback ("" = let the device decide).
-  opts.push({ value: "", label: sys.canonicalFolder + (sys.existing && sys.existing.length ? "  (new)" : "  (will be created)") });
+  const hasExisting = sys.existing && sys.existing.length;
+  const canonLoc = sys.canonicalLocation || sys.canonicalFolder;
+  opts.push({ value: "", label: canonLoc + (hasExisting ? "  (new)" : "  (will be created)") });
   opts.forEach((o) => {
     const opt = document.createElement("option");
     opt.value = o.value;
@@ -121,21 +127,59 @@ wireDrop("biosDrop", "biosFile", (files) => {
 });
 
 // ── Media ──────────────────────────────────────────────────────────────────────
+let GAMES = [];
+
 async function loadGames() {
   try {
     const res = await fetch("/api/games", { credentials: "same-origin" });
     if (!res.ok) return;
     const data = await res.json();
-    const sel = el("gameSelect");
-    sel.innerHTML = "";
-    (data.games || []).sort((a, b) => a.title.localeCompare(b.title)).forEach((g) => {
-      const opt = document.createElement("option");
-      opt.value = g.id;
-      opt.textContent = `${g.title} (${g.platformId})`;
-      sel.appendChild(opt);
-    });
+    GAMES = (data.games || []).slice().sort((a, b) => a.title.localeCompare(b.title));
+    populateMediaSystems();
+    renderGameOptions();
   } catch (e) { /* ignore */ }
 }
+
+// Friendly platform name from the systems list we already loaded (falls back to the id).
+function platformName(id) {
+  const s = SYSTEMS.find((x) => x.id === id);
+  return s ? s.name : id;
+}
+
+// System filter for the media picker: only systems that actually have games, plus an "All" option.
+function populateMediaSystems() {
+  const sel = el("mediaSysSelect");
+  const prev = sel.value;
+  const ids = [...new Set(GAMES.map((g) => g.platformId))]
+    .sort((a, b) => platformName(a).localeCompare(platformName(b)));
+  sel.innerHTML = "";
+  const all = document.createElement("option");
+  all.value = "";
+  all.textContent = `All systems (${GAMES.length})`;
+  sel.appendChild(all);
+  ids.forEach((id) => {
+    const count = GAMES.filter((g) => g.platformId === id).length;
+    const opt = document.createElement("option");
+    opt.value = id;
+    opt.textContent = `${platformName(id)} (${count})`;
+    sel.appendChild(opt);
+  });
+  if (prev && ids.includes(prev)) sel.value = prev; // keep the selection across reloads
+}
+
+function renderGameOptions() {
+  const sysId = el("mediaSysSelect").value;
+  const sel = el("gameSelect");
+  sel.innerHTML = "";
+  GAMES.filter((g) => !sysId || g.platformId === sysId).forEach((g) => {
+    const opt = document.createElement("option");
+    opt.value = g.id;
+    opt.textContent = `${g.title} (${g.platformId})`;
+    sel.appendChild(opt);
+  });
+}
+
+el("mediaSysSelect").addEventListener("change", renderGameOptions);
 
 wireDrop("mediaDrop", "mediaFile", (files) => {
   const gameId = el("gameSelect").value;
@@ -152,38 +196,6 @@ wireDrop("bgDrop", "bgFile", (files) => {
   const f = files[0];
   if (!f) return;
   upload("bgQueue", "POST", "/api/upload/background", f, f.name);
-});
-
-// ── Settings ─────────────────────────────────────────────────────────────────
-el("exportBtn").addEventListener("click", async () => {
-  try {
-    const res = await fetch("/api/settings/export", { credentials: "same-origin" });
-    if (!res.ok) { el("settingsMsg").textContent = "Export failed."; return; }
-    const blob = await res.blob();
-    const a = document.createElement("a");
-    a.href = URL.createObjectURL(blob);
-    a.download = "eor-settings.json";
-    a.click();
-    URL.revokeObjectURL(a.href);
-  } catch (e) { el("settingsMsg").textContent = "Export failed."; }
-});
-
-wireDrop("settingsDrop", "settingsFile", async (files) => {
-  const f = files[0];
-  if (!f) return;
-  try {
-    const text = await f.text();
-    const res = await fetch("/api/settings/import", {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "Content-Type": "application/json" },
-      body: text,
-    });
-    const body = await res.json().catch(() => ({}));
-    el("settingsMsg").textContent = res.ok
-      ? `Imported ${body.applied} settings.`
-      : "Import failed — is this an eOr settings file?";
-  } catch (e) { el("settingsMsg").textContent = "Import failed."; }
 });
 
 // ── Shared: drag/drop + upload with progress ───────────────────────────────────

--- a/app/src/main/assets/webtransfer/index.html
+++ b/app/src/main/assets/webtransfer/index.html
@@ -30,7 +30,6 @@
       <button class="tab" data-tab="bios">BIOS</button>
       <button class="tab" data-tab="media">Media</button>
       <button class="tab" data-tab="background">Background</button>
-      <button class="tab" data-tab="settings">Settings</button>
     </nav>
 
     <section class="panel active" data-panel="games">
@@ -59,6 +58,8 @@
 
     <section class="panel" data-panel="media">
       <div class="card">
+        <label class="lbl">System</label>
+        <select id="mediaSysSelect"></select>
         <label class="lbl">Game</label>
         <select id="gameSelect"></select>
         <label class="lbl">Media type</label>
@@ -86,16 +87,6 @@
       <div id="bgQueue" class="queue"></div>
     </section>
 
-    <section class="panel" data-panel="settings">
-      <div class="card">
-        <p class="hint">Move your appearance, layout and library preferences between devices. Passwords and account tokens are never included.</p>
-        <button id="exportBtn" class="primary">Download settings</button>
-        <div class="drop small" id="settingsDrop">
-          <p>Drag a settings file here to import, or <label class="link">browse<input id="settingsFile" type="file" accept=".json,application/json" hidden /></label></p>
-        </div>
-        <p id="settingsMsg" class="hint"></p>
-      </div>
-    </section>
   </main>
 
   <script src="app.js"></script>

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/RomDestinationResolver.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/RomDestinationResolver.kt
@@ -26,6 +26,8 @@ class RomDestinationResolver @Inject constructor() {
         val displayName: String,
         /** Path relative to the ROM root, using '/' separators (e.g. "Nintendo/SNES"). */
         val relativePath: String,
+        /** Full on-device path (e.g. "/storage/1CE5-2B42/ROMs/Nintendo/SNES"), for display. */
+        val absolutePath: String,
         val depth: Int,
     )
 
@@ -49,6 +51,7 @@ class RomDestinationResolver @Inject constructor() {
                         platformId = platform.id,
                         displayName = platform.displayName,
                         relativePath = relativeTo(root, child),
+                        absolutePath = child.absolutePath,
                         depth = depth,
                     )
                 }

--- a/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferServer.kt
+++ b/app/src/main/java/com/gamelaunch/frontend/data/webserver/WebTransferServer.kt
@@ -169,15 +169,35 @@ class WebTransferServer(
         val arr = JSONArray()
         PlatformDefinitions.ALL.forEach { p ->
             val folders = existing[p.id].orEmpty().sortedBy { it.depth }
+            val existingArr = JSONArray()
+            folders.forEach { f ->
+                existingArr.put(
+                    JSONObject()
+                        .put("path", f.relativePath)
+                        .put("location", describeLocation(f.absolutePath))
+                )
+            }
+            val canonical = p.folderNames.first()
+            val canonicalLocation = root?.let { describeLocation(File(it, canonical).absolutePath) } ?: ""
             arr.put(
                 JSONObject()
                     .put("id", p.id)
                     .put("name", p.displayName)
-                    .put("canonicalFolder", p.folderNames.first())
-                    .put("existing", JSONArray(folders.map { it.relativePath }))
+                    .put("canonicalFolder", canonical)
+                    .put("canonicalLocation", canonicalLocation)
+                    .put("existing", existingArr)
             )
         }
         return json(Response.Status.OK, JSONObject().put("systems", arr).put("hasRomRoot", root != null))
+    }
+
+    /** Human description of where an absolute path physically lives (e.g. "SD card · /storage/…/ROMs/nes"). */
+    private fun describeLocation(absolutePath: String): String {
+        val volumes = runCatching { StorageUtils.getStorageVolumes(deps.context) }.getOrDefault(emptyList())
+        val match = volumes
+            .filter { absolutePath == it.second || absolutePath.startsWith(it.second.trimEnd('/') + "/") }
+            .maxByOrNull { it.second.length }
+        return if (match != null) "${match.first} · $absolutePath" else absolutePath
     }
 
     private suspend fun apiFolders(): Response {


### PR DESCRIPTION
UI polish for the Web Transfer beta, from on-device testing. These changes were authored alongside the #114 fixes but landed on the branch just after #114's merge captured only the compile-fix commit, so they need this separate PR to reach `main`.

## Changes

- **Destination folder shows its physical location.** Each option now reads e.g. `SD card · /storage/1CE5-2B42/ROMs/famicom  (existing)` so it's clear which volume an upload lands on; the canonical `(new)` option shows where it would be created. `apiSystems` returns each folder's absolute path + a human volume label (via `StorageUtils.getStorageVolumes`); `RomDestinationResolver.PlatformFolder` gains `absolutePath`.
- **Media tab gets a System selector** that filters the game list by platform (per-system counts, `All systems` default) instead of one giant flat list. Selection persists across the post-upload reload.
- **Removed the Settings tab for now**, plus its export/import JS (which would otherwise throw on the now-missing elements). The `/api/settings/*` endpoints and use cases are left in place, just not surfaced.

## Verification

- `./gradlew :app:clean :app:assembleFullDebug` — succeeds
- `./gradlew :app:testFullDebugUnitTest` (RomDestinationResolverTest, SettingsTransferTest) — pass
- Confirmed the packaged `app-full-debug.apk` contains the updated assets; installed and tested on a Retroid Pocket 4 Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)